### PR TITLE
Add tooling for listing unwraped API functions

### DIFF
--- a/tiledb/sys/.gitignore
+++ b/tiledb/sys/.gitignore
@@ -1,1 +1,4 @@
 generated.rs
+generated-functions.txt
+covered-functions.txt
+todo.txt

--- a/tiledb/sys/Makefile
+++ b/tiledb/sys/Makefile
@@ -1,9 +1,20 @@
 
-# You might have to `cargo install bindgen-cli` for this to work
-bindings:
+all: todo
+
+generated.rs:
 	bindgen \
     -o generated.rs \
     --allowlist-function '^tiledb_.*' \
     --allowlist-var '^TILEDB_.*' \
     wrapper.h \
     -- -I/opt/tiledb/include
+
+generated-functions.txt: generated.rs
+	rg -o --no-line-number --no-filename '\bfn\s+tiledb_[^(]+' generated.rs | sort > generated-functions.txt
+
+covered-functions.txt:
+	rg -o --no-line-number --no-filename '\bfn\s+tiledb_[^(]+' src/*.rs | sort > covered-functions.txt
+
+todo: generated-functions.txt covered-functions.txt
+	comm -23 generated-functions.txt covered-functions.txt > todo.txt
+	cat todo.txt

--- a/tiledb/sys/README.md
+++ b/tiledb/sys/README.md
@@ -1,0 +1,26 @@
+tiledb-sys
+===
+
+This crate contains the raw wrapped function definitions that are then used
+by the `tiledb/api` crate to provide a usable Rust API to TileDB. Nothing in
+this crate is intended for use by anything other than `tiledb/api`.
+
+Listing Unwrapped APIs
+===
+
+If you're looking to contribute to this repository, the easiest approach to
+looking for things to wrap is to change directories into the directory
+containing this file and run `make`. This will dump a list of unwrapped
+functions.
+
+Requirements
+---
+
+To generate the todo list of functions to wrap, you need to have installed
+both bindgen and ripgrep. On macOS, the easiest way to acquire these
+is to run the following:
+
+```bash
+$ cargo install bindgen-cli
+$ brew install ripgrep
+```


### PR DESCRIPTION
The usage for this is included in the `tiledb/sys/README.md` docs. But for anyone too lazy to look at that, the basics are:

```bash
cd tiledb/sys
make
```

If you get errors about bindgen or ripgrep do the following on macOS:

```bash
cargo install bindgen-cli
brew install ripgrep
```