### PR TITLE
Add Schema::open with simple quickstart_dense test

### DIFF
--- a/tiledb/api/src/array/dimension.rs
+++ b/tiledb/api/src/array/dimension.rs
@@ -37,12 +37,8 @@ impl<'ctx> Dimension<'ctx> {
     }
 
     /// Read from the C API whatever we need to use this dimension from Rust
-    pub(crate) fn load(
-        context: &'ctx Context,
-        raw: RawDimension,
-    ) -> TileDBResult<Self> {
-        // TODO: ???
-        Ok(Dimension { context, raw })
+    pub(crate) fn new(context: &'ctx Context, raw: RawDimension) -> Self {
+        Dimension { context, raw }
     }
 
     pub fn datatype(&self) -> Datatype {

--- a/tiledb/api/src/array/domain.rs
+++ b/tiledb/api/src/array/domain.rs
@@ -57,7 +57,15 @@ impl<'ctx> Domain<'ctx> {
         let c_context = self.context.as_mut_ptr();
         let c_domain = *self.raw;
         let mut c_dimension: *mut ffi::tiledb_dimension_t = out_ptr!();
-        let c_idx = idx.try_into().unwrap();
+        let c_idx = match idx.try_into() {
+            Ok(idx) => idx,
+            Err(e) => {
+                return Err(crate::error::Error::from(format!(
+                    "Invalid dimension: {}",
+                    e
+                )))
+            }
+        };
         let c_ret = unsafe {
             ffi::tiledb_domain_get_dimension_from_index(
                 c_context,


### PR DESCRIPTION
This pull request adds an equivalent of the `tiledb_array_schema_load` function which opens an array schema from a URI.

Prior work with array schema *creation* put the Domain in as a field in the `ArraySchema`, so most of the implementation here is actually about that.  `ArraySchema::open` calls `Domain::load` which fetches into Rust the information needed from the C API.

"Prior work" was the focus on the `quickstart_dense` example which creates, rather than reads, an array.  In that example we had to make sure that the Domain lifetime was at least as long as the Schema lifetime, and then Domain has a vector of Dimension for the same reason.

Since the tests for this naturally want to ask about the dimensions, there are also changes to the `Domain::dimension` function, specifically to return a reference to an existing one rather than create a new one.  This uses interior mutability to lazily manifest the dimensions from the C API.