### PR TITLE
Implement strategy for arbitrary Schema generation, for dense or sparse arrays

### DIFF
--- a/tiledb/api/src/array/schema.rs
+++ b/tiledb/api/src/array/schema.rs
@@ -9,7 +9,7 @@ use crate::array::{Attribute, Domain, Layout};
 use crate::context::Context;
 use crate::Result as TileDBResult;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ArrayType {
     Dense,
     Sparse,

--- a/tiledb/sys/src/datatype.rs
+++ b/tiledb/sys/src/datatype.rs
@@ -277,6 +277,93 @@ impl Datatype {
             false
         }
     }
+
+    /// Returns whether this type is an integral type (i.e. integer)
+    // Keep in sync with sm/enums/datatype.h::datatype_is_integer
+    pub fn is_integral_type(&self) -> bool {
+        matches!(
+            *self,
+            Datatype::Boolean
+                | Datatype::Int8
+                | Datatype::Int16
+                | Datatype::Int32
+                | Datatype::Int64
+                | Datatype::UInt8
+                | Datatype::UInt16
+                | Datatype::UInt32
+                | Datatype::UInt64
+        )
+    }
+
+    /// Returns whether this type is a variable-length string type
+    // Keep in sync with sm/enums/datatype.h::datatype_is_string
+    pub fn is_string_type(&self) -> bool {
+        matches!(
+            *self,
+            Datatype::StringAscii
+                | Datatype::StringUtf8
+                | Datatype::StringUtf16
+                | Datatype::StringUtf32
+                | Datatype::StringUcs2
+                | Datatype::StringUcs4
+        )
+    }
+
+    /// Returns whether this type is a DateTime type of any resolution
+    // Keep in sync with sm/enums/datatype.h::datatype_is_datetime
+    pub fn is_datetime_type(&self) -> bool {
+        matches!(
+            *self,
+            Datatype::DateTimeYear
+                | Datatype::DateTimeMonth
+                | Datatype::DateTimeWeek
+                | Datatype::DateTimeDay
+                | Datatype::DateTimeHour
+                | Datatype::DateTimeMinute
+                | Datatype::DateTimeSecond
+                | Datatype::DateTimeMillisecond
+                | Datatype::DateTimeMicrosecond
+                | Datatype::DateTimeNanosecond
+                | Datatype::DateTimePicosecond
+                | Datatype::DateTimeFemtosecond
+                | Datatype::DateTimeAttosecond
+        )
+    }
+
+    /// Returns whether this type is a Time type of any resolution
+    // Keep in sync with sm/enums/datatype.h::datatype_is_time
+    pub fn is_time_type(&self) -> bool {
+        matches!(
+            *self,
+            Datatype::TimeHour
+                | Datatype::TimeMinute
+                | Datatype::TimeSecond
+                | Datatype::TimeMillisecond
+                | Datatype::TimeMicrosecond
+                | Datatype::TimeNanosecond
+                | Datatype::TimePicosecond
+                | Datatype::TimeFemtosecond
+                | Datatype::TimeAttosecond
+        )
+    }
+
+    /// Returns whether this type can be used as a dimension type of a sparse array
+    pub fn is_allowed_dimension_type_sparse(&self) -> bool {
+        self.is_integral_type()
+            || self.is_datetime_type()
+            || self.is_time_type()
+            || matches!(
+                *self,
+                Datatype::Float32 | Datatype::Float64 | Datatype::StringAscii
+            )
+    }
+
+    /// Returns whether this type can be used as a dimension type of a dense array
+    pub fn is_allowed_dimension_type_dense(&self) -> bool {
+        self.is_integral_type()
+            || self.is_datetime_type()
+            || self.is_time_type()
+    }
 }
 
 impl Display for Datatype {

--- a/tiledb/test/src/attribute.rs
+++ b/tiledb/test/src/attribute.rs
@@ -5,6 +5,10 @@ use tiledb::context::Context;
 pub fn arbitrary_name() -> impl Strategy<Value = String> {
     proptest::string::string_regex("[a-zA-Z0-9_]*")
         .expect("Error creating attribute name strategy")
+        .prop_filter(
+            "Attribute names may not begin with reserved prefix",
+            |name| !name.starts_with("__"),
+        )
 }
 
 pub fn arbitrary(context: &Context) -> impl Strategy<Value = Attribute> {

--- a/tiledb/test/src/datatype.rs
+++ b/tiledb/test/src/datatype.rs
@@ -49,9 +49,10 @@ pub fn arbitrary() -> impl Strategy<Value = tiledb::Datatype> {
     ]
 }
 
-/// Choose an arbitrary datatype which satisifes the CAPIConverter trait
+/// Choose an arbitrary datatype which is implemented
+/// (satisfies CAPIConv, and has cases in fn_typed)
 // TODO: make sure to keep this list up to date as we add more types
-pub fn arbitrary_conv() -> impl Strategy<Value = tiledb::Datatype> {
+pub fn arbitrary_implemented() -> impl Strategy<Value = tiledb::Datatype> {
     prop_oneof![
         Just(tiledb::Datatype::Int8),
         Just(tiledb::Datatype::Int16),
@@ -64,4 +65,12 @@ pub fn arbitrary_conv() -> impl Strategy<Value = tiledb::Datatype> {
         Just(tiledb::Datatype::Float32),
         Just(tiledb::Datatype::Float64),
     ]
+}
+
+pub fn arbitrary_for_dense_dimension() -> impl Strategy<Value = tiledb::Datatype>
+{
+    arbitrary_implemented().prop_filter(
+        "Type is not a valid dimension type for dense arrays",
+        |dt| dt.is_allowed_dimension_type_dense(),
+    )
 }

--- a/tiledb/test/src/dimension.rs
+++ b/tiledb/test/src/dimension.rs
@@ -95,7 +95,7 @@ pub fn arbitrary(
 mod tests {
     use super::*;
 
-    /// Test that the arbitrary attribute construction always succeeds
+    /// Test that the arbitrary dimension construction always succeeds
     #[test]
     fn dimension_arbitrary() {
         let ctx = Context::new().expect("Error creating context");

--- a/tiledb/test/src/domain.rs
+++ b/tiledb/test/src/domain.rs
@@ -1,25 +1,32 @@
 use proptest::prelude::*;
-use tiledb::array::{Domain, DomainBuilder};
+use tiledb::array::{ArrayType, Domain, DomainBuilder};
 use tiledb::context::Context;
 use tiledb::Result as TileDBResult;
 
+use crate::strategy::LifetimeBoundStrategy;
+
 pub fn arbitrary(
     context: &Context,
+    array_type: ArrayType,
 ) -> impl Strategy<Value = TileDBResult<Domain>> {
     const MIN_DIMENSIONS: usize = 1;
     const MAX_DIMENSIONS: usize = 8;
 
-    proptest::collection::vec(
-        crate::dimension::arbitrary(context),
-        MIN_DIMENSIONS..=MAX_DIMENSIONS,
-    )
-    .prop_map(|dimensions| {
-        let mut d = DomainBuilder::new(context)?;
-        for dim in dimensions {
-            d = d.add_dimension(dim?)?;
-        }
-        Ok(d.build())
-    })
+    match array_type {
+        ArrayType::Dense => unimplemented!(),
+        ArrayType::Sparse => proptest::collection::vec(
+            crate::dimension::arbitrary(context),
+            MIN_DIMENSIONS..=MAX_DIMENSIONS,
+        )
+        .prop_map(|dimensions| {
+            let mut d = DomainBuilder::new(context)?;
+            for dim in dimensions {
+                d = d.add_dimension(dim?)?;
+            }
+            Ok(d.build())
+        })
+        .bind(),
+    }
 }
 
 #[cfg(test)]
@@ -28,11 +35,11 @@ mod tests {
 
     /// Test that the arbitrary domain construction always succeeds
     #[test]
-    fn domain_arbitrary() {
+    fn domain_arbitrary_sparse() {
         let ctx = Context::new().expect("Error creating context");
 
-        proptest!(|(maybe_domain in arbitrary(&ctx))| {
-            maybe_domain.expect("Error constructing arbitrary dimension");
+        proptest!(|(maybe_domain in arbitrary(&ctx, ArrayType::Sparse))| {
+            maybe_domain.expect("Error constructing arbitrary domain");
         });
     }
 }

--- a/tiledb/test/src/domain.rs
+++ b/tiledb/test/src/domain.rs
@@ -1,0 +1,38 @@
+use proptest::prelude::*;
+use tiledb::array::{Domain, DomainBuilder};
+use tiledb::context::Context;
+use tiledb::Result as TileDBResult;
+
+pub fn arbitrary(
+    context: &Context,
+) -> impl Strategy<Value = TileDBResult<Domain>> {
+    const MIN_DIMENSIONS: usize = 1;
+    const MAX_DIMENSIONS: usize = 8;
+
+    proptest::collection::vec(
+        crate::dimension::arbitrary(context),
+        MIN_DIMENSIONS..=MAX_DIMENSIONS,
+    )
+    .prop_map(|dimensions| {
+        let mut d = DomainBuilder::new(context)?;
+        for dim in dimensions {
+            d = d.add_dimension(dim?)?;
+        }
+        Ok(d.build())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test that the arbitrary domain construction always succeeds
+    #[test]
+    fn domain_arbitrary() {
+        let ctx = Context::new().expect("Error creating context");
+
+        proptest!(|(maybe_domain in arbitrary(&ctx))| {
+            maybe_domain.expect("Error constructing arbitrary dimension");
+        });
+    }
+}

--- a/tiledb/test/src/lib.rs
+++ b/tiledb/test/src/lib.rs
@@ -5,4 +5,5 @@ extern crate tiledb;
 pub mod attribute;
 pub mod datatype;
 pub mod dimension;
+pub mod domain;
 pub mod strategy;

--- a/tiledb/test/src/lib.rs
+++ b/tiledb/test/src/lib.rs
@@ -6,4 +6,5 @@ pub mod attribute;
 pub mod datatype;
 pub mod dimension;
 pub mod domain;
+pub mod schema;
 pub mod strategy;

--- a/tiledb/test/src/schema.rs
+++ b/tiledb/test/src/schema.rs
@@ -1,0 +1,49 @@
+use proptest::prelude::*;
+use tiledb::array::{ArrayType, Schema, SchemaBuilder};
+use tiledb::context::Context;
+use tiledb::Result as TileDBResult;
+
+pub fn arbitrary_array_type() -> impl Strategy<Value = ArrayType> {
+    // TODO: implement Domain scenario for Dense arrays
+    Just(ArrayType::Sparse)
+}
+
+pub fn arbitrary(
+    context: &Context,
+) -> impl Strategy<Value = TileDBResult<Schema>> {
+    const MIN_ATTRS: usize = 1;
+    const MAX_ATTRS: usize = 128;
+
+    arbitrary_array_type()
+        .prop_flat_map(move |array_type|
+            (
+                Just(array_type),
+                crate::domain::arbitrary(context, array_type),
+                proptest::collection::vec(crate::attribute::arbitrary(context), MIN_ATTRS..=MAX_ATTRS)
+            ))
+        .prop_map(|(array_type, domain, attrs)| {
+            /* TODO: cell order, tile order, capacity, duplicates */
+            let mut b = SchemaBuilder::new(context, array_type, domain?)?;
+            for attr in attrs {
+                /* TODO: how to ensure no duplicate names, assuming that matters? */
+                b = b.add_attribute(attr)?
+            }
+
+            Ok(b.build())
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test that the arbitrary schema construction always succeeds
+    #[test]
+    fn schema_arbitrary() {
+        let ctx = Context::new().expect("Error creating context");
+
+        proptest!(|(maybe_schema in arbitrary(&ctx))| {
+            maybe_schema.expect("Error constructing arbitrary schema");
+        });
+    }
+}

--- a/tiledb/test/src/schema.rs
+++ b/tiledb/test/src/schema.rs
@@ -4,8 +4,7 @@ use tiledb::context::Context;
 use tiledb::Result as TileDBResult;
 
 pub fn arbitrary_array_type() -> impl Strategy<Value = ArrayType> {
-    // TODO: implement Domain scenario for Dense arrays
-    Just(ArrayType::Sparse)
+    prop_oneof![Just(ArrayType::Dense), Just(ArrayType::Sparse),]
 }
 
 pub fn arbitrary(


### PR DESCRIPTION
There are some restrictions on dimension types for dense arrays, for which adding some `Datatype` query functions was very helpful.