### PR TITLE
Rename as_mut_ptr() to capi() for consistency

### DIFF
--- a/tiledb/api/src/array/dimension.rs
+++ b/tiledb/api/src/array/dimension.rs
@@ -46,7 +46,7 @@ impl<'ctx> Dimension<'ctx> {
     }
 
     pub fn datatype(&self) -> Datatype {
-        let c_context = self.context.as_mut_ptr();
+        let c_context = self.context.capi();
         let c_dimension = self.capi();
         let mut c_datatype: ffi::tiledb_datatype_t = out_ptr!();
         let c_ret = unsafe {
@@ -63,7 +63,7 @@ impl<'ctx> Dimension<'ctx> {
     }
 
     pub fn domain<Conv: CAPIConverter>(&self) -> TileDBResult<[Conv; 2]> {
-        let c_context = self.context.as_mut_ptr();
+        let c_context = self.context.capi();
         let c_dimension = self.capi();
         let mut c_domain_ptr: *const std::ffi::c_void = out_ptr!();
 
@@ -87,7 +87,7 @@ impl<'ctx> Dimension<'ctx> {
     pub fn filters(&self) -> FilterList {
         let mut c_fl: *mut ffi::tiledb_filter_list_t = out_ptr!();
 
-        let c_context = self.context.as_mut_ptr();
+        let c_context = self.context.capi();
         let c_dimension = self.capi();
         let c_ret = unsafe {
             ffi::tiledb_dimension_get_filter_list(
@@ -133,7 +133,7 @@ impl<'ctx> Builder<'ctx> {
         domain: &[Conv; 2],
         extent: &Conv,
     ) -> TileDBResult<Self> {
-        let c_context = context.as_mut_ptr();
+        let c_context = context.capi();
         let c_datatype = datatype.capi_enum();
 
         let c_name = cstring!(name);
@@ -169,9 +169,9 @@ impl<'ctx> Builder<'ctx> {
     }
 
     pub fn filters(self, filters: FilterList) -> TileDBResult<Self> {
-        let c_context = self.dim.context.as_mut_ptr();
+        let c_context = self.dim.context.capi();
         let c_dimension = self.dim.capi();
-        let c_fl = filters.as_mut_ptr();
+        let c_fl = filters.capi();
 
         if unsafe {
             ffi::tiledb_dimension_set_filter_list(c_context, c_dimension, c_fl)

--- a/tiledb/api/src/array/domain.rs
+++ b/tiledb/api/src/array/domain.rs
@@ -45,7 +45,7 @@ impl<'ctx> Domain<'ctx> {
         let mut ndim: u32 = out_ptr!();
         let c_ret = unsafe {
             ffi::tiledb_domain_get_ndim(
-                self.context.as_mut_ptr(),
+                self.context.capi(),
                 *self.raw,
                 &mut ndim,
             )
@@ -56,7 +56,7 @@ impl<'ctx> Domain<'ctx> {
     }
 
     pub fn dimension(&self, idx: usize) -> TileDBResult<Dimension<'ctx>> {
-        let c_context = self.context.as_mut_ptr();
+        let c_context = self.context.capi();
         let c_domain = *self.raw;
         let mut c_dimension: *mut ffi::tiledb_dimension_t = out_ptr!();
         let c_idx = match idx.try_into() {
@@ -113,9 +113,8 @@ pub struct Builder<'ctx> {
 impl<'ctx> Builder<'ctx> {
     pub fn new(context: &'ctx Context) -> TileDBResult<Self> {
         let mut c_domain: *mut ffi::tiledb_domain_t = out_ptr!();
-        let c_ret = unsafe {
-            ffi::tiledb_domain_alloc(context.as_mut_ptr(), &mut c_domain)
-        };
+        let c_ret =
+            unsafe { ffi::tiledb_domain_alloc(context.capi(), &mut c_domain) };
         if c_ret == ffi::TILEDB_OK {
             Ok(Builder {
                 domain: Domain {
@@ -132,7 +131,7 @@ impl<'ctx> Builder<'ctx> {
         self,
         dimension: Dimension<'ctx>,
     ) -> TileDBResult<Self> {
-        let c_context = self.domain.context.as_mut_ptr();
+        let c_context = self.domain.context.capi();
         let c_domain = *self.domain.raw;
         let c_dim = dimension.capi();
 

--- a/tiledb/api/src/array/schema.rs
+++ b/tiledb/api/src/array/schema.rs
@@ -67,16 +67,16 @@ pub struct Schema<'ctx> {
 }
 
 impl<'ctx> Schema<'ctx> {
+    pub(crate) fn capi(&self) -> *mut ffi::tiledb_array_schema_t {
+        *self.raw
+    }
+
     pub(crate) fn new(context: &'ctx Context, raw: RawSchema) -> Self {
         Schema { context, raw }
     }
 
-    pub(crate) fn as_mut_ptr(&self) -> *mut ffi::tiledb_array_schema_t {
-        *self.raw
-    }
-
     pub fn domain(&self) -> TileDBResult<Domain<'ctx>> {
-        let c_context: *mut ffi::tiledb_ctx_t = self.context.as_mut_ptr();
+        let c_context: *mut ffi::tiledb_ctx_t = self.context.capi();
         let c_schema = *self.raw;
         let mut c_domain: *mut ffi::tiledb_domain_t = out_ptr!();
         let c_ret = unsafe {
@@ -95,7 +95,7 @@ impl<'ctx> Schema<'ctx> {
 
     /// Retrieve the schema of an array from storage
     pub fn load(context: &'ctx Context, uri: &str) -> TileDBResult<Self> {
-        let c_context: *mut ffi::tiledb_ctx_t = context.as_mut_ptr();
+        let c_context: *mut ffi::tiledb_ctx_t = context.capi();
         let c_uri = cstring!(uri);
         let mut c_schema: *mut ffi::tiledb_array_schema_t = out_ptr!();
 
@@ -117,8 +117,8 @@ impl<'ctx> Schema<'ctx> {
         let mut c_ret: std::os::raw::c_int = out_ptr!();
         if unsafe {
             ffi::tiledb_array_schema_get_allows_dups(
-                self.context.as_mut_ptr(),
-                self.as_mut_ptr(),
+                self.context.capi(),
+                self.capi(),
                 &mut c_ret,
             )
         } == ffi::TILEDB_OK
@@ -130,7 +130,7 @@ impl<'ctx> Schema<'ctx> {
     }
 
     pub fn array_type(&self) -> ArrayType {
-        let c_context = self.context.as_mut_ptr();
+        let c_context = self.context.capi();
         let c_schema = *self.raw;
         let mut c_atype: ffi::tiledb_array_type_t = out_ptr!();
         let c_ret = unsafe {
@@ -145,7 +145,7 @@ impl<'ctx> Schema<'ctx> {
     }
 
     pub fn capacity(&self) -> u64 {
-        let c_context = self.context.as_mut_ptr();
+        let c_context = self.context.capi();
         let c_schema = *self.raw;
         let mut c_capacity: u64 = out_ptr!();
         let c_ret = unsafe {
@@ -160,7 +160,7 @@ impl<'ctx> Schema<'ctx> {
     }
 
     pub fn cell_order(&self) -> Layout {
-        let c_context = self.context.as_mut_ptr();
+        let c_context = self.context.capi();
         let c_schema = *self.raw;
         let mut c_cell_order: ffi::tiledb_layout_t = out_ptr!();
         let c_ret = unsafe {
@@ -175,7 +175,7 @@ impl<'ctx> Schema<'ctx> {
     }
 
     pub fn tile_order(&self) -> Layout {
-        let c_context = self.context.as_mut_ptr();
+        let c_context = self.context.capi();
         let c_schema = *self.raw;
         let mut c_tile_order: ffi::tiledb_layout_t = out_ptr!();
         let c_ret = unsafe {
@@ -193,8 +193,8 @@ impl<'ctx> Schema<'ctx> {
         let mut c_ret: std::os::raw::c_int = out_ptr!();
         if unsafe {
             ffi::tiledb_array_schema_get_allows_dups(
-                self.context.as_mut_ptr(),
-                self.as_mut_ptr(),
+                self.context.capi(),
+                self.capi(),
                 &mut c_ret,
             )
         } == ffi::TILEDB_OK
@@ -206,7 +206,7 @@ impl<'ctx> Schema<'ctx> {
     }
 
     pub fn nattributes(&self) -> usize {
-        let c_context = self.context.as_mut_ptr();
+        let c_context = self.context.capi();
         let c_schema = *self.raw;
         let mut c_nattrs: u32 = out_ptr!();
         let c_ret = unsafe {
@@ -221,7 +221,7 @@ impl<'ctx> Schema<'ctx> {
     }
 
     pub fn attribute(&self, index: usize) -> TileDBResult<Attribute> {
-        let c_context = self.context.as_mut_ptr();
+        let c_context = self.context.capi();
         let c_schema = *self.raw;
         let c_index = index as u32;
         let mut c_attr: *mut ffi::tiledb_attribute_t = out_ptr!();
@@ -274,7 +274,7 @@ impl<'ctx> Builder<'ctx> {
         array_type: ArrayType,
         domain: Domain<'ctx>,
     ) -> TileDBResult<Self> {
-        let c_context = context.as_mut_ptr();
+        let c_context = context.capi();
         let c_array_type = array_type.capi_enum();
         let mut c_schema: *mut ffi::tiledb_array_schema_t =
             std::ptr::null_mut();
@@ -306,7 +306,7 @@ impl<'ctx> Builder<'ctx> {
     }
 
     pub fn capacity(self, capacity: u64) -> TileDBResult<Self> {
-        let c_context = self.schema.context.as_mut_ptr();
+        let c_context = self.schema.context.capi();
         let c_schema = *self.schema.raw;
         let c_ret = unsafe {
             ffi::tiledb_array_schema_set_capacity(c_context, c_schema, capacity)
@@ -319,7 +319,7 @@ impl<'ctx> Builder<'ctx> {
     }
 
     pub fn cell_order(self, order: Layout) -> TileDBResult<Self> {
-        let c_context = self.schema.context.as_mut_ptr();
+        let c_context = self.schema.context.capi();
         let c_schema = *self.schema.raw;
         let c_order = order.capi_enum();
         let c_ret = unsafe {
@@ -335,7 +335,7 @@ impl<'ctx> Builder<'ctx> {
     }
 
     pub fn tile_order(self, order: Layout) -> TileDBResult<Self> {
-        let c_context = self.schema.context.as_mut_ptr();
+        let c_context = self.schema.context.capi();
         let c_schema = *self.schema.raw;
         let c_order = order.capi_enum();
         let c_ret = unsafe {
@@ -354,7 +354,7 @@ impl<'ctx> Builder<'ctx> {
         let c_allow = if allow { 1 } else { 0 };
         if unsafe {
             ffi::tiledb_array_schema_set_allows_dups(
-                self.schema.context.as_mut_ptr(),
+                self.schema.context.capi(),
                 *self.schema.raw,
                 c_allow,
             )
@@ -369,9 +369,9 @@ impl<'ctx> Builder<'ctx> {
     pub fn add_attribute(self, attr: Attribute) -> TileDBResult<Self> {
         if unsafe {
             ffi::tiledb_array_schema_add_attribute(
-                self.schema.context.as_mut_ptr(),
+                self.schema.context.capi(),
                 *self.schema.raw,
-                attr.as_mut_ptr(),
+                attr.capi(),
             )
         } == ffi::TILEDB_OK
         {

--- a/tiledb/api/src/context.rs
+++ b/tiledb/api/src/context.rs
@@ -1,8 +1,7 @@
-extern crate tiledb_sys as ffi;
-
 use std::convert::From;
+use std::ops::Deref;
 
-use crate::config::Config;
+use crate::config::{Config, RawConfig};
 use crate::error::Error;
 use crate::Result as TileDBResult;
 
@@ -11,29 +10,48 @@ pub enum ObjectType {
     Group,
 }
 
+pub(crate) enum RawContext {
+    Owned(*mut ffi::tiledb_ctx_t),
+}
+
+impl Deref for RawContext {
+    type Target = *mut ffi::tiledb_ctx_t;
+    fn deref(&self) -> &Self::Target {
+        let RawContext::Owned(ref ffi) = *self;
+        ffi
+    }
+}
+
+impl Drop for RawContext {
+    fn drop(&mut self) {
+        let RawContext::Owned(ref mut ffi) = *self;
+        unsafe {
+            ffi::tiledb_ctx_free(ffi);
+        }
+    }
+}
+
 pub struct Context {
-    _wrapped: *mut ffi::tiledb_ctx_t,
+    raw: RawContext,
 }
 
 impl Context {
+    pub fn capi(&self) -> *mut ffi::tiledb_ctx_t {
+        *self.raw
+    }
+
     pub fn new() -> TileDBResult<Context> {
-        let cfg = Config::new().expect("Error creating config instance.");
+        let cfg = Config::new()?;
         Context::from_config(&cfg)
     }
 
-    pub fn as_mut_ptr(&self) -> *mut ffi::tiledb_ctx_t {
-        self._wrapped
-    }
-
     pub fn from_config(cfg: &Config) -> TileDBResult<Context> {
-        let mut ctx = Context {
-            _wrapped: std::ptr::null_mut::<ffi::tiledb_ctx_t>(),
-        };
-        let res = unsafe {
-            ffi::tiledb_ctx_alloc(cfg.as_mut_ptr(), &mut ctx._wrapped)
-        };
+        let mut c_ctx: *mut ffi::tiledb_ctx_t = out_ptr!();
+        let res = unsafe { ffi::tiledb_ctx_alloc(cfg.capi(), &mut c_ctx) };
         if res == ffi::TILEDB_OK {
-            Ok(ctx)
+            Ok(Context {
+                raw: RawContext::Owned(c_ctx),
+            })
         } else {
             Err(Error::from("Error creating context."))
         }
@@ -43,7 +61,7 @@ impl Context {
         let mut c_json = std::ptr::null_mut::<std::os::raw::c_char>();
         let res = unsafe {
             ffi::tiledb_ctx_get_stats(
-                self._wrapped,
+                *self.raw,
                 &mut c_json as *mut *mut std::os::raw::c_char,
             )
         };
@@ -57,22 +75,21 @@ impl Context {
     }
 
     pub fn get_config(&self) -> TileDBResult<Config> {
-        let mut cfg = Config::default();
-        let res = unsafe {
-            ffi::tiledb_ctx_get_config(self._wrapped, cfg.as_mut_ptr_ptr())
-        };
+        let mut c_cfg: *mut ffi::tiledb_config_t = out_ptr!();
+        let res = unsafe { ffi::tiledb_ctx_get_config(*self.raw, &mut c_cfg) };
         if res == ffi::TILEDB_OK {
-            Ok(cfg)
+            Ok(Config {
+                raw: RawConfig::Owned(c_cfg),
+            })
         } else {
             Err(self.expect_last_error())
         }
     }
 
     pub fn get_last_error(&self) -> Option<Error> {
-        let mut c_err: *mut ffi::tiledb_error_t = std::ptr::null_mut();
-        let res = unsafe {
-            ffi::tiledb_ctx_get_last_error(self._wrapped, &mut c_err)
-        };
+        let mut c_err: *mut ffi::tiledb_error_t = out_ptr!();
+        let res =
+            unsafe { ffi::tiledb_ctx_get_last_error(*self.raw, &mut c_err) };
         if res == ffi::TILEDB_OK && !c_err.is_null() {
             Some(Error::from(c_err))
         } else {
@@ -90,7 +107,7 @@ impl Context {
         let mut supported: i32 = 0;
         let res = unsafe {
             ffi::tiledb_ctx_is_supported_fs(
-                self._wrapped,
+                *self.raw,
                 fs as u32,
                 &mut supported,
             )
@@ -109,7 +126,7 @@ impl Context {
             std::ffi::CString::new(val).expect("Error creating CString");
         let res = unsafe {
             ffi::tiledb_ctx_set_tag(
-                self._wrapped,
+                *self.raw,
                 c_key.as_c_str().as_ptr(),
                 c_val.as_c_str().as_ptr(),
             )
@@ -127,11 +144,7 @@ impl Context {
         let mut c_objtype: ffi::tiledb_object_t = out_ptr!();
 
         let c_ret = unsafe {
-            ffi::tiledb_object_type(
-                self.as_mut_ptr(),
-                c_name.as_ptr(),
-                &mut c_objtype,
-            )
+            ffi::tiledb_object_type(*self.raw, c_name.as_ptr(), &mut c_objtype)
         };
         if c_ret == ffi::TILEDB_OK {
             Ok(match c_objtype {
@@ -142,15 +155,6 @@ impl Context {
         } else {
             Err(self.expect_last_error())
         }
-    }
-}
-
-impl Drop for Context {
-    fn drop(&mut self) {
-        if self._wrapped.is_null() {
-            return;
-        }
-        unsafe { ffi::tiledb_ctx_free(&mut self._wrapped) }
     }
 }
 

--- a/tiledb/api/src/filter.rs
+++ b/tiledb/api/src/filter.rs
@@ -43,7 +43,7 @@ impl Filter {
         let mut c_filter: *mut ffi::tiledb_filter_t = out_ptr!();
         let ftype = filter_type as u32;
         let res = unsafe {
-            ffi::tiledb_filter_alloc(ctx.as_mut_ptr(), ftype, &mut c_filter)
+            ffi::tiledb_filter_alloc(ctx.capi(), ftype, &mut c_filter)
         };
         if res == ffi::TILEDB_OK {
             Ok(Filter {
@@ -61,11 +61,7 @@ impl Filter {
     pub fn get_type(&self, ctx: &Context) -> TileDBResult<FilterType> {
         let mut c_ftype: u32 = 0;
         let res = unsafe {
-            ffi::tiledb_filter_get_type(
-                ctx.as_mut_ptr(),
-                self.capi(),
-                &mut c_ftype,
-            )
+            ffi::tiledb_filter_get_type(ctx.capi(), self.capi(), &mut c_ftype)
         };
         if res == ffi::TILEDB_OK {
             let ftype = FilterType::from_u32(c_ftype);
@@ -339,7 +335,7 @@ impl Filter {
     ) -> TileDBResult<()> {
         let res = unsafe {
             ffi::tiledb_filter_set_option(
-                ctx.as_mut_ptr(),
+                ctx.capi(),
                 self.capi(),
                 fopt as u32,
                 val,
@@ -360,7 +356,7 @@ impl Filter {
     ) -> TileDBResult<()> {
         let res = unsafe {
             ffi::tiledb_filter_get_option(
-                ctx.as_mut_ptr(),
+                ctx.capi(),
                 self.capi(),
                 fopt as u32,
                 val,

--- a/tiledb/api/src/filter_list.rs
+++ b/tiledb/api/src/filter_list.rs
@@ -9,26 +9,22 @@ pub struct FilterList {
 }
 
 impl FilterList {
+    pub fn capi(&self) -> *mut ffi::tiledb_filter_list_t {
+        self._wrapped
+    }
+
     pub fn new(ctx: &Context) -> TileDBResult<FilterList> {
         let mut flist = FilterList {
             _wrapped: std::ptr::null_mut::<ffi::tiledb_filter_list_t>(),
         };
         let res = unsafe {
-            ffi::tiledb_filter_list_alloc(ctx.as_mut_ptr(), &mut flist._wrapped)
+            ffi::tiledb_filter_list_alloc(ctx.capi(), &mut flist._wrapped)
         };
         if res == ffi::TILEDB_OK {
             Ok(flist)
         } else {
             Err(ctx.expect_last_error())
         }
-    }
-
-    pub fn as_mut_ptr(&self) -> *mut ffi::tiledb_filter_list_t {
-        self._wrapped
-    }
-
-    pub fn as_mut_ptr_ptr(&mut self) -> *mut *mut ffi::tiledb_filter_list_t {
-        &mut self._wrapped
     }
 
     pub fn add_filter(
@@ -38,7 +34,7 @@ impl FilterList {
     ) -> TileDBResult<()> {
         let res = unsafe {
             ffi::tiledb_filter_list_add_filter(
-                ctx.as_mut_ptr(),
+                ctx.capi(),
                 self._wrapped,
                 filter.capi(),
             )
@@ -54,7 +50,7 @@ impl FilterList {
         let mut num: u32 = 0;
         let res = unsafe {
             ffi::tiledb_filter_list_get_nfilters(
-                ctx.as_mut_ptr(),
+                ctx.capi(),
                 self._wrapped,
                 &mut num,
             )
@@ -74,7 +70,7 @@ impl FilterList {
         let mut c_filter: *mut ffi::tiledb_filter_t = out_ptr!();
         let res = unsafe {
             ffi::tiledb_filter_list_get_filter_from_index(
-                ctx.as_mut_ptr(),
+                ctx.capi(),
                 self._wrapped,
                 index,
                 &mut c_filter,
@@ -96,7 +92,7 @@ impl FilterList {
     ) -> TileDBResult<()> {
         let res = unsafe {
             ffi::tiledb_filter_list_set_max_chunk_size(
-                ctx.as_mut_ptr(),
+                ctx.capi(),
                 self._wrapped,
                 size,
             )
@@ -112,7 +108,7 @@ impl FilterList {
         let mut size: u32 = 0;
         let res = unsafe {
             ffi::tiledb_filter_list_get_max_chunk_size(
-                ctx.as_mut_ptr(),
+                ctx.capi(),
                 self._wrapped,
                 &mut size,
             )

--- a/tiledb/api/src/query/mod.rs
+++ b/tiledb/api/src/query/mod.rs
@@ -48,7 +48,7 @@ impl<'ctx> Query<'ctx> {
     // if you can re-submit the query then Self makes sense.
     // if not then Array makes more sense
     pub fn submit(self) -> TileDBResult<Self> {
-        let c_context = self.context.as_mut_ptr();
+        let c_context = self.context.capi();
         let c_query = *self.raw;
         let c_ret = unsafe { ffi::tiledb_query_submit(c_context, c_query) };
         if c_ret == ffi::TILEDB_OK {
@@ -69,7 +69,7 @@ impl<'ctx> Builder<'ctx> {
         array: Array<'ctx>,
         query_type: QueryType,
     ) -> TileDBResult<Self> {
-        let c_context = context.as_mut_ptr();
+        let c_context = context.capi();
         let c_array = array.capi();
         let c_query_type = query_type.capi_enum();
         let mut c_query: *mut ffi::tiledb_query_t = out_ptr!();
@@ -97,7 +97,7 @@ impl<'ctx> Builder<'ctx> {
     }
 
     pub fn layout(self, layout: Layout) -> TileDBResult<Self> {
-        let c_context = self.query.context.as_mut_ptr();
+        let c_context = self.query.context.capi();
         let c_query = *self.query.raw;
         let c_layout = layout.capi_enum();
         let c_ret = unsafe {
@@ -119,7 +119,7 @@ impl<'ctx> Builder<'ctx> {
         name: &str,
         data: &mut [Conv],
     ) -> TileDBResult<Self> {
-        let c_context = self.query.context.as_mut_ptr();
+        let c_context = self.query.context.capi();
         let c_query = *self.query.raw;
         let c_name = cstring!(name);
 

--- a/tiledb/api/src/query/subarray.rs
+++ b/tiledb/api/src/query/subarray.rs
@@ -37,7 +37,7 @@ pub struct Builder<'ctx> {
 impl<'ctx> Builder<'ctx> {
     pub(crate) fn for_query(query: QueryBuilder<'ctx>) -> TileDBResult<Self> {
         let context = query.query.context;
-        let c_context = context.as_mut_ptr();
+        let c_context = context.capi();
         let c_array = query.query.array.capi();
         let mut c_subarray: *mut ffi::tiledb_subarray_t = out_ptr!();
 
@@ -62,7 +62,7 @@ impl<'ctx> Builder<'ctx> {
         idx: u32,
         range: &[Conv; 2],
     ) -> TileDBResult<QueryBuilder<'ctx>> {
-        let c_context = self.subarray.context.as_mut_ptr();
+        let c_context = self.subarray.context.capi();
         let c_subarray = *self.subarray.raw;
 
         let c_start = &range[0] as *const Conv as *const std::ffi::c_void;
@@ -86,7 +86,7 @@ impl<'ctx> Builder<'ctx> {
     }
 
     fn build(mut self) -> TileDBResult<QueryBuilder<'ctx>> {
-        let c_context = self.subarray.context.as_mut_ptr();
+        let c_context = self.subarray.context.capi();
         let c_query = *self.query.query.raw;
         let c_subarray = *self.subarray.raw;
 


### PR DESCRIPTION
First, all instances of as_mut_ptr() have been replaced with the now standard capi(). Both of these do exactly the same thing, this just unifies the naming convention.

Secondly, I've moved almost everything over to using the RawThing/Thing pattern where RawThing is just a deref-able enum containing the ffi pointer. This removes the need for all of the instances of as_mut_ptr_ptr and Default implementations that were sketchy at best.

Filters haven't been updated yet, but they will be as part of PR #19.