### PR TITLE
Set LD_LIBRARY_PATH for `cargo test`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 Cargo.lock
 target
 test.config
+
+.*.swp
+.*.swo

--- a/build.rs
+++ b/build.rs
@@ -5,9 +5,8 @@ const INSTALL_ENVVAR: &str = "CMAKE_INSTALL_PREFIX";
 const INSTALL_DEFAULT: &str = "/opt/tiledb/lib";
 
 fn main() {
-    // Hard coded for now
-    println!("cargo:rustc-link-lib=tiledb");
-    println!("cargo:rustc-link-search=all={}",
+    println!(
+        "cargo:rustc-env=LD_LIBRARY_PATH={}",
         match env::var(INSTALL_ENVVAR) {
             Ok(dir) => dir,
             Err(e) =>


### PR DESCRIPTION
Implements a likely not portable means of enabling `cargo test` to run with `libtiledb.so` in its rpath without any system hackery. 