### PR TITLE
Add wrappers for VFS

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,8 +32,8 @@ jobs:
           set -e pipefail
           mkdir -p /opt/tiledb
           cd /opt/tiledb
-          wget -q ${RELEASES_URL}/2.21.0-rc1/tiledb-linux-x86_64-2.21.0-rc1-0ea9c13.tar.gz
-          wget -q ${RELEASES_URL}/2.21.0-rc1/tiledb-linux-x86_64-2.21.0-rc1-0ea9c13.tar.gz.sha256
+          wget -q ${RELEASES_URL}/2.21.0/tiledb-linux-x86_64-2.21.0-0ea9c13.tar.gz
+          wget -q ${RELEASES_URL}/2.21.0/tiledb-linux-x86_64-2.21.0-0ea9c13.tar.gz.sha256
           sha256sum tiledb*.sha256
           tar -C /opt/tiledb -xzf tiledb*.tar.gz
       - name: Lint

--- a/.github/workflows/nigthtly-stable.yml
+++ b/.github/workflows/nigthtly-stable.yml
@@ -17,8 +17,8 @@ jobs:
           set -e pipefail
           mkdir -p /opt/tiledb
           cd /opt/tiledb
-          wget -q ${RELEASES_URL}/2.21.0-rc1/tiledb-linux-x86_64-2.21.0-rc1-0ea9c13.tar.gz
-          wget -q ${RELEASES_URL}/2.21.0-rc1/tiledb-linux-x86_64-2.21.0-rc1-0ea9c13.tar.gz.sha256
+          wget -q ${RELEASES_URL}/2.21.0/tiledb-linux-x86_64-2.21.0-0ea9c13.tar.gz
+          wget -q ${RELEASES_URL}/2.21.0/tiledb-linux-x86_64-2.21.0-0ea9c13.tar.gz.sha256
           sha256sum tiledb*.sha256
           tar -C /opt/tiledb -xzf tiledb*.tar.gz
       - name: Update Dependencies

--- a/tiledb/api/src/lib.rs
+++ b/tiledb/api/src/lib.rs
@@ -29,6 +29,19 @@ pub mod filter;
 pub mod filter_list;
 pub mod query;
 pub mod string;
+pub mod vfs;
+
+pub fn version() -> (i32, i32, i32) {
+    let mut major: i32 = 0;
+    let mut minor: i32 = 0;
+    let mut patch: i32 = 0;
+
+    unsafe {
+        ffi::tiledb_version(&mut major, &mut minor, &mut patch);
+    }
+
+    (major, minor, patch)
+}
 
 pub use array::Array;
 pub use ffi::Datatype;

--- a/tiledb/api/src/vfs.rs
+++ b/tiledb/api/src/vfs.rs
@@ -1,0 +1,892 @@
+use std::ops::Deref;
+
+pub use ffi::VFSMode;
+
+use crate::config::Config;
+use crate::context::Context;
+use crate::Result as TileDBResult;
+
+pub(crate) enum RawVFS {
+    Owned(*mut ffi::tiledb_vfs_t),
+}
+
+impl Deref for RawVFS {
+    type Target = *mut ffi::tiledb_vfs_t;
+    fn deref(&self) -> &Self::Target {
+        match *self {
+            RawVFS::Owned(ref ffi) => ffi,
+        }
+    }
+}
+
+impl Drop for RawVFS {
+    fn drop(&mut self) {
+        let RawVFS::Owned(ref mut ffi) = *self;
+        unsafe { ffi::tiledb_vfs_free(ffi) };
+    }
+}
+
+pub struct VFS<'ctx> {
+    context: &'ctx Context,
+    raw: RawVFS,
+}
+
+pub(crate) enum RawVFSHandle {
+    Owned(*mut ffi::tiledb_vfs_fh_t),
+}
+
+impl Deref for RawVFSHandle {
+    type Target = *mut ffi::tiledb_vfs_fh_t;
+    fn deref(&self) -> &Self::Target {
+        match *self {
+            RawVFSHandle::Owned(ref ffi) => ffi,
+        }
+    }
+}
+
+impl Drop for RawVFSHandle {
+    fn drop(&mut self) {
+        let RawVFSHandle::Owned(ref mut ffi) = *self;
+        unsafe { ffi::tiledb_vfs_fh_free(ffi) };
+    }
+}
+
+pub struct VFSHandle<'ctx> {
+    context: &'ctx Context,
+    raw: RawVFSHandle,
+}
+
+impl<'ctx> VFS<'ctx> {
+    pub fn new(ctx: &'ctx Context, config: &Config) -> TileDBResult<VFS<'ctx>> {
+        let mut c_vfs: *mut ffi::tiledb_vfs_t = out_ptr!();
+        let res = unsafe {
+            ffi::tiledb_vfs_alloc(
+                ctx.as_mut_ptr(),
+                config.as_mut_ptr(),
+                &mut c_vfs,
+            )
+        };
+        if res == ffi::TILEDB_OK {
+            Ok(VFS {
+                context: ctx,
+                raw: RawVFS::Owned(c_vfs),
+            })
+        } else {
+            Err(ctx.expect_last_error())
+        }
+    }
+
+    pub fn get_config(&self) -> TileDBResult<Config> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_vfs = *self.raw;
+        let mut config = Config::default();
+        let res = unsafe {
+            ffi::tiledb_vfs_get_config(c_ctx, c_vfs, config.as_mut_ptr_ptr())
+        };
+
+        if res == ffi::TILEDB_OK {
+            Ok(config)
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    pub fn is_bucket(&self, uri: &str) -> TileDBResult<bool> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_vfs = *self.raw;
+        let c_uri = cstring!(uri);
+        let mut c_is_bucket: i32 = 0;
+        let res = unsafe {
+            ffi::tiledb_vfs_is_empty_bucket(
+                c_ctx,
+                c_vfs,
+                c_uri.as_ptr(),
+                &mut c_is_bucket,
+            )
+        };
+
+        if res == ffi::TILEDB_OK {
+            Ok(c_is_bucket == 1)
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    pub fn is_empty_bucket(&self, uri: &str) -> TileDBResult<bool> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_vfs = *self.raw;
+        let c_uri = cstring!(uri);
+        let mut c_is_empty: i32 = 0;
+        let res = unsafe {
+            ffi::tiledb_vfs_is_empty_bucket(
+                c_ctx,
+                c_vfs,
+                c_uri.as_ptr(),
+                &mut c_is_empty,
+            )
+        };
+
+        if res == ffi::TILEDB_OK {
+            Ok(c_is_empty == 1)
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    pub fn create_bucket(&self, uri: &str) -> TileDBResult<()> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_vfs = *self.raw;
+        let c_uri = cstring!(uri);
+        let res = unsafe {
+            ffi::tiledb_vfs_create_bucket(c_ctx, c_vfs, c_uri.as_ptr())
+        };
+
+        if res == ffi::TILEDB_OK {
+            Ok(())
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    pub fn remove_bucket(&self, uri: &str) -> TileDBResult<()> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_vfs = *self.raw;
+        let c_uri = cstring!(uri);
+        let res = unsafe {
+            ffi::tiledb_vfs_remove_bucket(c_ctx, c_vfs, c_uri.as_ptr())
+        };
+
+        if res == ffi::TILEDB_OK {
+            Ok(())
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    pub fn empty_bucket(&self, uri: &str) -> TileDBResult<()> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_vfs = *self.raw;
+        let c_uri = cstring!(uri);
+        let res = unsafe {
+            ffi::tiledb_vfs_empty_bucket(c_ctx, c_vfs, c_uri.as_ptr())
+        };
+
+        if res == ffi::TILEDB_OK {
+            Ok(())
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    pub fn is_dir(&self, uri: &str) -> TileDBResult<bool> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_vfs = *self.raw;
+        let c_uri = cstring!(uri);
+        let mut c_is_dir: i32 = 0;
+        let res = unsafe {
+            ffi::tiledb_vfs_is_dir(c_ctx, c_vfs, c_uri.as_ptr(), &mut c_is_dir)
+        };
+
+        if res == ffi::TILEDB_OK {
+            Ok(c_is_dir == 1)
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    pub fn dir_size(&self, uri: &str) -> TileDBResult<u64> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_vfs = *self.raw;
+        let c_uri = cstring!(uri);
+        let mut c_size: u64 = 0;
+        let res = unsafe {
+            ffi::tiledb_vfs_dir_size(c_ctx, c_vfs, c_uri.as_ptr(), &mut c_size)
+        };
+
+        if res == ffi::TILEDB_OK {
+            Ok(c_size)
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    pub fn create_dir(&self, uri: &str) -> TileDBResult<()> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_vfs = *self.raw;
+        let c_uri = cstring!(uri);
+        let res =
+            unsafe { ffi::tiledb_vfs_create_dir(c_ctx, c_vfs, c_uri.as_ptr()) };
+
+        if res == ffi::TILEDB_OK {
+            Ok(())
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    pub fn remove_dir(&self, uri: &str) -> TileDBResult<()> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_vfs = *self.raw;
+        let c_uri = cstring!(uri);
+        let res =
+            unsafe { ffi::tiledb_vfs_remove_dir(c_ctx, c_vfs, c_uri.as_ptr()) };
+
+        if res == ffi::TILEDB_OK {
+            Ok(())
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    pub fn copy_dir(&self, uri_src: &str, uri_tgt: &str) -> TileDBResult<()> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_vfs = *self.raw;
+        let c_uri_src = cstring!(uri_src);
+        let c_uri_tgt = cstring!(uri_tgt);
+        let res = unsafe {
+            ffi::tiledb_vfs_copy_dir(
+                c_ctx,
+                c_vfs,
+                c_uri_src.as_ptr(),
+                c_uri_tgt.as_ptr(),
+            )
+        };
+
+        if res == ffi::TILEDB_OK {
+            Ok(())
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    pub fn move_dir(&self, uri_src: &str, uri_tgt: &str) -> TileDBResult<()> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_vfs = *self.raw;
+        let c_uri_src = cstring!(uri_src);
+        let c_uri_tgt = cstring!(uri_tgt);
+        let res = unsafe {
+            ffi::tiledb_vfs_move_dir(
+                c_ctx,
+                c_vfs,
+                c_uri_src.as_ptr(),
+                c_uri_tgt.as_ptr(),
+            )
+        };
+
+        if res == ffi::TILEDB_OK {
+            Ok(())
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    pub fn is_file(&self, uri: &str) -> TileDBResult<bool> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_vfs = *self.raw;
+        let c_uri = cstring!(uri);
+        let mut c_is_file: i32 = 0;
+        let res = unsafe {
+            ffi::tiledb_vfs_is_file(
+                c_ctx,
+                c_vfs,
+                c_uri.as_ptr(),
+                &mut c_is_file,
+            )
+        };
+
+        if res == ffi::TILEDB_OK {
+            Ok(c_is_file == 1)
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    pub fn file_size(&self, uri: &str) -> TileDBResult<u64> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_vfs = *self.raw;
+        let c_uri = cstring!(uri);
+        let mut c_size: u64 = 0;
+        let res = unsafe {
+            ffi::tiledb_vfs_file_size(c_ctx, c_vfs, c_uri.as_ptr(), &mut c_size)
+        };
+
+        if res == ffi::TILEDB_OK {
+            Ok(c_size)
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    pub fn touch(&self, uri: &str) -> TileDBResult<()> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_vfs = *self.raw;
+        let c_uri = cstring!(uri);
+        let res =
+            unsafe { ffi::tiledb_vfs_touch(c_ctx, c_vfs, c_uri.as_ptr()) };
+
+        if res == ffi::TILEDB_OK {
+            Ok(())
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    pub fn create_file(&self, uri: &str) -> TileDBResult<()> {
+        self.touch(uri)
+    }
+
+    pub fn open(
+        &self,
+        uri: &str,
+        mode: VFSMode,
+    ) -> TileDBResult<VFSHandle<'ctx>> {
+        let mut c_fh: *mut ffi::tiledb_vfs_fh_t = out_ptr!();
+        let c_ctx = self.context.as_mut_ptr();
+        let c_vfs = *self.raw;
+        let c_uri = cstring!(uri);
+        let res = unsafe {
+            ffi::tiledb_vfs_open(c_ctx, c_vfs, c_uri.as_ptr(), mode, &mut c_fh)
+        };
+
+        if res == ffi::TILEDB_OK {
+            Ok(VFSHandle {
+                context: self.context,
+                raw: RawVFSHandle::Owned(c_fh),
+            })
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    pub fn remove_file(&self, uri: &str) -> TileDBResult<()> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_vfs = *self.raw;
+        let c_uri = cstring!(uri);
+        let res = unsafe {
+            ffi::tiledb_vfs_remove_file(c_ctx, c_vfs, c_uri.as_ptr())
+        };
+
+        if res == ffi::TILEDB_OK {
+            Ok(())
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    pub fn copy_file(&self, uri_src: &str, uri_tgt: &str) -> TileDBResult<()> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_vfs = *self.raw;
+        let c_uri_src = cstring!(uri_src);
+        let c_uri_tgt = cstring!(uri_tgt);
+        let res = unsafe {
+            ffi::tiledb_vfs_copy_file(
+                c_ctx,
+                c_vfs,
+                c_uri_src.as_ptr(),
+                c_uri_tgt.as_ptr(),
+            )
+        };
+
+        if res == ffi::TILEDB_OK {
+            Ok(())
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    pub fn move_file(&self, uri_src: &str, uri_tgt: &str) -> TileDBResult<()> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_vfs = *self.raw;
+        let c_uri_src = cstring!(uri_src);
+        let c_uri_tgt = cstring!(uri_tgt);
+        let res = unsafe {
+            ffi::tiledb_vfs_move_file(
+                c_ctx,
+                c_vfs,
+                c_uri_src.as_ptr(),
+                c_uri_tgt.as_ptr(),
+            )
+        };
+
+        if res == ffi::TILEDB_OK {
+            Ok(())
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    /// # Safety
+    /// This function is unsafe because of the data pointer being passed.
+    pub unsafe fn ls(
+        &self,
+        uri: &str,
+        callback: ffi::LSCallback,
+        data: *mut ::std::os::raw::c_void,
+    ) -> TileDBResult<()> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_vfs = *self.raw;
+        let c_uri = cstring!(uri);
+        let res = unsafe {
+            ffi::tiledb_vfs_ls(c_ctx, c_vfs, c_uri.as_ptr(), callback, data)
+        };
+
+        if res == ffi::TILEDB_OK {
+            Ok(())
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    /// # Safety
+    /// This function is unsafe because of the data pointer being passed.
+    pub unsafe fn ls_recursive(
+        &self,
+        uri: &str,
+        callback: ffi::LSRecursiveCallback,
+        data: *mut ::std::os::raw::c_void,
+    ) -> TileDBResult<()> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_vfs = *self.raw;
+        let c_uri = cstring!(uri);
+        let res = unsafe {
+            ffi::tiledb_vfs_ls_recursive(
+                c_ctx,
+                c_vfs,
+                c_uri.as_ptr(),
+                callback,
+                data,
+            )
+        };
+
+        if res == ffi::TILEDB_OK {
+            Ok(())
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+}
+
+impl<'ctx> VFSHandle<'ctx> {
+    pub fn is_closed(&self) -> TileDBResult<bool> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_fh = *self.raw;
+        let mut c_is_closed: i32 = 0;
+        let res = unsafe {
+            ffi::tiledb_vfs_fh_is_closed(c_ctx, c_fh, &mut c_is_closed)
+        };
+
+        if res == ffi::TILEDB_OK {
+            Ok(c_is_closed == 1)
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    pub fn close(&self) -> TileDBResult<()> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_fh = *self.raw;
+        let res = unsafe { ffi::tiledb_vfs_close(c_ctx, c_fh) };
+
+        if res == ffi::TILEDB_OK {
+            Ok(())
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    pub fn read(&self, offset: u64, buffer: &mut [u8]) -> TileDBResult<()> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_fh = *self.raw;
+        let res = unsafe {
+            ffi::tiledb_vfs_read(
+                c_ctx,
+                c_fh,
+                offset,
+                buffer.as_ptr() as *mut std::ffi::c_void,
+                buffer.len() as u64,
+            )
+        };
+
+        if res == ffi::TILEDB_OK {
+            Ok(())
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    pub fn write(&self, buffer: &[u8]) -> TileDBResult<()> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_fh = *self.raw;
+        let res = unsafe {
+            ffi::tiledb_vfs_write(
+                c_ctx,
+                c_fh,
+                buffer.as_ptr() as *const std::ffi::c_void,
+                buffer.len() as u64,
+            )
+        };
+
+        if res == ffi::TILEDB_OK {
+            Ok(())
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
+    pub fn sync(&self) -> TileDBResult<()> {
+        let c_ctx = self.context.as_mut_ptr();
+        let c_fh = *self.raw;
+        let res = unsafe { ffi::tiledb_vfs_sync(c_ctx, c_fh) };
+
+        if res == ffi::TILEDB_OK {
+            Ok(())
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error;
+    use tempdir::TempDir;
+
+    #[test]
+    fn vfs_alloc() -> TileDBResult<()> {
+        let ctx = Context::new()?;
+        let cfg = Config::new()?;
+        VFS::new(&ctx, &cfg)?;
+        Ok(())
+    }
+
+    #[test]
+    fn vfs_directory_operations() -> TileDBResult<()> {
+        let ctx = Context::new()?;
+        let cfg = Config::new()?;
+        let vfs = VFS::new(&ctx, &cfg)?;
+
+        let tmp_dir = TempDir::new("test_rs_bdelit").map_err(|e| {
+            error::Error::from(format!(
+                "Error creating temporary directory: {}",
+                e
+            ))
+        })?;
+
+        let tmp_uri = String::from("file://")
+            + tmp_dir.path().to_str().expect("Error creating tmp_uri");
+
+        assert!(vfs.is_dir(&tmp_uri)?);
+
+        let dir1_uri = String::from("file://")
+            + tmp_dir
+                .path()
+                .join("vfs_test_dir_1")
+                .to_str()
+                .expect("Whoops.");
+
+        let dir1_foo_uri = String::from("file://")
+            + tmp_dir
+                .path()
+                .join("vfs_test_dir_1/foo")
+                .to_str()
+                .expect("Whoops.");
+
+        let dir2_uri = String::from("file://")
+            + tmp_dir
+                .path()
+                .join("vfs_test_dir_2")
+                .to_str()
+                .expect("Whoops.");
+
+        let dir3_uri = String::from("file://")
+            + tmp_dir
+                .path()
+                .join("vfs_test_dir_3")
+                .to_str()
+                .expect("Whoops.");
+
+        assert!(!vfs.is_dir(&dir1_uri)?);
+        vfs.create_dir(&dir1_uri)?;
+        assert!(vfs.is_dir(&dir1_uri)?);
+
+        assert_eq!(vfs.dir_size(&dir1_uri)?, 0);
+
+        vfs.touch(&dir1_foo_uri)?;
+        assert!(vfs.is_file(&dir1_foo_uri)?);
+
+        // Write some data for dir_size checks
+        let data: &[u8] = &[42; 1024];
+        let fh = vfs.open(&dir1_foo_uri, VFSMode::Write)?;
+        fh.write(data)?;
+        assert_eq!(vfs.dir_size(&dir1_uri)?, 1024);
+
+        assert!(!vfs.is_dir(&dir2_uri)?);
+        vfs.move_dir(&dir1_uri, &dir2_uri)?;
+        assert!(!vfs.is_dir(&dir1_uri)?);
+        assert!(vfs.is_dir(&dir2_uri)?);
+        assert_eq!(vfs.dir_size(&dir2_uri)?, 1024);
+
+        assert!(!vfs.is_dir(&dir3_uri)?);
+        vfs.copy_dir(&dir2_uri, &dir3_uri)?;
+        assert!(vfs.is_dir(&dir2_uri)?);
+        assert!(vfs.is_dir(&dir3_uri)?);
+        assert_eq!(vfs.dir_size(&dir2_uri)?, vfs.dir_size(&dir3_uri)?);
+        assert_eq!(vfs.dir_size(&dir3_uri)?, 1024);
+
+        vfs.remove_dir(&dir2_uri)?;
+        vfs.remove_dir(&dir3_uri)?;
+        assert!(!vfs.is_dir(&dir2_uri)?);
+        assert!(!vfs.is_dir(&dir3_uri)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn vfs_file_operations() -> TileDBResult<()> {
+        let ctx = Context::new()?;
+        let cfg = Config::new()?;
+        let vfs = VFS::new(&ctx, &cfg)?;
+
+        let tmp_dir = TempDir::new("test_rs_bdelit").map_err(|e| {
+            error::Error::from(format!(
+                "Error creating temporary directory: {}",
+                e
+            ))
+        })?;
+
+        let file1_uri = String::from("file://")
+            + tmp_dir
+                .path()
+                .join("vfs_test_file_1")
+                .to_str()
+                .expect("Whoops.");
+
+        let file2_uri = String::from("file://")
+            + tmp_dir
+                .path()
+                .join("vfs_test_file_2")
+                .to_str()
+                .expect("Whoops.");
+
+        let file3_uri = String::from("file://")
+            + tmp_dir
+                .path()
+                .join("vfs_test_file_3")
+                .to_str()
+                .expect("Whoops.");
+
+        // A file doesn't exist before creation, but does after.
+        assert!(!vfs.is_file(&file1_uri)?);
+        vfs.touch(&file1_uri)?;
+        assert!(vfs.is_file(&file1_uri)?);
+
+        // Files are created empty.
+        assert_eq!(vfs.file_size(&file1_uri)?, 0);
+
+        // Move the file
+        assert!(!vfs.is_file(&file2_uri)?);
+        vfs.move_file(&file1_uri, &file2_uri)?;
+        assert!(vfs.is_file(&file2_uri)?);
+        assert_eq!(vfs.file_size(&file2_uri)?, 0);
+
+        // Open the file and write some data to it.
+        let mut data1 = String::from("Hello, world!");
+        let fh1 = vfs.open(&file2_uri, VFSMode::Write)?;
+        unsafe {
+            fh1.write(data1.as_bytes_mut())?;
+        }
+        fh1.sync()?;
+        fh1.close()?;
+        assert!(fh1.is_closed()?);
+
+        // Copy the file
+        vfs.copy_file(&file2_uri, &file3_uri)?;
+        assert_eq!(vfs.file_size(&file3_uri)?, 13);
+
+        // Check that removing works
+        vfs.remove_file(&file2_uri)?;
+        assert!(!vfs.is_file(&file2_uri)?);
+
+        // Check that reading from the copy matches the original write.
+        let mut data2 = String::from("             ");
+        let fh2 = vfs.open(&file3_uri, VFSMode::Read)?;
+        unsafe {
+            fh2.read(0, data2.as_bytes_mut())?;
+        }
+        assert_eq!(data2, data1);
+
+        Ok(())
+    }
+
+    fn create_test_dir_structure(
+        vfs: &VFS,
+        tmp_dir: &TempDir,
+    ) -> TileDBResult<()> {
+        let tmp_uri = String::from("file://")
+            + tmp_dir.path().to_str().expect("Error creating tmp_uri");
+
+        assert!(vfs.is_dir(&tmp_uri)?);
+
+        let dir1_uri = String::from("file://")
+            + tmp_dir
+                .path()
+                .join("vfs_test_dir_1")
+                .to_str()
+                .expect("Whoops.");
+
+        let dir1_foo_uri = String::from("file://")
+            + tmp_dir
+                .path()
+                .join("vfs_test_dir_1/foo")
+                .to_str()
+                .expect("Whoops.");
+
+        let dir2_uri = String::from("file://")
+            + tmp_dir
+                .path()
+                .join("vfs_test_dir_2")
+                .to_str()
+                .expect("Whoops.");
+
+        let dir3_uri = String::from("file://")
+            + tmp_dir
+                .path()
+                .join("vfs_test_dir_3")
+                .to_str()
+                .expect("Whoops.");
+
+        vfs.create_dir(&dir1_uri)?;
+        vfs.create_dir(&dir2_uri)?;
+        vfs.create_dir(&dir3_uri)?;
+
+        let data: &[u8] = &[32; 1024];
+        let fh = vfs.open(&dir1_foo_uri, VFSMode::Write)?;
+        fh.write(data)?;
+
+        Ok(())
+    }
+
+    unsafe extern "C" fn ls_callback(
+        _: *const std::os::raw::c_char,
+        count: *mut std::os::raw::c_void,
+    ) -> i32 {
+        *(count as *mut u64) += 1;
+        1
+    }
+
+    #[test]
+    fn vfs_ls() -> TileDBResult<()> {
+        let ctx = Context::new()?;
+        let cfg = Config::new()?;
+        let vfs = VFS::new(&ctx, &cfg)?;
+
+        let tmp_dir = TempDir::new("test_rs_bdelit").map_err(|e| {
+            error::Error::from(format!(
+                "Error creating temporary directory: {}",
+                e
+            ))
+        })?;
+
+        create_test_dir_structure(&vfs, &tmp_dir)?;
+
+        let tmp_uri = tmp_dir.path().to_str().expect("Error getting temp dir");
+        let mut count: u64 = 0;
+        unsafe {
+            vfs.ls(
+                tmp_uri,
+                Some(ls_callback),
+                &mut count as *mut std::ffi::c_ulonglong
+                    as *mut std::ffi::c_void,
+            )?;
+        }
+
+        // ls only sees the three directories.
+        assert_eq!(count, 3);
+
+        Ok(())
+    }
+
+    unsafe extern "C" fn ls_recursive_callback(
+        _: *const std::os::raw::c_char,
+        _: usize,
+        _: u64,
+        count: *mut std::os::raw::c_void,
+    ) -> i32 {
+        *(count as *mut u64) += 1;
+        1
+    }
+
+    #[test]
+    fn vfs_ls_recursive_old() -> TileDBResult<()> {
+        // Recursive ls over the Posix backend doesn't exist before 2.21
+        let (major, minor, _) = crate::version();
+        if major >= 2 && minor >= 21 {
+            return Ok(());
+        }
+
+        let ctx = Context::new()?;
+        let cfg = Config::new()?;
+        let vfs = VFS::new(&ctx, &cfg)?;
+
+        let tmp_dir = TempDir::new("test_rs_bdelit").map_err(|e| {
+            error::Error::from(format!(
+                "Error creating temporary directory: {}",
+                e
+            ))
+        })?;
+
+        let tmp_uri = tmp_dir.path().to_str().expect("Error getting tmp_uri");
+        let mut count: u64 = 0;
+        assert!(unsafe {
+            vfs.ls_recursive(
+                tmp_uri,
+                Some(ls_recursive_callback),
+                &mut count as *mut std::ffi::c_ulonglong
+                    as *mut std::ffi::c_void,
+            )
+            .is_err()
+        });
+
+        Ok(())
+    }
+
+    #[test]
+    fn vfs_ls_recursive_new() -> TileDBResult<()> {
+        // Recursive ls over the Posix backend doesn't exist before 2.21
+        let (major, minor, patch) = crate::version();
+        println!("VERSION: {}.{}.{}", major, minor, patch);
+        if !(major >= 2 && minor >= 21) {
+            return Ok(());
+        }
+
+        let ctx = Context::new()?;
+        let cfg = Config::new()?;
+        let vfs = VFS::new(&ctx, &cfg)?;
+
+        let tmp_dir = TempDir::new("test_rs_bdelit").map_err(|e| {
+            error::Error::from(format!(
+                "Error creating temporary directory: {}",
+                e
+            ))
+        })?;
+
+        create_test_dir_structure(&vfs, &tmp_dir)?;
+
+        let tmp_uri = tmp_dir.path().to_str().expect("Error getting temp dir");
+        let mut count: u64 = 0;
+        unsafe {
+            vfs.ls_recursive(
+                tmp_uri,
+                Some(ls_recursive_callback),
+                &mut count as *mut std::ffi::c_ulonglong
+                    as *mut std::ffi::c_void,
+            )?;
+        }
+
+        // ls_recursive sees three directories and one file.
+        assert_eq!(count, 4);
+
+        Ok(())
+    }
+}

--- a/tiledb/sys/src/lib.rs
+++ b/tiledb/sys/src/lib.rs
@@ -23,6 +23,8 @@ mod schema;
 mod string;
 mod subarray;
 mod types;
+mod version;
+mod vfs;
 
 pub use array::*;
 pub use attribute::*;
@@ -45,3 +47,5 @@ pub use schema::*;
 pub use string::*;
 pub use subarray::*;
 pub use types::*;
+pub use version::*;
+pub use vfs::*;

--- a/tiledb/sys/src/types.rs
+++ b/tiledb/sys/src/types.rs
@@ -5,6 +5,18 @@ pub type capi_status_t = i32;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct tiledb_array_t {
+    _unused: [u8; 0],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct tiledb_array_schema_t {
+    _unused: [u8; 0],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct tiledb_attribute_t {
     _unused: [u8; 0],
 }
@@ -29,6 +41,18 @@ pub struct tiledb_ctx_t {
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct tiledb_dimension_t {
+    _unused: [u8; 0],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct tiledb_domain_t {
+    _unused: [u8; 0],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct tiledb_error_t {
     _unused: [u8; 0],
 }
@@ -47,42 +71,36 @@ pub struct tiledb_filter_list_t {
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct tiledb_query_t {
+    _unused: [u8; 0],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct tiledb_query_condition_t {
+    _unused: [u8; 0],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct tiledb_string_t {
     _unused: [u8; 0],
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct tiledb_array_t {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct tiledb_subarray_t {
     _unused: [u8; 0],
 }
+
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct tiledb_dimension_t {
+pub struct tiledb_vfs_t {
     _unused: [u8; 0],
 }
+
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct tiledb_array_schema_t {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct tiledb_domain_t {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct tiledb_query_t {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct tiledb_query_condition_t {
+pub struct tiledb_vfs_fh_t {
     _unused: [u8; 0],
 }

--- a/tiledb/sys/src/version.rs
+++ b/tiledb/sys/src/version.rs
@@ -1,0 +1,3 @@
+extern "C" {
+    pub fn tiledb_version(major: *mut i32, minor: *mut i32, rev: *mut i32);
+}

--- a/tiledb/sys/src/vfs.rs
+++ b/tiledb/sys/src/vfs.rs
@@ -1,0 +1,221 @@
+use crate::types::{
+    capi_return_t, tiledb_config_t, tiledb_ctx_t, tiledb_vfs_fh_t, tiledb_vfs_t,
+};
+
+#[repr(C)]
+pub enum VFSMode {
+    Read = 0,
+    Write = 1,
+    Append = 2,
+}
+
+pub type LSCallback = ::std::option::Option<
+    unsafe extern "C" fn(
+        path: *const ::std::os::raw::c_char,
+        callback_data: *mut ::std::os::raw::c_void,
+    ) -> i32,
+>;
+
+pub type LSRecursiveCallback = ::std::option::Option<
+    unsafe extern "C" fn(
+        path: *const std::os::raw::c_char,
+        path_len: usize,
+        object_size: u64,
+        callback_data: *mut ::std::os::raw::c_void,
+    ) -> i32,
+>;
+
+extern "C" {
+    pub fn tiledb_vfs_mode_to_str(
+        vfs_mode: VFSMode,
+        str_: *mut *const ::std::os::raw::c_char,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_mode_from_str(
+        str_: *const ::std::os::raw::c_char,
+        vfs_mode: *mut VFSMode,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_alloc(
+        ctx: *mut tiledb_ctx_t,
+        config: *mut tiledb_config_t,
+        vfs: *mut *mut tiledb_vfs_t,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_free(vfs: *mut *mut tiledb_vfs_t);
+
+    pub fn tiledb_vfs_get_config(
+        ctx: *mut tiledb_ctx_t,
+        vfs: *mut tiledb_vfs_t,
+        config: *mut *mut tiledb_config_t,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_create_bucket(
+        ctx: *mut tiledb_ctx_t,
+        vfs: *mut tiledb_vfs_t,
+        uri: *const ::std::os::raw::c_char,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_remove_bucket(
+        ctx: *mut tiledb_ctx_t,
+        vfs: *mut tiledb_vfs_t,
+        uri: *const ::std::os::raw::c_char,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_empty_bucket(
+        ctx: *mut tiledb_ctx_t,
+        vfs: *mut tiledb_vfs_t,
+        uri: *const ::std::os::raw::c_char,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_is_empty_bucket(
+        ctx: *mut tiledb_ctx_t,
+        vfs: *mut tiledb_vfs_t,
+        uri: *const ::std::os::raw::c_char,
+        is_empty: *mut i32,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_is_bucket(
+        ctx: *mut tiledb_ctx_t,
+        vfs: *mut tiledb_vfs_t,
+        uri: *const ::std::os::raw::c_char,
+        is_bucket: *mut i32,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_is_dir(
+        ctx: *mut tiledb_ctx_t,
+        vfs: *mut tiledb_vfs_t,
+        uri: *const ::std::os::raw::c_char,
+        is_dir: *mut i32,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_dir_size(
+        ctx: *mut tiledb_ctx_t,
+        vfs: *mut tiledb_vfs_t,
+        uri: *const ::std::os::raw::c_char,
+        size: *mut u64,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_create_dir(
+        ctx: *mut tiledb_ctx_t,
+        vfs: *mut tiledb_vfs_t,
+        uri: *const ::std::os::raw::c_char,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_remove_dir(
+        ctx: *mut tiledb_ctx_t,
+        vfs: *mut tiledb_vfs_t,
+        uri: *const ::std::os::raw::c_char,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_copy_dir(
+        ctx: *mut tiledb_ctx_t,
+        vfs: *mut tiledb_vfs_t,
+        old_uri: *const ::std::os::raw::c_char,
+        new_uri: *const ::std::os::raw::c_char,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_move_dir(
+        ctx: *mut tiledb_ctx_t,
+        vfs: *mut tiledb_vfs_t,
+        old_uri: *const ::std::os::raw::c_char,
+        new_uri: *const ::std::os::raw::c_char,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_is_file(
+        ctx: *mut tiledb_ctx_t,
+        vfs: *mut tiledb_vfs_t,
+        uri: *const ::std::os::raw::c_char,
+        is_file: *mut i32,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_file_size(
+        ctx: *mut tiledb_ctx_t,
+        vfs: *mut tiledb_vfs_t,
+        uri: *const ::std::os::raw::c_char,
+        size: *mut u64,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_touch(
+        ctx: *mut tiledb_ctx_t,
+        vfs: *mut tiledb_vfs_t,
+        uri: *const ::std::os::raw::c_char,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_remove_file(
+        ctx: *mut tiledb_ctx_t,
+        vfs: *mut tiledb_vfs_t,
+        uri: *const ::std::os::raw::c_char,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_copy_file(
+        ctx: *mut tiledb_ctx_t,
+        vfs: *mut tiledb_vfs_t,
+        old_uri: *const ::std::os::raw::c_char,
+        new_uri: *const ::std::os::raw::c_char,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_move_file(
+        ctx: *mut tiledb_ctx_t,
+        vfs: *mut tiledb_vfs_t,
+        old_uri: *const ::std::os::raw::c_char,
+        new_uri: *const ::std::os::raw::c_char,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_ls(
+        ctx: *mut tiledb_ctx_t,
+        vfs: *mut tiledb_vfs_t,
+        path: *const ::std::os::raw::c_char,
+        callback: LSCallback,
+        data: *mut ::std::os::raw::c_void,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_ls_recursive(
+        ctx: *mut tiledb_ctx_t,
+        vfs: *mut tiledb_vfs_t,
+        path: *const ::std::os::raw::c_char,
+        callback: LSRecursiveCallback,
+        data: *mut ::std::os::raw::c_void,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_open(
+        ctx: *mut tiledb_ctx_t,
+        vfs: *mut tiledb_vfs_t,
+        uri: *const ::std::os::raw::c_char,
+        mode: VFSMode,
+        fh: *mut *mut tiledb_vfs_fh_t,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_close(
+        ctx: *mut tiledb_ctx_t,
+        fh: *mut tiledb_vfs_fh_t,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_read(
+        ctx: *mut tiledb_ctx_t,
+        fh: *mut tiledb_vfs_fh_t,
+        offset: u64,
+        buffer: *mut ::std::os::raw::c_void,
+        nbytes: u64,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_write(
+        ctx: *mut tiledb_ctx_t,
+        fh: *mut tiledb_vfs_fh_t,
+        buffer: *const ::std::os::raw::c_void,
+        nbytes: u64,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_sync(
+        ctx: *mut tiledb_ctx_t,
+        fh: *mut tiledb_vfs_fh_t,
+    ) -> capi_return_t;
+
+    pub fn tiledb_vfs_fh_free(fh: *mut *mut tiledb_vfs_fh_t);
+
+    pub fn tiledb_vfs_fh_is_closed(
+        ctx: *mut tiledb_ctx_t,
+        fh: *mut tiledb_vfs_fh_t,
+        is_closed: *mut i32,
+    ) -> capi_return_t;
+}


### PR DESCRIPTION
This covers the VFS API. I've not covered the bucket APIs with tests becauase I don't feel like adding a CI object store definition. Given that these are extensively tested during C++ builds I'm not overly concerned about the lack of coverage. I'm sure in the future I'll get around to setting things up in CI to exercise things when I switch to improving coverage mode.