### PR TITLE
Remove test crate circular dependency and add arbitrary Attribute pbt strategy

### DIFF
--- a/tiledb/api/Cargo.toml
+++ b/tiledb/api/Cargo.toml
@@ -13,4 +13,3 @@ tiledb-sys = { workspace = true }
 [dev-dependencies]
 proptest = "1.0.0"
 tempdir = "0.3.7"
-tiledb-test = { workspace = true }

--- a/tiledb/api/src/array/attribute.rs
+++ b/tiledb/api/src/array/attribute.rs
@@ -1,6 +1,7 @@
 extern crate tiledb_sys as ffi;
 
 use std::convert::From;
+use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::ops::Deref;
 
 pub use tiledb_sys::Datatype;
@@ -40,6 +41,10 @@ pub struct Attribute<'ctx> {
 impl<'ctx> Attribute<'ctx> {
     pub(crate) fn as_mut_ptr(&self) -> *mut ffi::tiledb_attribute_t {
         *self.raw
+    }
+
+    pub(crate) fn new(context: &'ctx Context, raw: RawAttribute) -> Self {
+        Attribute { context, raw }
     }
 
     pub fn name(&self) -> TileDBResult<String> {
@@ -201,12 +206,23 @@ impl<'ctx> Attribute<'ctx> {
     }
 }
 
-impl<'ctx> From<(&'ctx Context, RawAttribute)> for Attribute<'ctx> {
-    fn from(value: (&'ctx Context, RawAttribute)) -> Self {
-        Attribute {
-            context: value.0,
-            raw: value.1,
-        }
+impl<'ctx> Debug for Attribute<'ctx> {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(
+            f,
+            "{{ \"name\": \"{}\", \"type\": \"{}\", \"address\": \"0x{:?}\" }}",
+            match self.name() {
+                Ok(name) => name,
+                Err(e) => format!("<error reading name: {}>", e),
+            },
+            match self.datatype() {
+                Ok(dt) => dt
+                    .to_string()
+                    .unwrap_or(String::from("<unrecognized datatype>")),
+                Err(e) => format!("<error reading datatype: {}>", e),
+            },
+            *self.raw
+        )
     }
 }
 

--- a/tiledb/api/src/array/attribute.rs
+++ b/tiledb/api/src/array/attribute.rs
@@ -394,17 +394,6 @@ mod test {
     use crate::filter::Filter;
     pub use tiledb_sys::FilterType;
 
-    use proptest::prelude::*;
-
-    proptest! {
-        #[test]
-        fn attribute_alloc(dt in tiledb_test::datatype::arbitrary()) {
-            let ctx = Context::new().expect("Error creating context instance.");
-            Builder::new(&ctx, "foo", dt)
-                .expect("Error creating attribute instance.");
-        }
-    }
-
     #[test]
     fn attribute_get_name_and_type() {
         let ctx = Context::new().expect("Error creating context instance.");

--- a/tiledb/api/src/array/schema.rs
+++ b/tiledb/api/src/array/schema.rs
@@ -232,7 +232,7 @@ impl<'ctx> Schema<'ctx> {
             )
         };
         if c_ret == ffi::TILEDB_OK {
-            Ok(Attribute::from((self.context, RawAttribute::Owned(c_attr))))
+            Ok(Attribute::new(self.context, RawAttribute::Owned(c_attr)))
         } else {
             Err(self.context.expect_last_error())
         }

--- a/tiledb/api/src/lib.rs
+++ b/tiledb/api/src/lib.rs
@@ -1,10 +1,5 @@
 extern crate tiledb_sys as ffi;
 
-#[cfg(test)]
-extern crate proptest;
-#[cfg(test)]
-extern crate tiledb_test;
-
 macro_rules! cstring {
     ($arg:ident) => {
         match std::ffi::CString::new($arg) {

--- a/tiledb/arrow/src/datatype.rs
+++ b/tiledb/arrow/src/datatype.rs
@@ -48,7 +48,7 @@ pub fn arrow_type_physical(
         }
         tiledb::Datatype::DateTimeNanosecond => {
             Some(arrow_schema::DataType::Timestamp(
-                arrow_schema::TimeUnit::Microsecond,
+                arrow_schema::TimeUnit::Nanosecond,
                 None,
             ))
         }
@@ -92,6 +92,28 @@ pub fn tiledb_type_physical(
         arrow_schema::DataType::UInt64 => Some(tiledb::Datatype::UInt64),
         arrow_schema::DataType::Float32 => Some(tiledb::Datatype::Float32),
         arrow_schema::DataType::Float64 => Some(tiledb::Datatype::Float64),
+        arrow_schema::DataType::Timestamp(
+            arrow_schema::TimeUnit::Second,
+            None,
+        ) => Some(tiledb::Datatype::DateTimeSecond),
+        arrow_schema::DataType::Timestamp(
+            arrow_schema::TimeUnit::Millisecond,
+            None,
+        ) => Some(tiledb::Datatype::DateTimeMillisecond),
+        arrow_schema::DataType::Timestamp(
+            arrow_schema::TimeUnit::Microsecond,
+            None,
+        ) => Some(tiledb::Datatype::DateTimeMicrosecond),
+        arrow_schema::DataType::Timestamp(
+            arrow_schema::TimeUnit::Nanosecond,
+            None,
+        ) => Some(tiledb::Datatype::DateTimeNanosecond),
+        arrow_schema::DataType::Time64(arrow_schema::TimeUnit::Microsecond) => {
+            Some(tiledb::Datatype::TimeMicrosecond)
+        }
+        arrow_schema::DataType::Time64(arrow_schema::TimeUnit::Nanosecond) => {
+            Some(tiledb::Datatype::TimeNanosecond)
+        }
         _ => None, // TODO
     }
 }
@@ -112,7 +134,8 @@ mod tests {
                     // TODO: assert that `tdb_dt` is variable-length
                 }
 
-                // TODO: invertibility
+                let inverted_dt = tiledb_type_physical(&arrow_dt);
+                assert_eq!(Some(tdb_dt), inverted_dt);
             }
         }
     }

--- a/tiledb/test/src/attribute.rs
+++ b/tiledb/test/src/attribute.rs
@@ -1,0 +1,28 @@
+use proptest::prelude::*;
+use tiledb::array::{Attribute, AttributeBuilder};
+use tiledb::context::Context;
+
+pub fn arbitrary_name() -> impl Strategy<Value = String> {
+    proptest::string::string_regex("[a-zA-Z0-9_]*")
+        .expect("Error creating attribute name strategy")
+}
+
+pub fn arbitrary(context: &Context) -> impl Strategy<Value = Attribute> {
+    (arbitrary_name(), crate::datatype::arbitrary()).prop_map(|(name, dt)| {
+        AttributeBuilder::new(context, name.as_ref(), dt)
+            .expect("Error building attribute")
+            .build()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn attribute_alloc() {
+        let ctx = Context::new().expect("Error creating context");
+
+        proptest!(|(_ in arbitrary(&ctx))| {});
+    }
+}

--- a/tiledb/test/src/lib.rs
+++ b/tiledb/test/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate proptest;
 extern crate tiledb;
 
+pub mod attribute;
 pub mod datatype;


### PR DESCRIPTION
The addition of the Attribute pbt strategy revealed that the circular dependency did not actually work.