### PR TITLE
impl PartialEq for Attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,6 +1010,7 @@ name = "tiledb"
 version = "0.1.0"
 dependencies = [
  "proptest",
+ "serde",
  "serde_json",
  "tempdir",
  "tiledb-sys",

--- a/tiledb/api/Cargo.toml
+++ b/tiledb/api/Cargo.toml
@@ -8,6 +8,7 @@ name = "tiledb"
 path = "src/lib.rs"
 
 [dependencies]
+serde = "1.0.136"
 serde_json = "1.0.114"
 tiledb-sys = { workspace = true }
 

--- a/tiledb/api/src/convert.rs
+++ b/tiledb/api/src/convert.rs
@@ -29,3 +29,58 @@ impl<T: CAPISameRepr> CAPIConverter for T {
         *value
     }
 }
+
+/// Trait for comparisons based on value bits.
+/// This exists to work around float NaN which is not equal to itself,
+/// but we want it to be for generic operations with TileDB structures.
+/*
+ * Fun fact:
+ * `impl<T> BitsEq for T where T: Eq` is forbidden in concert with
+ * `impl BitsEq for f32` because the compiler says that `std` may
+ * `impl Eq for f32` someday. Seems unlikely.
+ */
+pub trait BitsEq: PartialEq {
+    fn bits_eq(&self, other: &Self) -> bool;
+}
+
+macro_rules! derive_reflexive_eq {
+    ($typename:ty) => {
+        impl BitsEq for $typename {
+            fn bits_eq(&self, other: &Self) -> bool {
+                <Self as PartialEq>::eq(self, other)
+            }
+        }
+    };
+}
+
+derive_reflexive_eq!(bool);
+derive_reflexive_eq!(u8);
+derive_reflexive_eq!(u16);
+derive_reflexive_eq!(u32);
+derive_reflexive_eq!(u64);
+derive_reflexive_eq!(i8);
+derive_reflexive_eq!(i16);
+derive_reflexive_eq!(i32);
+derive_reflexive_eq!(i64);
+
+impl BitsEq for f32 {
+    fn bits_eq(&self, other: &Self) -> bool {
+        self.to_bits() == other.to_bits()
+    }
+}
+
+impl BitsEq for f64 {
+    fn bits_eq(&self, other: &Self) -> bool {
+        self.to_bits() == other.to_bits()
+    }
+}
+
+impl<T1, T2> BitsEq for (T1, T2)
+where
+    T1: BitsEq,
+    T2: BitsEq,
+{
+    fn bits_eq(&self, other: &Self) -> bool {
+        self.0.bits_eq(&other.0) && self.1.bits_eq(&other.1)
+    }
+}

--- a/tiledb/api/src/datatype.rs
+++ b/tiledb/api/src/datatype.rs
@@ -3,12 +3,76 @@
 /// Apply a generic function `$func` to data which implements `$datatype` and then run
 /// the expression `$then` on the result.
 /// The `$then` expression may use the function name as an identifier for the function result.
+///
+/// Variants:
+/// - fn_typed!(my_function, my_datatype, arg1, ..., argN => then_expr)
+///   Calls the function on the supplied arguments with a generic type parameter, and afterwards
+///   runs `then_expr` on the result. The result is bound to an identifier which shadows the
+///   function name.
+/// - fn_typed!(obj.my_function, my_datatype, arg1, ..., argN => then_expr)
+///   Calls the method on the supplied arguments with a generic type parameter, and afterwards
+///   runs `then_expr` on the result. The result is bound to an identifier which shadows the
+///   method name.
+/// - fn_typed!(my_datatype, TypeName, then_expr)
+///   Binds the type which implements `my_datatype` to `TypeName` for use in `then_expr`.
 
 // note to developers: this is mimicking the C++ code
 //      template <class Fn, class... Args>
 //      inline auto apply_with_type(Fn&& f, Datatype type, Args&&... args)
 //
+// Also we probably only need the third variation since that can easily implement the other ones
+//
 macro_rules! fn_typed {
+    ($datatype:expr, $typename:ident, $then:expr) => {{
+        type Datatype = $crate::Datatype;
+        match $datatype {
+            Datatype::Int8 => { type $typename = i8; $then },
+            Datatype::Int16 => { type $typename = i16; $then },
+            Datatype::Int32 => { type $typename = i32; $then },
+            Datatype::Int64 => { type $typename = i64; $then },
+            Datatype::UInt8 => { type $typename = u8; $then },
+            Datatype::UInt16 => { type $typename = u16; $then },
+            Datatype::UInt32 => { type $typename = u32; $then },
+            Datatype::UInt64 => { type $typename = u64; $then },
+            Datatype::Float32 => { type $typename = f32; $then },
+            Datatype::Float64 => { type $typename = f64; $then },
+            Datatype::Char => unimplemented!(),
+            Datatype::StringAscii => unimplemented!(),
+            Datatype::StringUtf8 => unimplemented!(),
+            Datatype::StringUtf16 => unimplemented!(),
+            Datatype::StringUtf32 => unimplemented!(),
+            Datatype::StringUcs2 => unimplemented!(),
+            Datatype::StringUcs4 => unimplemented!(),
+            Datatype::Any => unimplemented!(),
+            Datatype::DateTimeYear => unimplemented!(),
+            Datatype::DateTimeMonth => unimplemented!(),
+            Datatype::DateTimeWeek => unimplemented!(),
+            Datatype::DateTimeDay => unimplemented!(),
+            Datatype::DateTimeHour => unimplemented!(),
+            Datatype::DateTimeMinute => unimplemented!(),
+            Datatype::DateTimeSecond => unimplemented!(),
+            Datatype::DateTimeMillisecond => unimplemented!(),
+            Datatype::DateTimeMicrosecond => unimplemented!(),
+            Datatype::DateTimeNanosecond => unimplemented!(),
+            Datatype::DateTimePicosecond => unimplemented!(),
+            Datatype::DateTimeFemtosecond => unimplemented!(),
+            Datatype::DateTimeAttosecond => unimplemented!(),
+            Datatype::TimeHour => unimplemented!(),
+            Datatype::TimeMinute => unimplemented!(),
+            Datatype::TimeSecond => unimplemented!(),
+            Datatype::TimeMillisecond => unimplemented!(),
+            Datatype::TimeMicrosecond => unimplemented!(),
+            Datatype::TimeNanosecond => unimplemented!(),
+            Datatype::TimePicosecond => unimplemented!(),
+            Datatype::TimeFemtosecond => unimplemented!(),
+            Datatype::TimeAttosecond => unimplemented!(),
+            Datatype::Blob => unimplemented!(),
+            Datatype::Boolean => unimplemented!(),
+            Datatype::GeometryWkb => unimplemented!(),
+            Datatype::GeometryWkt => unimplemented!(),
+        }
+    }};
+
     ($func:ident, $datatype:expr$(, $arg:expr)* => $then:expr) => {{
         type Datatype = $crate::Datatype;
         match $datatype {

--- a/tiledb/api/src/error.rs
+++ b/tiledb/api/src/error.rs
@@ -4,6 +4,8 @@ use std::convert::Into;
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use std::str::FromStr;
 
+use serde::{Serialize, Serializer};
+
 pub(crate) enum ErrorData {
     Native(*mut ffi::tiledb_error_t),
     Custom(String),
@@ -95,6 +97,15 @@ impl Drop for Error {
         if let ErrorData::Native(ref mut cptr) = self.data {
             unsafe { ffi::tiledb_error_free(cptr) }
         }
+    }
+}
+
+impl Serialize for Error {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        format!("<{}>", self.get_message()).serialize(serializer)
     }
 }
 

--- a/tiledb/api/src/lib.rs
+++ b/tiledb/api/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate serde;
 extern crate serde_json;
 extern crate tiledb_sys as ffi;
 

--- a/tiledb/test/src/attribute.rs
+++ b/tiledb/test/src/attribute.rs
@@ -12,11 +12,13 @@ pub fn arbitrary_name() -> impl Strategy<Value = String> {
 }
 
 pub fn arbitrary(context: &Context) -> impl Strategy<Value = Attribute> {
-    (arbitrary_name(), crate::datatype::arbitrary()).prop_map(|(name, dt)| {
-        AttributeBuilder::new(context, name.as_ref(), dt)
-            .expect("Error building attribute")
-            .build()
-    })
+    (arbitrary_name(), crate::datatype::arbitrary_implemented()).prop_map(
+        |(name, dt)| {
+            AttributeBuilder::new(context, name.as_ref(), dt)
+                .expect("Error building attribute")
+                .build()
+        },
+    )
 }
 
 #[cfg(test)]

--- a/tiledb/test/src/attribute.rs
+++ b/tiledb/test/src/attribute.rs
@@ -32,4 +32,13 @@ mod tests {
 
         proptest!(|(_ in arbitrary(&ctx))| {});
     }
+
+    #[test]
+    fn attribute_eq_reflexivity() {
+        let ctx = Context::new().expect("Error creating context");
+
+        proptest!(|(attr in arbitrary(&ctx))| {
+            assert_eq!(attr, attr);
+        });
+    }
 }


### PR DESCRIPTION
To test Arrow schema to/from TileDB schema conversion, we will want to test invertability.  That will require some means of checking that the Attribute we get out is the same as the Attribute we put in.  `PartialEq` is a natural choice for this, so this pull request does most of the work to implement it for Attribute.

What's missing is the filter comparison, and that will probably be done as a follow-up after #19 is merged.