### PR TITLE
Fix the VFS::ls and VFS::ls_recursive APIs

### DIFF
--- a/tiledb/sys/src/vfs.rs
+++ b/tiledb/sys/src/vfs.rs
@@ -18,7 +18,7 @@ pub type LSCallback = ::std::option::Option<
 
 pub type LSRecursiveCallback = ::std::option::Option<
     unsafe extern "C" fn(
-        path: *const std::os::raw::c_char,
+        path: *const std::os::raw::c_uchar,
         path_len: usize,
         object_size: u64,
         callback_data: *mut ::std::os::raw::c_void,


### PR DESCRIPTION
These weren't very Rusty on my first attempt. After some discussion with Ryan, he reminded me that FnMut is a thing and it turns out is actually usable as an argument being passed to a C API. Its a bit nutty on the implementation, but it seems to work just fine.