### PR TITLE
Attribute has a Context member and Builder like the other structs, and add a bunch more getters/setters for Attribute and Schema

### DIFF
--- a/tiledb/api/examples/quickstart_dense.rs
+++ b/tiledb/api/examples/quickstart_dense.rs
@@ -47,11 +47,12 @@ fn create_array() -> TileDBResult<()> {
             .build()
     };
 
-    let attribute_a = tiledb::array::Attribute::new(
+    let attribute_a = tiledb::array::AttributeBuilder::new(
         &tdb,
         QUICKSTART_ATTRIBUTE_NAME,
         tiledb::Datatype::Int32,
-    )?;
+    )?
+    .build();
 
     let schema = tiledb::array::SchemaBuilder::new(
         &tdb,

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -1,3 +1,4 @@
+use std::convert::TryFrom;
 use std::ops::Deref;
 
 use crate::context::Context;
@@ -31,6 +32,7 @@ impl Mode {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub enum Layout {
     Unordered,
     RowMajor,
@@ -45,6 +47,19 @@ impl Layout {
             Layout::RowMajor => ffi::tiledb_layout_t_TILEDB_ROW_MAJOR,
             Layout::ColumnMajor => ffi::tiledb_layout_t_TILEDB_COL_MAJOR,
             Layout::Hilbert => ffi::tiledb_layout_t_TILEDB_HILBERT,
+        }
+    }
+}
+
+impl TryFrom<ffi::tiledb_layout_t> for Layout {
+    type Error = crate::error::Error;
+    fn try_from(value: ffi::tiledb_layout_t) -> TileDBResult<Self> {
+        match value {
+            ffi::tiledb_layout_t_TILEDB_UNORDERED => Ok(Layout::Unordered),
+            ffi::tiledb_layout_t_TILEDB_ROW_MAJOR => Ok(Layout::RowMajor),
+            ffi::tiledb_layout_t_TILEDB_COL_MAJOR => Ok(Layout::ColumnMajor),
+            ffi::tiledb_layout_t_TILEDB_HILBERT => Ok(Layout::Hilbert),
+            _ => Err(Self::Error::from(format!("Invalid layout: {}", value))),
         }
     }
 }

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -9,7 +9,7 @@ mod dimension;
 mod domain;
 mod schema;
 
-pub use attribute::Attribute;
+pub use attribute::{Attribute, Builder as AttributeBuilder};
 pub use dimension::{Builder as DimensionBuilder, Dimension};
 pub use domain::{Builder as DomainBuilder, Domain};
 pub use schema::{ArrayType, Builder as SchemaBuilder, Schema};
@@ -209,7 +209,9 @@ pub mod tests {
         let s: Schema = SchemaBuilder::new(context, ArrayType::Sparse, d)
             .unwrap()
             .add_attribute(
-                Attribute::new(context, "a", Datatype::UInt64).unwrap(),
+                AttributeBuilder::new(context, "a", Datatype::UInt64)
+                    .unwrap()
+                    .build(),
             )
             .unwrap()
             .into();

--- a/tiledb/api/src/array/schema.rs
+++ b/tiledb/api/src/array/schema.rs
@@ -1,3 +1,4 @@
+use std::convert::TryFrom;
 use std::ops::Deref;
 
 use crate::array::domain::RawDomain;
@@ -5,6 +6,7 @@ use crate::array::{Attribute, Domain};
 use crate::context::Context;
 use crate::Result as TileDBResult;
 
+#[derive(Debug, PartialEq)]
 pub enum ArrayType {
     Dense,
     Sparse,
@@ -15,6 +17,19 @@ impl ArrayType {
         match *self {
             ArrayType::Dense => ffi::tiledb_array_type_t_TILEDB_DENSE,
             ArrayType::Sparse => ffi::tiledb_array_type_t_TILEDB_SPARSE,
+        }
+    }
+}
+
+impl TryFrom<ffi::tiledb_array_type_t> for ArrayType {
+    type Error = crate::error::Error;
+    fn try_from(value: ffi::tiledb_array_type_t) -> TileDBResult<Self> {
+        match value {
+            ffi::tiledb_array_type_t_TILEDB_DENSE => Ok(ArrayType::Dense),
+            ffi::tiledb_array_type_t_TILEDB_SPARSE => Ok(ArrayType::Sparse),
+            _ => {
+                Err(Self::Error::from(format!("Invalid array type: {}", value)))
+            }
         }
     }
 }


### PR DESCRIPTION
This adds a bunch more pretty-much-straightforward methods to the Attribute and Schema classes.

Along the way we also stylize the `Attribute` struct in a manner similar to `Schema`, `Domain`, and `Dimension`.  We split off a `Builder` class for the setter methods to construct a new `Attribute` and add a `&'ctx Context` member to make all of the methods more convenient.

This surely conflicts with #6 which we should merge first.