### PR TITLE
Fixup Dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-lazy_static = "1.4.0"
-tempdir = "0.3.7"
 tiledb-sys = {version = "0.1.0", path = "tiledb-sys" }
+
+[dev-dependencies]
+tempdir = "0.3.7"

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -149,22 +149,17 @@ impl Drop for Array<'_> {
 
 #[cfg(test)]
 mod tests {
-    extern crate lazy_static;
-    extern crate tempdir;
+    use std::io;
+    use tempdir::TempDir;
 
     use crate::array::*;
     use crate::context::Context;
     use crate::Datatype;
-    use lazy_static::lazy_static;
-
-    lazy_static! {
-        static ref DIR: tempdir::TempDir =
-            tempdir::TempDir::new("tiledb-rs.array").unwrap();
-    }
 
     #[test]
-    fn test_array_create() {
-        let arr_path = DIR.path().join("test_array_create");
+    fn test_array_create() -> io::Result<()> {
+        let tmp_dir = TempDir::new("test_rs_bdelit")?;
+        let arr_dir = tmp_dir.path().join("create_test");
 
         let c: Context = Context::new().unwrap();
 
@@ -196,6 +191,11 @@ mod tests {
 
         // domain not set
         // TODO
-        assert!(Array::create(&c, arr_path.to_str().unwrap(), s).is_ok());
+        assert!(Array::create(&c, arr_dir.to_str().unwrap(), s).is_ok());
+
+        // Make sure we can remove the array we created.
+        tmp_dir.close()?;
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Both tempdir and lazy_static should be in the `[dev-dependencies]` section so that we're not forcing them on downstream users. Secondly I removed lazy_static in favor of creating a TempDir per test to avoid sharing global state in tests as well as error localization in the very unlikely situation core ever creates a non-writable file.