### PR TITLE
Scaffolding to support generating arbitrary filter pipelines

### DIFF
--- a/tiledb/api/Cargo.toml
+++ b/tiledb/api/Cargo.toml
@@ -8,7 +8,7 @@ name = "tiledb"
 path = "src/lib.rs"
 
 [dependencies]
-serde = "1.0.136"
+serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.114"
 tiledb-sys = { workspace = true }
 

--- a/tiledb/api/src/array/attribute.rs
+++ b/tiledb/api/src/array/attribute.rs
@@ -448,7 +448,7 @@ impl<'ctx> Builder<'ctx> {
         }
     }
 
-    pub fn filter_list(self, filter_list: FilterList) -> TileDBResult<Self> {
+    pub fn filter_list(self, filter_list: &FilterList) -> TileDBResult<Self> {
         let c_context = self.attr.context.capi();
         let res = unsafe {
             ffi::tiledb_attribute_set_filter_list(
@@ -550,7 +550,7 @@ mod test {
 
             let attr = Builder::new(&ctx, "foo", Datatype::UInt8)
                 .expect("Error creating attribute instance.")
-                .filter_list(flist2)
+                .filter_list(&flist2)
                 .expect("Error setting filter list.")
                 .build();
 

--- a/tiledb/api/src/array/attribute.rs
+++ b/tiledb/api/src/array/attribute.rs
@@ -448,7 +448,7 @@ impl<'ctx> Builder<'ctx> {
         }
     }
 
-    pub fn filter_list(self, filter_list: &FilterList) -> TileDBResult<Self> {
+    pub fn filter_list(self, filter_list: FilterList) -> TileDBResult<Self> {
         let c_context = self.attr.context.capi();
         let res = unsafe {
             ffi::tiledb_attribute_set_filter_list(
@@ -550,7 +550,7 @@ mod test {
 
             let attr = Builder::new(&ctx, "foo", Datatype::UInt8)
                 .expect("Error creating attribute instance.")
-                .filter_list(&flist2)
+                .filter_list(flist2)
                 .expect("Error setting filter list.")
                 .build();
 

--- a/tiledb/api/src/datatype.rs
+++ b/tiledb/api/src/datatype.rs
@@ -295,6 +295,12 @@ impl Datatype {
         )
     }
 
+    /// Returns whether this type is a real number (i.e. floating point)
+    // Keep in sync with sm/enums/datatype.h::datatype_is_real
+    pub fn is_real_type(&self) -> bool {
+        matches!(*self, Datatype::Float32 | Datatype::Float64)
+    }
+
     /// Returns whether this type is a variable-length string type
     // Keep in sync with sm/enums/datatype.h::datatype_is_string
     pub fn is_string_type(&self) -> bool {
@@ -344,6 +350,15 @@ impl Datatype {
                 | Datatype::TimePicosecond
                 | Datatype::TimeFemtosecond
                 | Datatype::TimeAttosecond
+        )
+    }
+
+    /// Returns whether this type is a byte
+    // Keep in sync with sm/enums/datatype.h:datatype_is_byte
+    pub fn is_byte_type(&self) -> bool {
+        matches!(
+            *self,
+            Datatype::Boolean | Datatype::GeometryWkb | Datatype::GeometryWkt
         )
     }
 

--- a/tiledb/api/src/datatype.rs
+++ b/tiledb/api/src/datatype.rs
@@ -1,4 +1,470 @@
-#[macro_export]
+use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
+
+use serde::{Deserialize, Serialize};
+
+use crate::Result as TileDBResult;
+
+#[derive(Clone, Copy, Deserialize, Eq, PartialEq, Serialize)]
+#[repr(u64)]
+pub enum Datatype {
+    #[doc = " 32-bit signed integer"]
+    Int32,
+    #[doc = " 64-bit signed integer"]
+    Int64,
+    #[doc = " 32-bit floating point value"]
+    Float32,
+    #[doc = " 64-bit floating point value"]
+    Float64,
+    #[doc = " Character"]
+    Char,
+    #[doc = " 8-bit signed integer"]
+    Int8,
+    #[doc = " 8-bit unsigned integer"]
+    UInt8,
+    #[doc = " 16-bit signed integer"]
+    Int16,
+    #[doc = " 16-bit unsigned integer"]
+    UInt16,
+    #[doc = " 32-bit unsigned integer"]
+    UInt32,
+    #[doc = " 64-bit unsigned integer"]
+    UInt64,
+    #[doc = " ASCII string"]
+    StringAscii,
+    #[doc = " UTF-8 string"]
+    StringUtf8,
+    #[doc = " UTF-16 string"]
+    StringUtf16,
+    #[doc = " UTF-32 string"]
+    StringUtf32,
+    #[doc = " UCS2 string"]
+    StringUcs2,
+    #[doc = " UCS4 string"]
+    StringUcs4,
+    #[doc = " This can be any datatype. Must store (type tag, value) pairs."]
+    Any,
+    #[doc = " DateTime with year resolution"]
+    DateTimeYear,
+    #[doc = " DateTime with month resolution"]
+    DateTimeMonth,
+    #[doc = " DateTime with week resolution"]
+    DateTimeWeek,
+    #[doc = " DateTime with day resolution"]
+    DateTimeDay,
+    #[doc = " DateTime with hour resolution"]
+    DateTimeHour,
+    #[doc = " DateTime with minute resolution"]
+    DateTimeMinute,
+    #[doc = " DateTime with second resolution"]
+    DateTimeSecond,
+    #[doc = " DateTime with millisecond resolution"]
+    DateTimeMillisecond,
+    #[doc = " DateTime with microsecond resolution"]
+    DateTimeMicrosecond,
+    #[doc = " DateTime with nanosecond resolution"]
+    DateTimeNanosecond,
+    #[doc = " DateTime with picosecond resolution"]
+    DateTimePicosecond,
+    #[doc = " DateTime with femtosecond resolution"]
+    DateTimeFemtosecond,
+    #[doc = " DateTime with attosecond resolution"]
+    DateTimeAttosecond,
+    #[doc = " Time with hour resolution"]
+    TimeHour,
+    #[doc = " Time with minute resolution"]
+    TimeMinute,
+    #[doc = " Time with second resolution"]
+    TimeSecond,
+    #[doc = " Time with millisecond resolution"]
+    TimeMillisecond,
+    #[doc = " Time with microsecond resolution"]
+    TimeMicrosecond,
+    #[doc = " Time with nanosecond resolution"]
+    TimeNanosecond,
+    #[doc = " Time with picosecond resolution"]
+    TimePicosecond,
+    #[doc = " Time with femtosecond resolution"]
+    TimeFemtosecond,
+    #[doc = " Time with attosecond resolution"]
+    TimeAttosecond,
+    #[doc = " Byte sequence"]
+    Blob,
+    #[doc = " Boolean"]
+    Boolean,
+    #[doc = " Geometry data in well-known binary (WKB) format, stored as std::byte"]
+    GeometryWkb,
+    #[doc = " Geometry data in well-known text (WKT) format, stored as std::byte"]
+    GeometryWkt,
+}
+
+impl Datatype {
+    pub(crate) fn capi_enum(&self) -> ffi::tiledb_datatype_t {
+        match *self {
+            Datatype::Int8 => ffi::tiledb_datatype_t_TILEDB_INT8,
+            Datatype::Int16 => ffi::tiledb_datatype_t_TILEDB_INT16,
+            Datatype::Int32 => ffi::tiledb_datatype_t_TILEDB_INT32,
+            Datatype::Int64 => ffi::tiledb_datatype_t_TILEDB_INT64,
+            Datatype::Float32 => ffi::tiledb_datatype_t_TILEDB_FLOAT32,
+            Datatype::Float64 => ffi::tiledb_datatype_t_TILEDB_FLOAT64,
+            Datatype::Char => ffi::tiledb_datatype_t_TILEDB_CHAR,
+            Datatype::UInt8 => ffi::tiledb_datatype_t_TILEDB_UINT8,
+            Datatype::UInt16 => ffi::tiledb_datatype_t_TILEDB_UINT16,
+            Datatype::UInt32 => ffi::tiledb_datatype_t_TILEDB_UINT32,
+            Datatype::UInt64 => ffi::tiledb_datatype_t_TILEDB_UINT64,
+            Datatype::StringAscii => ffi::tiledb_datatype_t_TILEDB_STRING_ASCII,
+            Datatype::StringUtf8 => ffi::tiledb_datatype_t_TILEDB_STRING_UTF8,
+            Datatype::StringUtf16 => ffi::tiledb_datatype_t_TILEDB_STRING_UTF16,
+            Datatype::StringUtf32 => ffi::tiledb_datatype_t_TILEDB_STRING_UTF32,
+            Datatype::StringUcs2 => ffi::tiledb_datatype_t_TILEDB_STRING_UCS2,
+            Datatype::StringUcs4 => ffi::tiledb_datatype_t_TILEDB_STRING_UCS4,
+            Datatype::Any => ffi::tiledb_datatype_t_TILEDB_ANY,
+            Datatype::DateTimeYear => {
+                ffi::tiledb_datatype_t_TILEDB_DATETIME_YEAR
+            }
+            Datatype::DateTimeMonth => {
+                ffi::tiledb_datatype_t_TILEDB_DATETIME_MONTH
+            }
+            Datatype::DateTimeWeek => {
+                ffi::tiledb_datatype_t_TILEDB_DATETIME_WEEK
+            }
+            Datatype::DateTimeDay => ffi::tiledb_datatype_t_TILEDB_DATETIME_DAY,
+            Datatype::DateTimeHour => ffi::tiledb_datatype_t_TILEDB_DATETIME_HR,
+            Datatype::DateTimeMinute => {
+                ffi::tiledb_datatype_t_TILEDB_DATETIME_MIN
+            }
+            Datatype::DateTimeSecond => {
+                ffi::tiledb_datatype_t_TILEDB_DATETIME_SEC
+            }
+            Datatype::DateTimeMillisecond => {
+                ffi::tiledb_datatype_t_TILEDB_DATETIME_MS
+            }
+            Datatype::DateTimeMicrosecond => {
+                ffi::tiledb_datatype_t_TILEDB_DATETIME_US
+            }
+            Datatype::DateTimeNanosecond => {
+                ffi::tiledb_datatype_t_TILEDB_DATETIME_NS
+            }
+            Datatype::DateTimePicosecond => {
+                ffi::tiledb_datatype_t_TILEDB_DATETIME_PS
+            }
+            Datatype::DateTimeFemtosecond => {
+                ffi::tiledb_datatype_t_TILEDB_DATETIME_FS
+            }
+            Datatype::DateTimeAttosecond => {
+                ffi::tiledb_datatype_t_TILEDB_DATETIME_AS
+            }
+            Datatype::TimeHour => ffi::tiledb_datatype_t_TILEDB_TIME_HR,
+            Datatype::TimeMinute => ffi::tiledb_datatype_t_TILEDB_TIME_MIN,
+            Datatype::TimeSecond => ffi::tiledb_datatype_t_TILEDB_TIME_SEC,
+            Datatype::TimeMillisecond => ffi::tiledb_datatype_t_TILEDB_TIME_MS,
+            Datatype::TimeMicrosecond => ffi::tiledb_datatype_t_TILEDB_TIME_US,
+            Datatype::TimeNanosecond => ffi::tiledb_datatype_t_TILEDB_TIME_NS,
+            Datatype::TimePicosecond => ffi::tiledb_datatype_t_TILEDB_TIME_PS,
+            Datatype::TimeFemtosecond => ffi::tiledb_datatype_t_TILEDB_TIME_FS,
+            Datatype::TimeAttosecond => ffi::tiledb_datatype_t_TILEDB_TIME_AS,
+            Datatype::Blob => ffi::tiledb_datatype_t_TILEDB_BLOB,
+            Datatype::Boolean => ffi::tiledb_datatype_t_TILEDB_BOOL,
+            Datatype::GeometryWkb => ffi::tiledb_datatype_t_TILEDB_GEOM_WKB,
+            Datatype::GeometryWkt => ffi::tiledb_datatype_t_TILEDB_GEOM_WKT,
+        }
+    }
+
+    pub fn size(&self) -> u64 {
+        let copy = *self;
+        unsafe { ffi::tiledb_datatype_size(copy as ffi::tiledb_datatype_t) }
+    }
+
+    pub fn to_string(&self) -> Option<String> {
+        let copy = *self;
+        let c_dtype = copy as ffi::tiledb_datatype_t;
+        let mut c_str = std::ptr::null::<std::os::raw::c_char>();
+        let res = unsafe { ffi::tiledb_datatype_to_str(c_dtype, &mut c_str) };
+        if res == ffi::TILEDB_OK {
+            let c_msg = unsafe { std::ffi::CStr::from_ptr(c_str) };
+            Some(String::from(c_msg.to_string_lossy()))
+        } else {
+            None
+        }
+    }
+
+    pub fn from_string(dtype: &str) -> Option<Self> {
+        let c_dtype =
+            std::ffi::CString::new(dtype).expect("Error creating CString");
+        let mut c_ret: ffi::tiledb_datatype_t = out_ptr!();
+        let res = unsafe {
+            ffi::tiledb_datatype_from_str(
+                c_dtype.as_c_str().as_ptr(),
+                &mut c_ret,
+            )
+        };
+
+        if res == ffi::TILEDB_OK {
+            match Datatype::try_from(c_ret) {
+                Ok(dt) => Some(dt),
+                Err(_) => None,
+            }
+        } else {
+            None
+        }
+    }
+
+    pub fn is_compatible_type<T: 'static>(&self) -> bool {
+        use std::any::TypeId;
+
+        let tid = TypeId::of::<T>();
+        if tid == TypeId::of::<f32>() {
+            matches!(*self, Datatype::Float32)
+        } else if tid == TypeId::of::<f64>() {
+            matches!(*self, Datatype::Float64)
+        } else if tid == TypeId::of::<i8>() {
+            matches!(*self, Datatype::Char | Datatype::Int8)
+        } else if tid == TypeId::of::<u8>() {
+            matches!(
+                *self,
+                Datatype::Any
+                    | Datatype::Blob
+                    | Datatype::Boolean
+                    | Datatype::GeometryWkb
+                    | Datatype::GeometryWkt
+                    | Datatype::StringAscii
+                    | Datatype::StringUtf8
+                    | Datatype::UInt8
+            )
+        } else if tid == TypeId::of::<i16>() {
+            matches!(*self, Datatype::Int16)
+        } else if tid == TypeId::of::<u16>() {
+            matches!(
+                *self,
+                Datatype::StringUtf16 | Datatype::StringUcs2 | Datatype::UInt16
+            )
+        } else if tid == TypeId::of::<i32>() {
+            matches!(*self, Datatype::Int32)
+        } else if tid == TypeId::of::<u32>() {
+            matches!(
+                *self,
+                Datatype::StringUtf32 | Datatype::StringUcs4 | Datatype::UInt32
+            )
+        } else if tid == TypeId::of::<i64>() {
+            matches!(
+                *self,
+                Datatype::Int64
+                    | Datatype::DateTimeYear
+                    | Datatype::DateTimeMonth
+                    | Datatype::DateTimeWeek
+                    | Datatype::DateTimeDay
+                    | Datatype::DateTimeHour
+                    | Datatype::DateTimeMinute
+                    | Datatype::DateTimeSecond
+                    | Datatype::DateTimeMillisecond
+                    | Datatype::DateTimeMicrosecond
+                    | Datatype::DateTimeNanosecond
+                    | Datatype::DateTimePicosecond
+                    | Datatype::DateTimeFemtosecond
+                    | Datatype::DateTimeAttosecond
+                    | Datatype::TimeHour
+                    | Datatype::TimeMinute
+                    | Datatype::TimeSecond
+                    | Datatype::TimeMillisecond
+                    | Datatype::TimeMicrosecond
+                    | Datatype::TimeNanosecond
+                    | Datatype::TimePicosecond
+                    | Datatype::TimeFemtosecond
+                    | Datatype::TimeAttosecond
+            )
+        } else if tid == TypeId::of::<u64>() {
+            matches!(*self, Datatype::UInt64)
+        } else {
+            false
+        }
+    }
+
+    /// Returns whether this type is an integral type (i.e. integer)
+    // Keep in sync with sm/enums/datatype.h::datatype_is_integer
+    pub fn is_integral_type(&self) -> bool {
+        matches!(
+            *self,
+            Datatype::Boolean
+                | Datatype::Int8
+                | Datatype::Int16
+                | Datatype::Int32
+                | Datatype::Int64
+                | Datatype::UInt8
+                | Datatype::UInt16
+                | Datatype::UInt32
+                | Datatype::UInt64
+        )
+    }
+
+    /// Returns whether this type is a variable-length string type
+    // Keep in sync with sm/enums/datatype.h::datatype_is_string
+    pub fn is_string_type(&self) -> bool {
+        matches!(
+            *self,
+            Datatype::StringAscii
+                | Datatype::StringUtf8
+                | Datatype::StringUtf16
+                | Datatype::StringUtf32
+                | Datatype::StringUcs2
+                | Datatype::StringUcs4
+        )
+    }
+
+    /// Returns whether this type is a DateTime type of any resolution
+    // Keep in sync with sm/enums/datatype.h::datatype_is_datetime
+    pub fn is_datetime_type(&self) -> bool {
+        matches!(
+            *self,
+            Datatype::DateTimeYear
+                | Datatype::DateTimeMonth
+                | Datatype::DateTimeWeek
+                | Datatype::DateTimeDay
+                | Datatype::DateTimeHour
+                | Datatype::DateTimeMinute
+                | Datatype::DateTimeSecond
+                | Datatype::DateTimeMillisecond
+                | Datatype::DateTimeMicrosecond
+                | Datatype::DateTimeNanosecond
+                | Datatype::DateTimePicosecond
+                | Datatype::DateTimeFemtosecond
+                | Datatype::DateTimeAttosecond
+        )
+    }
+
+    /// Returns whether this type is a Time type of any resolution
+    // Keep in sync with sm/enums/datatype.h::datatype_is_time
+    pub fn is_time_type(&self) -> bool {
+        matches!(
+            *self,
+            Datatype::TimeHour
+                | Datatype::TimeMinute
+                | Datatype::TimeSecond
+                | Datatype::TimeMillisecond
+                | Datatype::TimeMicrosecond
+                | Datatype::TimeNanosecond
+                | Datatype::TimePicosecond
+                | Datatype::TimeFemtosecond
+                | Datatype::TimeAttosecond
+        )
+    }
+
+    /// Returns whether this type can be used as a dimension type of a sparse array
+    pub fn is_allowed_dimension_type_sparse(&self) -> bool {
+        self.is_integral_type()
+            || self.is_datetime_type()
+            || self.is_time_type()
+            || matches!(
+                *self,
+                Datatype::Float32 | Datatype::Float64 | Datatype::StringAscii
+            )
+    }
+
+    /// Returns whether this type can be used as a dimension type of a dense array
+    pub fn is_allowed_dimension_type_dense(&self) -> bool {
+        self.is_integral_type()
+            || self.is_datetime_type()
+            || self.is_time_type()
+    }
+}
+
+impl Debug for Datatype {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        <Self as Display>::fmt(self, f)
+    }
+}
+
+impl Display for Datatype {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(
+            f,
+            "{}",
+            match self.to_string() {
+                Some(s) => s,
+                None => String::from("<UNKNOWN DATA TYPE>"),
+            }
+        )
+    }
+}
+
+impl TryFrom<ffi::tiledb_datatype_t> for Datatype {
+    type Error = crate::error::Error;
+
+    fn try_from(value: ffi::tiledb_datatype_t) -> TileDBResult<Self> {
+        Ok(match value {
+            ffi::tiledb_datatype_t_TILEDB_INT8 => Datatype::Int8,
+            ffi::tiledb_datatype_t_TILEDB_INT16 => Datatype::Int16,
+            ffi::tiledb_datatype_t_TILEDB_INT32 => Datatype::Int32,
+            ffi::tiledb_datatype_t_TILEDB_INT64 => Datatype::Int64,
+            ffi::tiledb_datatype_t_TILEDB_FLOAT32 => Datatype::Float32,
+            ffi::tiledb_datatype_t_TILEDB_FLOAT64 => Datatype::Float64,
+            ffi::tiledb_datatype_t_TILEDB_CHAR => Datatype::Char,
+            ffi::tiledb_datatype_t_TILEDB_UINT8 => Datatype::UInt8,
+            ffi::tiledb_datatype_t_TILEDB_UINT16 => Datatype::UInt16,
+            ffi::tiledb_datatype_t_TILEDB_UINT32 => Datatype::UInt32,
+            ffi::tiledb_datatype_t_TILEDB_UINT64 => Datatype::UInt64,
+            ffi::tiledb_datatype_t_TILEDB_STRING_ASCII => Datatype::StringAscii,
+            ffi::tiledb_datatype_t_TILEDB_STRING_UTF8 => Datatype::StringUtf8,
+            ffi::tiledb_datatype_t_TILEDB_STRING_UTF16 => Datatype::StringUtf16,
+            ffi::tiledb_datatype_t_TILEDB_STRING_UTF32 => Datatype::StringUtf32,
+            ffi::tiledb_datatype_t_TILEDB_STRING_UCS2 => Datatype::StringUcs2,
+            ffi::tiledb_datatype_t_TILEDB_STRING_UCS4 => Datatype::StringUcs4,
+            ffi::tiledb_datatype_t_TILEDB_ANY => Datatype::Any,
+            ffi::tiledb_datatype_t_TILEDB_DATETIME_YEAR => {
+                Datatype::DateTimeYear
+            }
+            ffi::tiledb_datatype_t_TILEDB_DATETIME_MONTH => {
+                Datatype::DateTimeMonth
+            }
+            ffi::tiledb_datatype_t_TILEDB_DATETIME_WEEK => {
+                Datatype::DateTimeWeek
+            }
+            ffi::tiledb_datatype_t_TILEDB_DATETIME_DAY => Datatype::DateTimeDay,
+            ffi::tiledb_datatype_t_TILEDB_DATETIME_HR => Datatype::DateTimeHour,
+            ffi::tiledb_datatype_t_TILEDB_DATETIME_MIN => {
+                Datatype::DateTimeMinute
+            }
+            ffi::tiledb_datatype_t_TILEDB_DATETIME_SEC => {
+                Datatype::DateTimeSecond
+            }
+            ffi::tiledb_datatype_t_TILEDB_DATETIME_MS => {
+                Datatype::DateTimeMillisecond
+            }
+            ffi::tiledb_datatype_t_TILEDB_DATETIME_US => {
+                Datatype::DateTimeMicrosecond
+            }
+            ffi::tiledb_datatype_t_TILEDB_DATETIME_NS => {
+                Datatype::DateTimeNanosecond
+            }
+            ffi::tiledb_datatype_t_TILEDB_DATETIME_PS => {
+                Datatype::DateTimePicosecond
+            }
+            ffi::tiledb_datatype_t_TILEDB_DATETIME_FS => {
+                Datatype::DateTimeFemtosecond
+            }
+            ffi::tiledb_datatype_t_TILEDB_DATETIME_AS => {
+                Datatype::DateTimeAttosecond
+            }
+            ffi::tiledb_datatype_t_TILEDB_TIME_HR => Datatype::TimeHour,
+            ffi::tiledb_datatype_t_TILEDB_TIME_MIN => Datatype::TimeMinute,
+            ffi::tiledb_datatype_t_TILEDB_TIME_SEC => Datatype::TimeSecond,
+            ffi::tiledb_datatype_t_TILEDB_TIME_MS => Datatype::TimeMillisecond,
+            ffi::tiledb_datatype_t_TILEDB_TIME_US => Datatype::TimeMicrosecond,
+            ffi::tiledb_datatype_t_TILEDB_TIME_NS => Datatype::TimeNanosecond,
+            ffi::tiledb_datatype_t_TILEDB_TIME_PS => Datatype::TimePicosecond,
+            ffi::tiledb_datatype_t_TILEDB_TIME_FS => Datatype::TimeFemtosecond,
+            ffi::tiledb_datatype_t_TILEDB_TIME_AS => Datatype::TimeAttosecond,
+            ffi::tiledb_datatype_t_TILEDB_BLOB => Datatype::Blob,
+            ffi::tiledb_datatype_t_TILEDB_BOOL => Datatype::Boolean,
+            ffi::tiledb_datatype_t_TILEDB_GEOM_WKB => Datatype::GeometryWkb,
+            ffi::tiledb_datatype_t_TILEDB_GEOM_WKT => Datatype::GeometryWkt,
+            _ => {
+                return Err(crate::error::Error::from(format!(
+                    "Invalid datatype: {}",
+                    value
+                )))
+            }
+        })
+    }
+}
 
 /// Apply a generic function `$func` to data which implements `$datatype` and then run
 /// the expression `$then` on the result.
@@ -22,6 +488,7 @@
 //
 // Also we probably only need the third variation since that can easily implement the other ones
 //
+#[macro_export]
 macro_rules! fn_typed {
     ($datatype:expr, $typename:ident, $then:expr) => {{
         type Datatype = $crate::Datatype;
@@ -231,4 +698,73 @@ macro_rules! fn_typed {
             Datatype::GeometryWkt => unimplemented!(),
         }
     }};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn datatype_test() {
+        for i in 0..256 {
+            println!("I: {}", i);
+            if i <= 43 {
+                let dt = Datatype::try_from(i as u32)
+                    .expect("Error converting value to Datatype");
+                assert_ne!(
+                    format!("{}", dt),
+                    "<UNKNOWN DATA TYPE>".to_string()
+                );
+                assert!(check_valid(&dt));
+            } else {
+                assert!(Datatype::try_from(i as u32).is_err());
+            }
+        }
+    }
+
+    fn check_valid(dt: &Datatype) -> bool {
+        let mut count = 0;
+
+        if dt.is_compatible_type::<f32>() {
+            count += 1;
+        }
+
+        if dt.is_compatible_type::<f64>() {
+            count += 1;
+        }
+
+        if dt.is_compatible_type::<i8>() {
+            count += 1;
+        }
+
+        if dt.is_compatible_type::<u8>() {
+            count += 1;
+        }
+
+        if dt.is_compatible_type::<i16>() {
+            count += 1;
+        }
+
+        if dt.is_compatible_type::<u16>() {
+            count += 1;
+        }
+
+        if dt.is_compatible_type::<i32>() {
+            count += 1;
+        }
+
+        if dt.is_compatible_type::<u32>() {
+            count += 1;
+        }
+
+        if dt.is_compatible_type::<i64>() {
+            count += 1;
+        }
+
+        if dt.is_compatible_type::<u64>() {
+            count += 1;
+        }
+
+        count == 1
+    }
 }

--- a/tiledb/api/src/filter.rs
+++ b/tiledb/api/src/filter.rs
@@ -196,12 +196,20 @@ impl FilterData {
             }) => match kind {
                 CompressionType::Delta | CompressionType::DoubleDelta => {
                     // these filters do not accept floating point
-                    if input.is_real_type() {
+                    let check_type =
+                        if let Some(Datatype::Any) = reinterpret_datatype {
+                            *input
+                        } else if let Some(reinterpret_datatype) =
+                            reinterpret_datatype
+                        {
+                            reinterpret_datatype
+                        } else {
+                            return None;
+                        };
+                    if check_type.is_real_type() {
                         None
-                    } else if reinterpret_datatype == Some(Datatype::Any) {
-                        Some(*input)
                     } else {
-                        reinterpret_datatype
+                        Some(check_type)
                     }
                 }
                 _ => Some(*input),

--- a/tiledb/api/src/filter.rs
+++ b/tiledb/api/src/filter.rs
@@ -588,20 +588,6 @@ impl<'c1, 'c2> PartialEq<Filter<'c2>> for Filter<'c1> {
             (Ok(mine), Ok(theirs)) => mine == theirs,
             _ => false,
         }
-
-        /*
-        let types_match = match (self.get_type(), other.get_type()) {
-            (Ok(mine), Ok(theirs)) => mine == theirs
-        };
-        if !types_match {
-            return false;
-        }
-
-        use ffi::FilterType;
-        match self.get_type().unwrap() {
-            FilterType::None =>
-        }
-        */
     }
 }
 

--- a/tiledb/api/src/filter.rs
+++ b/tiledb/api/src/filter.rs
@@ -81,11 +81,12 @@ impl CompressionData {
     }
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub enum ScaleFloatByteWidth {
     I8,
     I16,
     I32,
+    #[default] // keep in sync with tiledb/sm/filter/float_scaling_filter.h
     I64,
 }
 
@@ -106,13 +107,6 @@ impl ScaleFloatByteWidth {
             Self::I32 => Datatype::Int32,
             Self::I64 => Datatype::Int64,
         }
-    }
-}
-
-impl Default for ScaleFloatByteWidth {
-    fn default() -> Self {
-        // keep in sync with tiledb/sm/filter/float_scaling_filter.h
-        ScaleFloatByteWidth::I64
     }
 }
 

--- a/tiledb/api/src/filter_list.rs
+++ b/tiledb/api/src/filter_list.rs
@@ -68,6 +68,12 @@ impl<'ctx> FilterList<'ctx> {
         }
     }
 
+    pub fn to_vec(&self) -> TileDBResult<Vec<Filter<'ctx>>> {
+        (0..self.get_num_filters()?)
+            .map(|f| self.get_filter(f))
+            .collect()
+    }
+
     pub fn get_max_chunk_size(&self, ctx: &Context) -> TileDBResult<u32> {
         let mut size: u32 = 0;
         let res = unsafe {

--- a/tiledb/api/src/lib.rs
+++ b/tiledb/api/src/lib.rs
@@ -47,6 +47,6 @@ pub fn version() -> (i32, i32, i32) {
 }
 
 pub use array::Array;
-pub use ffi::Datatype;
+pub use datatype::Datatype;
 pub use query::{Builder as QueryBuilder, Query, QueryType};
 pub type Result<T> = std::result::Result<T, error::Error>;

--- a/tiledb/api/tests/enum_conversion_tests.rs
+++ b/tiledb/api/tests/enum_conversion_tests.rs
@@ -1,4 +1,4 @@
-use tiledb_sys::Datatype;
+use tiledb::Datatype;
 use tiledb_sys::Filesystem;
 use tiledb_sys::FilterOption;
 use tiledb_sys::FilterType;
@@ -6,8 +6,8 @@ use tiledb_sys::FilterType;
 #[test]
 fn datatype_roundtrips() {
     for i in 0..256 {
-        let maybe_dt = Datatype::from_u32(i);
-        if maybe_dt.is_some() {
+        let maybe_dt = Datatype::try_from(i);
+        if maybe_dt.is_ok() {
             let dt = maybe_dt.unwrap();
             let dt_str = dt.to_string().expect("Error creating string.");
             let str_dt = Datatype::from_string(&dt_str)

--- a/tiledb/arrow/src/attribute.rs
+++ b/tiledb/arrow/src/attribute.rs
@@ -45,6 +45,7 @@ mod tests {
         let c: TileDBContext = TileDBContext::new()?;
 
         proptest!(|(attr in tiledb_test::attribute::arbitrary(&c))| {
+            let attr = attr.expect("Error constructing arbitrary tiledb attribute");
             if let Some(arrow_field) = arrow_field(&attr).expect("Error reading tiledb attribute") {
                 assert_eq!(attr.name()?, *arrow_field.name());
                 assert!(crate::datatype::is_same_physical_type(&attr.datatype()?, arrow_field.data_type()));

--- a/tiledb/sys/src/datatype.rs
+++ b/tiledb/sys/src/datatype.rs
@@ -1,8 +1,50 @@
-use std::any::TypeId;
-use std::fmt::{Display, Formatter, Result as FmtResult};
-
-use crate::constants::TILEDB_OK;
 use crate::types::capi_return_t;
+
+pub const tiledb_datatype_t_TILEDB_INT32: tiledb_datatype_t = 0;
+pub const tiledb_datatype_t_TILEDB_INT64: tiledb_datatype_t = 1;
+pub const tiledb_datatype_t_TILEDB_FLOAT32: tiledb_datatype_t = 2;
+pub const tiledb_datatype_t_TILEDB_FLOAT64: tiledb_datatype_t = 3;
+pub const tiledb_datatype_t_TILEDB_CHAR: tiledb_datatype_t = 4;
+pub const tiledb_datatype_t_TILEDB_INT8: tiledb_datatype_t = 5;
+pub const tiledb_datatype_t_TILEDB_UINT8: tiledb_datatype_t = 6;
+pub const tiledb_datatype_t_TILEDB_INT16: tiledb_datatype_t = 7;
+pub const tiledb_datatype_t_TILEDB_UINT16: tiledb_datatype_t = 8;
+pub const tiledb_datatype_t_TILEDB_UINT32: tiledb_datatype_t = 9;
+pub const tiledb_datatype_t_TILEDB_UINT64: tiledb_datatype_t = 10;
+pub const tiledb_datatype_t_TILEDB_STRING_ASCII: tiledb_datatype_t = 11;
+pub const tiledb_datatype_t_TILEDB_STRING_UTF8: tiledb_datatype_t = 12;
+pub const tiledb_datatype_t_TILEDB_STRING_UTF16: tiledb_datatype_t = 13;
+pub const tiledb_datatype_t_TILEDB_STRING_UTF32: tiledb_datatype_t = 14;
+pub const tiledb_datatype_t_TILEDB_STRING_UCS2: tiledb_datatype_t = 15;
+pub const tiledb_datatype_t_TILEDB_STRING_UCS4: tiledb_datatype_t = 16;
+pub const tiledb_datatype_t_TILEDB_ANY: tiledb_datatype_t = 17;
+pub const tiledb_datatype_t_TILEDB_DATETIME_YEAR: tiledb_datatype_t = 18;
+pub const tiledb_datatype_t_TILEDB_DATETIME_MONTH: tiledb_datatype_t = 19;
+pub const tiledb_datatype_t_TILEDB_DATETIME_WEEK: tiledb_datatype_t = 20;
+pub const tiledb_datatype_t_TILEDB_DATETIME_DAY: tiledb_datatype_t = 21;
+pub const tiledb_datatype_t_TILEDB_DATETIME_HR: tiledb_datatype_t = 22;
+pub const tiledb_datatype_t_TILEDB_DATETIME_MIN: tiledb_datatype_t = 23;
+pub const tiledb_datatype_t_TILEDB_DATETIME_SEC: tiledb_datatype_t = 24;
+pub const tiledb_datatype_t_TILEDB_DATETIME_MS: tiledb_datatype_t = 25;
+pub const tiledb_datatype_t_TILEDB_DATETIME_US: tiledb_datatype_t = 26;
+pub const tiledb_datatype_t_TILEDB_DATETIME_NS: tiledb_datatype_t = 27;
+pub const tiledb_datatype_t_TILEDB_DATETIME_PS: tiledb_datatype_t = 28;
+pub const tiledb_datatype_t_TILEDB_DATETIME_FS: tiledb_datatype_t = 29;
+pub const tiledb_datatype_t_TILEDB_DATETIME_AS: tiledb_datatype_t = 30;
+pub const tiledb_datatype_t_TILEDB_TIME_HR: tiledb_datatype_t = 31;
+pub const tiledb_datatype_t_TILEDB_TIME_MIN: tiledb_datatype_t = 32;
+pub const tiledb_datatype_t_TILEDB_TIME_SEC: tiledb_datatype_t = 33;
+pub const tiledb_datatype_t_TILEDB_TIME_MS: tiledb_datatype_t = 34;
+pub const tiledb_datatype_t_TILEDB_TIME_US: tiledb_datatype_t = 35;
+pub const tiledb_datatype_t_TILEDB_TIME_NS: tiledb_datatype_t = 36;
+pub const tiledb_datatype_t_TILEDB_TIME_PS: tiledb_datatype_t = 37;
+pub const tiledb_datatype_t_TILEDB_TIME_FS: tiledb_datatype_t = 38;
+pub const tiledb_datatype_t_TILEDB_TIME_AS: tiledb_datatype_t = 39;
+pub const tiledb_datatype_t_TILEDB_BLOB: tiledb_datatype_t = 40;
+pub const tiledb_datatype_t_TILEDB_BOOL: tiledb_datatype_t = 41;
+pub const tiledb_datatype_t_TILEDB_GEOM_WKB: tiledb_datatype_t = 42;
+pub const tiledb_datatype_t_TILEDB_GEOM_WKT: tiledb_datatype_t = 43;
+pub type tiledb_datatype_t = ::std::os::raw::c_uint;
 
 extern "C" {
     pub fn tiledb_datatype_to_str(
@@ -16,434 +58,4 @@ extern "C" {
     ) -> capi_return_t;
 
     pub fn tiledb_datatype_size(type_: u32) -> u64;
-}
-
-#[allow(non_snake_case)]
-pub type tiledb_datatype_t = ::std::os::raw::c_uint;
-
-// When I find the time, I should come back and turn these into a macro
-// so that we can auto-generate the Datatype::from_u32 generation.
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-#[repr(u64)]
-pub enum Datatype {
-    #[doc = " 32-bit signed integer"]
-    Int32 = 0,
-    #[doc = " 64-bit signed integer"]
-    Int64 = 1,
-    #[doc = " 32-bit floating point value"]
-    Float32 = 2,
-    #[doc = " 64-bit floating point value"]
-    Float64 = 3,
-    #[doc = " Character"]
-    Char = 4,
-    #[doc = " 8-bit signed integer"]
-    Int8 = 5,
-    #[doc = " 8-bit unsigned integer"]
-    UInt8 = 6,
-    #[doc = " 16-bit signed integer"]
-    Int16 = 7,
-    #[doc = " 16-bit unsigned integer"]
-    UInt16 = 8,
-    #[doc = " 32-bit unsigned integer"]
-    UInt32 = 9,
-    #[doc = " 64-bit unsigned integer"]
-    UInt64 = 10,
-    #[doc = " ASCII string"]
-    StringAscii = 11,
-    #[doc = " UTF-8 string"]
-    StringUtf8 = 12,
-    #[doc = " UTF-16 string"]
-    StringUtf16 = 13,
-    #[doc = " UTF-32 string"]
-    StringUtf32 = 14,
-    #[doc = " UCS2 string"]
-    StringUcs2 = 15,
-    #[doc = " UCS4 string"]
-    StringUcs4 = 16,
-    #[doc = " This can be any datatype. Must store (type tag, value) pairs."]
-    Any = 17,
-    #[doc = " Datetime with year resolution"]
-    DateTimeYear = 18,
-    #[doc = " Datetime with month resolution"]
-    DateTimeMonth = 19,
-    #[doc = " Datetime with week resolution"]
-    DateTimeWeek = 20,
-    #[doc = " Datetime with day resolution"]
-    DateTimeDay = 21,
-    #[doc = " Datetime with hour resolution"]
-    DateTimeHour = 22,
-    #[doc = " Datetime with minute resolution"]
-    DateTimeMinute = 23,
-    #[doc = " Datetime with second resolution"]
-    DateTimeSecond = 24,
-    #[doc = " Datetime with millisecond resolution"]
-    DateTimeMillisecond = 25,
-    #[doc = " Datetime with microsecond resolution"]
-    DateTimeMicrosecond = 26,
-    #[doc = " Datetime with nanosecond resolution"]
-    DateTimeNanosecond = 27,
-    #[doc = " Datetime with picosecond resolution"]
-    DateTimePicosecond = 28,
-    #[doc = " Datetime with femtosecond resolution"]
-    DateTimeFemtosecond = 29,
-    #[doc = " Datetime with attosecond resolution"]
-    DateTimeAttosecond = 30,
-    #[doc = " Time with hour resolution"]
-    TimeHour = 31,
-    #[doc = " Time with minute resolution"]
-    TimeMinute = 32,
-    #[doc = " Time with second resolution"]
-    TimeSecond = 33,
-    #[doc = " Time with millisecond resolution"]
-    TimeMillisecond = 34,
-    #[doc = " Time with microsecond resolution"]
-    TimeMicrosecond = 35,
-    #[doc = " Time with nanosecond resolution"]
-    TimeNanosecond = 36,
-    #[doc = " Time with picosecond resolution"]
-    TimePicosecond = 37,
-    #[doc = " Time with femtosecond resolution"]
-    TimeFemtosecond = 38,
-    #[doc = " Time with attosecond resolution"]
-    TimeAttosecond = 39,
-    #[doc = " std::byte"]
-    Blob = 40,
-    #[doc = " Boolean"]
-    Boolean = 41,
-    #[doc = " Geometry data in well-known binary (WKB) format, stored as std::byte"]
-    GeometryWkb = 42,
-    #[doc = " Geometry data in well-known text (WKT) format, stored as std::byte"]
-    GeometryWkt = 43,
-}
-
-impl Datatype {
-    pub fn size(&self) -> u64 {
-        let copy = *self;
-        unsafe { tiledb_datatype_size(copy as tiledb_datatype_t) }
-    }
-
-    /// TODO: this should not be exposed outside of the tiledb-rs library
-    pub fn capi_enum(&self) -> tiledb_datatype_t {
-        *self as tiledb_datatype_t
-    }
-
-    pub fn from_capi_enum(c_datatype: tiledb_datatype_t) -> Self {
-        Self::from_u32(c_datatype).unwrap()
-    }
-
-    pub fn to_string(&self) -> Option<String> {
-        let copy = *self;
-        let c_dtype = copy as tiledb_datatype_t;
-        let mut c_str = std::ptr::null::<std::os::raw::c_char>();
-        let res = unsafe { tiledb_datatype_to_str(c_dtype, &mut c_str) };
-        if res == TILEDB_OK {
-            let c_msg = unsafe { std::ffi::CStr::from_ptr(c_str) };
-            Some(String::from(c_msg.to_string_lossy()))
-        } else {
-            None
-        }
-    }
-
-    pub fn from_string(dtype: &str) -> Option<Datatype> {
-        let c_dtype =
-            std::ffi::CString::new(dtype).expect("Error creating CString");
-        let mut c_ret: u32 = 0;
-        let res = unsafe {
-            tiledb_datatype_from_str(c_dtype.as_c_str().as_ptr(), &mut c_ret)
-        };
-
-        if res == TILEDB_OK {
-            Datatype::from_u32(c_ret)
-        } else {
-            None
-        }
-    }
-
-    pub fn from_u32(dtype: u32) -> Option<Datatype> {
-        match dtype {
-            0 => Some(Datatype::Int32),
-            1 => Some(Datatype::Int64),
-            2 => Some(Datatype::Float32),
-            3 => Some(Datatype::Float64),
-            4 => Some(Datatype::Char),
-            5 => Some(Datatype::Int8),
-            6 => Some(Datatype::UInt8),
-            7 => Some(Datatype::Int16),
-            8 => Some(Datatype::UInt16),
-            9 => Some(Datatype::UInt32),
-            10 => Some(Datatype::UInt64),
-            11 => Some(Datatype::StringAscii),
-            12 => Some(Datatype::StringUtf8),
-            13 => Some(Datatype::StringUtf16),
-            14 => Some(Datatype::StringUtf32),
-            15 => Some(Datatype::StringUcs2),
-            16 => Some(Datatype::StringUcs4),
-            17 => Some(Datatype::Any),
-            18 => Some(Datatype::DateTimeYear),
-            19 => Some(Datatype::DateTimeMonth),
-            20 => Some(Datatype::DateTimeWeek),
-            21 => Some(Datatype::DateTimeDay),
-            22 => Some(Datatype::DateTimeHour),
-            23 => Some(Datatype::DateTimeMinute),
-            24 => Some(Datatype::DateTimeSecond),
-            25 => Some(Datatype::DateTimeMillisecond),
-            26 => Some(Datatype::DateTimeMicrosecond),
-            27 => Some(Datatype::DateTimeNanosecond),
-            28 => Some(Datatype::DateTimePicosecond),
-            29 => Some(Datatype::DateTimeFemtosecond),
-            30 => Some(Datatype::DateTimeAttosecond),
-            31 => Some(Datatype::TimeHour),
-            32 => Some(Datatype::TimeMinute),
-            33 => Some(Datatype::TimeSecond),
-            34 => Some(Datatype::TimeMillisecond),
-            35 => Some(Datatype::TimeMicrosecond),
-            36 => Some(Datatype::TimeNanosecond),
-            37 => Some(Datatype::TimePicosecond),
-            38 => Some(Datatype::TimeFemtosecond),
-            39 => Some(Datatype::TimeAttosecond),
-            40 => Some(Datatype::Blob),
-            41 => Some(Datatype::Boolean),
-            42 => Some(Datatype::GeometryWkb),
-            43 => Some(Datatype::GeometryWkt),
-            _ => None,
-        }
-    }
-
-    pub fn is_compatible_type<T: 'static>(&self) -> bool {
-        let tid = TypeId::of::<T>();
-        if tid == TypeId::of::<f32>() {
-            matches!(*self, Datatype::Float32)
-        } else if tid == TypeId::of::<f64>() {
-            matches!(*self, Datatype::Float64)
-        } else if tid == TypeId::of::<i8>() {
-            matches!(*self, Datatype::Char | Datatype::Int8)
-        } else if tid == TypeId::of::<u8>() {
-            matches!(
-                *self,
-                Datatype::Any
-                    | Datatype::Blob
-                    | Datatype::Boolean
-                    | Datatype::GeometryWkb
-                    | Datatype::GeometryWkt
-                    | Datatype::StringAscii
-                    | Datatype::StringUtf8
-                    | Datatype::UInt8
-            )
-        } else if tid == TypeId::of::<i16>() {
-            matches!(*self, Datatype::Int16)
-        } else if tid == TypeId::of::<u16>() {
-            matches!(
-                *self,
-                Datatype::StringUtf16 | Datatype::StringUcs2 | Datatype::UInt16
-            )
-        } else if tid == TypeId::of::<i32>() {
-            matches!(*self, Datatype::Int32)
-        } else if tid == TypeId::of::<u32>() {
-            matches!(
-                *self,
-                Datatype::StringUtf32 | Datatype::StringUcs4 | Datatype::UInt32
-            )
-        } else if tid == TypeId::of::<i64>() {
-            matches!(
-                *self,
-                Datatype::Int64
-                    | Datatype::DateTimeYear
-                    | Datatype::DateTimeMonth
-                    | Datatype::DateTimeWeek
-                    | Datatype::DateTimeDay
-                    | Datatype::DateTimeHour
-                    | Datatype::DateTimeMinute
-                    | Datatype::DateTimeSecond
-                    | Datatype::DateTimeMillisecond
-                    | Datatype::DateTimeMicrosecond
-                    | Datatype::DateTimeNanosecond
-                    | Datatype::DateTimePicosecond
-                    | Datatype::DateTimeFemtosecond
-                    | Datatype::DateTimeAttosecond
-                    | Datatype::TimeHour
-                    | Datatype::TimeMinute
-                    | Datatype::TimeSecond
-                    | Datatype::TimeMillisecond
-                    | Datatype::TimeMicrosecond
-                    | Datatype::TimeNanosecond
-                    | Datatype::TimePicosecond
-                    | Datatype::TimeFemtosecond
-                    | Datatype::TimeAttosecond
-            )
-        } else if tid == TypeId::of::<u64>() {
-            matches!(*self, Datatype::UInt64)
-        } else {
-            false
-        }
-    }
-
-    /// Returns whether this type is an integral type (i.e. integer)
-    // Keep in sync with sm/enums/datatype.h::datatype_is_integer
-    pub fn is_integral_type(&self) -> bool {
-        matches!(
-            *self,
-            Datatype::Boolean
-                | Datatype::Int8
-                | Datatype::Int16
-                | Datatype::Int32
-                | Datatype::Int64
-                | Datatype::UInt8
-                | Datatype::UInt16
-                | Datatype::UInt32
-                | Datatype::UInt64
-        )
-    }
-
-    /// Returns whether this type is a variable-length string type
-    // Keep in sync with sm/enums/datatype.h::datatype_is_string
-    pub fn is_string_type(&self) -> bool {
-        matches!(
-            *self,
-            Datatype::StringAscii
-                | Datatype::StringUtf8
-                | Datatype::StringUtf16
-                | Datatype::StringUtf32
-                | Datatype::StringUcs2
-                | Datatype::StringUcs4
-        )
-    }
-
-    /// Returns whether this type is a DateTime type of any resolution
-    // Keep in sync with sm/enums/datatype.h::datatype_is_datetime
-    pub fn is_datetime_type(&self) -> bool {
-        matches!(
-            *self,
-            Datatype::DateTimeYear
-                | Datatype::DateTimeMonth
-                | Datatype::DateTimeWeek
-                | Datatype::DateTimeDay
-                | Datatype::DateTimeHour
-                | Datatype::DateTimeMinute
-                | Datatype::DateTimeSecond
-                | Datatype::DateTimeMillisecond
-                | Datatype::DateTimeMicrosecond
-                | Datatype::DateTimeNanosecond
-                | Datatype::DateTimePicosecond
-                | Datatype::DateTimeFemtosecond
-                | Datatype::DateTimeAttosecond
-        )
-    }
-
-    /// Returns whether this type is a Time type of any resolution
-    // Keep in sync with sm/enums/datatype.h::datatype_is_time
-    pub fn is_time_type(&self) -> bool {
-        matches!(
-            *self,
-            Datatype::TimeHour
-                | Datatype::TimeMinute
-                | Datatype::TimeSecond
-                | Datatype::TimeMillisecond
-                | Datatype::TimeMicrosecond
-                | Datatype::TimeNanosecond
-                | Datatype::TimePicosecond
-                | Datatype::TimeFemtosecond
-                | Datatype::TimeAttosecond
-        )
-    }
-
-    /// Returns whether this type can be used as a dimension type of a sparse array
-    pub fn is_allowed_dimension_type_sparse(&self) -> bool {
-        self.is_integral_type()
-            || self.is_datetime_type()
-            || self.is_time_type()
-            || matches!(
-                *self,
-                Datatype::Float32 | Datatype::Float64 | Datatype::StringAscii
-            )
-    }
-
-    /// Returns whether this type can be used as a dimension type of a dense array
-    pub fn is_allowed_dimension_type_dense(&self) -> bool {
-        self.is_integral_type()
-            || self.is_datetime_type()
-            || self.is_time_type()
-    }
-}
-
-impl Display for Datatype {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        write!(
-            f,
-            "{}",
-            match self.to_string() {
-                Some(s) => s,
-                None => String::from("<UNKNOWN DATA TYPE>"),
-            }
-        )
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn datatype_test() {
-        for i in 0..256 {
-            println!("I: {}", i);
-            if i <= 43 {
-                let dt = Datatype::from_u32(i as u32)
-                    .expect("Error converting value to Datatype");
-                assert_ne!(
-                    format!("{}", dt),
-                    "<UNKNOWN DATA TYPE>".to_string()
-                );
-                assert!(check_valid(&dt));
-            } else {
-                assert!(Datatype::from_u32(i as u32).is_none());
-            }
-        }
-    }
-
-    fn check_valid(dt: &Datatype) -> bool {
-        let mut count = 0;
-
-        if dt.is_compatible_type::<f32>() {
-            count += 1;
-        }
-
-        if dt.is_compatible_type::<f64>() {
-            count += 1;
-        }
-
-        if dt.is_compatible_type::<i8>() {
-            count += 1;
-        }
-
-        if dt.is_compatible_type::<u8>() {
-            count += 1;
-        }
-
-        if dt.is_compatible_type::<i16>() {
-            count += 1;
-        }
-
-        if dt.is_compatible_type::<u16>() {
-            count += 1;
-        }
-
-        if dt.is_compatible_type::<i32>() {
-            count += 1;
-        }
-
-        if dt.is_compatible_type::<u32>() {
-            count += 1;
-        }
-
-        if dt.is_compatible_type::<i64>() {
-            count += 1;
-        }
-
-        if dt.is_compatible_type::<u64>() {
-            count += 1;
-        }
-
-        count == 1
-    }
 }

--- a/tiledb/test/src/attribute.rs
+++ b/tiledb/test/src/attribute.rs
@@ -1,6 +1,7 @@
 use proptest::prelude::*;
 use tiledb::array::{Attribute, AttributeBuilder};
 use tiledb::context::Context;
+use tiledb::Result as TileDBResult;
 
 pub fn arbitrary_name() -> impl Strategy<Value = String> {
     proptest::string::string_regex("[a-zA-Z0-9_]*")
@@ -11,12 +12,21 @@ pub fn arbitrary_name() -> impl Strategy<Value = String> {
         )
 }
 
-pub fn arbitrary(context: &Context) -> impl Strategy<Value = Attribute> {
-    (arbitrary_name(), crate::datatype::arbitrary_implemented()).prop_map(
+pub fn arbitrary(
+    context: &Context,
+) -> impl Strategy<Value = TileDBResult<Attribute>> {
+    (arbitrary_name(), crate::datatype::arbitrary_implemented()).prop_flat_map(
         |(name, dt)| {
-            AttributeBuilder::new(context, name.as_ref(), dt)
-                .expect("Error building attribute")
-                .build()
+            (
+                Just(name),
+                Just(dt),
+                crate::filter::arbitrary_list_for_datatype(context, dt),
+            )
+                .prop_map(|(name, dt, filters)| {
+                    Ok(AttributeBuilder::new(context, name.as_ref(), dt)?
+                        .filter_list(filters?)?
+                        .build())
+                })
         },
     )
 }
@@ -30,7 +40,9 @@ mod tests {
     fn attribute_arbitrary() {
         let ctx = Context::new().expect("Error creating context");
 
-        proptest!(|(_ in arbitrary(&ctx))| {});
+        proptest!(|(attr in arbitrary(&ctx))| {
+            attr.expect("Error constructing arbitrary attribute");
+        });
     }
 
     #[test]
@@ -38,6 +50,7 @@ mod tests {
         let ctx = Context::new().expect("Error creating context");
 
         proptest!(|(attr in arbitrary(&ctx))| {
+            let attr = attr.expect("Error constructing arbitrary attribute");
             assert_eq!(attr, attr);
         });
     }

--- a/tiledb/test/src/attribute.rs
+++ b/tiledb/test/src/attribute.rs
@@ -24,7 +24,7 @@ pub fn arbitrary(
             )
                 .prop_map(|(name, dt, filters)| {
                     Ok(AttributeBuilder::new(context, name.as_ref(), dt)?
-                        .filter_list(filters?)?
+                        .filter_list(&filters?)?
                         .build())
                 })
         },

--- a/tiledb/test/src/filter.rs
+++ b/tiledb/test/src/filter.rs
@@ -57,25 +57,26 @@ pub fn arbitrary_positivedelta() -> impl Strategy<Value = FilterData> {
     const MIN_WINDOW: u32 = 8;
     const MAX_WINDOW: u32 = 1024;
 
-    (MIN_WINDOW..=MAX_WINDOW)
-        .prop_map(|max_window| FilterData::PositiveDelta { max_window })
+    (MIN_WINDOW..=MAX_WINDOW).prop_map(|max_window| FilterData::PositiveDelta {
+        max_window: Some(max_window),
+    })
 }
 
 pub fn arbitrary_scalefloat() -> impl Strategy<Value = FilterData> {
     (
         prop_oneof![
-            Just(std::mem::size_of::<i8>()),
-            Just(std::mem::size_of::<i16>()),
-            Just(std::mem::size_of::<i32>()),
-            Just(std::mem::size_of::<i64>()),
+            Just(ScaleFloatByteWidth::I8),
+            Just(ScaleFloatByteWidth::I16),
+            Just(ScaleFloatByteWidth::I32),
+            Just(ScaleFloatByteWidth::I64),
         ],
         proptest::num::f64::NORMAL,
         proptest::num::f64::NORMAL,
     )
         .prop_map(|(byte_width, factor, offset)| FilterData::ScaleFloat {
-            byte_width: byte_width as u64,
-            factor,
-            offset,
+            byte_width: Some(byte_width),
+            factor: Some(factor),
+            offset: Some(offset),
         })
 }
 
@@ -92,9 +93,9 @@ pub fn arbitrary_webp() -> impl Strategy<Value = FilterData> {
         0f32..=100f32,
     )
         .prop_map(|(input_format, lossless, quality)| FilterData::WebP {
-            input_format,
-            lossless,
-            quality,
+            input_format: Some(input_format),
+            lossless: Some(lossless),
+            quality: Some(quality),
         })
 }
 

--- a/tiledb/test/src/filter.rs
+++ b/tiledb/test/src/filter.rs
@@ -1,0 +1,135 @@
+use proptest::prelude::*;
+use proptest::strategy::Just;
+use tiledb::context::Context;
+use tiledb::filter::*;
+use tiledb::{Datatype, Result as TileDBResult};
+
+pub fn arbitrary_bitwidthreduction() -> impl Strategy<Value = FilterData> {
+    const MIN_WINDOW: u32 = 8;
+    const MAX_WINDOW: u32 = 1024;
+    prop_oneof![
+        Just(FilterData::BitWidthReduction { max_window: None }),
+        (MIN_WINDOW..=MAX_WINDOW).prop_map(|max_window| {
+            FilterData::BitWidthReduction {
+                max_window: Some(max_window),
+            }
+        })
+    ]
+}
+
+pub fn arbitrary_compression_reinterpret_datatype(
+) -> impl Strategy<Value = Datatype> {
+    crate::datatype::arbitrary_implemented()
+}
+
+pub fn arbitrary_compression() -> impl Strategy<Value = FilterData> {
+    const MIN_COMPRESSION_LEVEL: i32 = 1;
+    const MAX_COMPRESSION_LEVEL: i32 = 9;
+    (
+        prop_oneof![
+            Just(CompressionType::Bzip2),
+            Just(CompressionType::Delta),
+            Just(CompressionType::Dictionary),
+            Just(CompressionType::DoubleDelta),
+            Just(CompressionType::Gzip),
+            Just(CompressionType::Lz4),
+            Just(CompressionType::Rle),
+            Just(CompressionType::Zstd),
+        ],
+        MIN_COMPRESSION_LEVEL..=MAX_COMPRESSION_LEVEL,
+        arbitrary_compression_reinterpret_datatype(),
+    )
+        .prop_map(|(kind, level, reinterpret_datatype)| {
+            FilterData::Compression(CompressionData {
+                kind,
+                level: Some(level),
+                reinterpret_datatype: Some(reinterpret_datatype),
+            })
+        })
+}
+
+pub fn arbitrary_positivedelta() -> impl Strategy<Value = FilterData> {
+    const MIN_WINDOW: u32 = 8;
+    const MAX_WINDOW: u32 = 1024;
+
+    (MIN_WINDOW..=MAX_WINDOW)
+        .prop_map(|max_window| FilterData::PositiveDelta { max_window })
+}
+
+pub fn arbitrary_scalefloat() -> impl Strategy<Value = FilterData> {
+    (
+        prop_oneof![
+            Just(std::mem::size_of::<i8>()),
+            Just(std::mem::size_of::<i16>()),
+            Just(std::mem::size_of::<i32>()),
+            Just(std::mem::size_of::<i64>()),
+        ],
+        proptest::num::f64::NORMAL,
+        proptest::num::f64::NORMAL,
+    )
+        .prop_map(|(byte_width, factor, offset)| FilterData::ScaleFloat {
+            byte_width: byte_width as u64,
+            factor,
+            offset,
+        })
+}
+
+pub fn arbitrary_webp() -> impl Strategy<Value = FilterData> {
+    (
+        prop_oneof![
+            Just(WebPFilterInputFormat::None),
+            Just(WebPFilterInputFormat::Rgb),
+            Just(WebPFilterInputFormat::Bgr),
+            Just(WebPFilterInputFormat::Rgba),
+            Just(WebPFilterInputFormat::Bgra),
+        ],
+        prop_oneof![Just(false), Just(true)],
+        0f32..=100f32,
+    )
+        .prop_map(|(input_format, lossless, quality)| FilterData::WebP {
+            input_format,
+            lossless,
+            quality,
+        })
+}
+
+pub fn arbitrary(
+    context: &Context,
+) -> impl Strategy<Value = TileDBResult<Filter>> {
+    prop_oneof![
+        Just(FilterData::BitShuffle),
+        Just(FilterData::ByteShuffle),
+        arbitrary_bitwidthreduction(),
+        Just(FilterData::Checksum(ChecksumType::Md5)),
+        Just(FilterData::Checksum(ChecksumType::Sha256)),
+        arbitrary_compression(),
+        arbitrary_positivedelta(),
+        arbitrary_scalefloat(),
+        arbitrary_webp(),
+        Just(FilterData::Xor)
+    ]
+    .prop_map(|filter| Filter::create(context, filter))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test that the arbitrary attribute construction always succeeds
+    #[test]
+    fn filter_arbitrary() {
+        let ctx = Context::new().expect("Error creating context");
+
+        proptest!(|(_ in arbitrary(&ctx))| {});
+    }
+
+    #[test]
+    fn filter_eq_reflexivity() {
+        let ctx = Context::new().expect("Error creating context");
+
+        proptest!(|(attr in arbitrary(&ctx))| {
+            let attr = attr.expect("Error constructing arbitrary filter");
+            assert_eq!(attr, attr);
+        });
+    }
+}

--- a/tiledb/test/src/filter.rs
+++ b/tiledb/test/src/filter.rs
@@ -123,17 +123,17 @@ pub fn arbitrary_data_for_datatype(
         })
 }
 
-pub fn arbitrary_for_datatype<'ctx>(
-    context: &'ctx Context,
+pub fn arbitrary_for_datatype(
+    context: &Context,
     input_datatype: Datatype,
-) -> impl Strategy<Value = TileDBResult<Filter<'ctx>>> {
+) -> impl Strategy<Value = TileDBResult<Filter>> {
     arbitrary_data_for_datatype(input_datatype)
         .prop_map(|filter| Filter::create(context, filter))
 }
 
-pub fn arbitrary<'ctx>(
-    context: &'ctx Context,
-) -> impl Strategy<Value = TileDBResult<Filter<'ctx>>> {
+pub fn arbitrary(
+    context: &Context,
+) -> impl Strategy<Value = TileDBResult<Filter>> {
     arbitrary_data().prop_map(|filter| Filter::create(context, filter))
 }
 
@@ -155,10 +155,10 @@ fn arbitrary_pipeline(
     }
 }
 
-pub fn arbitrary_list_for_datatype<'ctx>(
-    context: &'ctx Context,
+pub fn arbitrary_list_for_datatype(
+    context: &Context,
     datatype: Datatype,
-) -> impl Strategy<Value = TileDBResult<FilterList<'ctx>>> {
+) -> impl Strategy<Value = TileDBResult<FilterList>> {
     const MIN_FILTERS: usize = 0;
     const MAX_FILTERS: usize = 4;
 
@@ -186,9 +186,9 @@ pub fn arbitrary_list_for_datatype<'ctx>(
     })
 }
 
-pub fn arbitrary_list<'ctx>(
-    context: &'ctx Context,
-) -> impl Strategy<Value = TileDBResult<FilterList<'ctx>>> {
+pub fn arbitrary_list(
+    context: &Context,
+) -> impl Strategy<Value = TileDBResult<FilterList>> {
     crate::datatype::arbitrary()
         .prop_flat_map(|dt| arbitrary_list_for_datatype(context, dt))
 }

--- a/tiledb/test/src/filter.rs
+++ b/tiledb/test/src/filter.rs
@@ -1,9 +1,13 @@
+use std::collections::VecDeque;
+
 use proptest::prelude::*;
 use proptest::strategy::Just;
 use tiledb::context::Context;
 use tiledb::filter::*;
 use tiledb::filter_list::FilterList;
 use tiledb::{Datatype, Result as TileDBResult};
+
+use crate::strategy::LifetimeBoundStrategy;
 
 pub fn arbitrary_bitwidthreduction() -> impl Strategy<Value = FilterData> {
     const MIN_WINDOW: u32 = 8;
@@ -94,9 +98,7 @@ pub fn arbitrary_webp() -> impl Strategy<Value = FilterData> {
         })
 }
 
-pub fn arbitrary(
-    context: &Context,
-) -> impl Strategy<Value = TileDBResult<Filter>> {
+pub fn arbitrary_data() -> impl Strategy<Value = FilterData> {
     prop_oneof![
         Just(FilterData::BitShuffle),
         Just(FilterData::ByteShuffle),
@@ -109,42 +111,143 @@ pub fn arbitrary(
         arbitrary_webp(),
         Just(FilterData::Xor)
     ]
-    .prop_map(|filter| Filter::create(context, filter))
 }
 
-pub fn arbitrary_list(
-    context: &Context,
-) -> impl Strategy<Value = TileDBResult<FilterList>> {
+pub fn arbitrary_data_for_datatype(
+    input_datatype: Datatype,
+) -> impl Strategy<Value = FilterData> {
+    arbitrary_data()
+        .prop_filter("Filter does not accept input type", move |filter| {
+            filter.transform_datatype(&input_datatype).is_some()
+        })
+}
+
+pub fn arbitrary_for_datatype<'ctx>(
+    context: &'ctx Context,
+    input_datatype: Datatype,
+) -> impl Strategy<Value = TileDBResult<Filter<'ctx>>> {
+    arbitrary_data_for_datatype(input_datatype)
+        .prop_map(|filter| Filter::create(context, filter))
+}
+
+pub fn arbitrary<'ctx>(
+    context: &'ctx Context,
+) -> impl Strategy<Value = TileDBResult<Filter<'ctx>>> {
+    arbitrary_data().prop_map(|filter| Filter::create(context, filter))
+}
+
+fn arbitrary_pipeline(
+    start: Datatype,
+    nfilters: usize,
+) -> impl Strategy<Value = VecDeque<FilterData>> {
+    if nfilters == 0 {
+        Just(VecDeque::new()).boxed()
+    } else {
+        arbitrary_data_for_datatype(start).prop_flat_map(move |filter| {
+            /* the transform type must be Some per filter in `arbitrary_data` */
+            let next = filter.transform_datatype(&start).unwrap();
+            arbitrary_pipeline(next, nfilters - 1).bind().prop_map(move |mut filter_vec| {
+                filter_vec.push_front(filter.clone());
+                filter_vec
+            })
+        }).boxed()
+    }
+}
+
+pub fn arbitrary_list_for_datatype<'ctx>(
+    context: &'ctx Context,
+    datatype: Datatype,
+) -> impl Strategy<Value = TileDBResult<FilterList<'ctx>>> {
     const MIN_FILTERS: usize = 0;
     const MAX_FILTERS: usize = 4;
 
-    proptest::collection::vec(arbitrary(context), MIN_FILTERS..=MAX_FILTERS)
-        .prop_map(|filters| {
+    (MIN_FILTERS..=MAX_FILTERS).prop_flat_map(move |nfilters| {
+        arbitrary_pipeline(datatype, nfilters).prop_map(move |filter_vec| {
             let mut b = tiledb::filter_list::Builder::new(context)?;
-            for filter in filters {
-                b = b.add_filter(filter?)?;
+            let mut current_dt = datatype;
+            for filter in filter_vec.iter() {
+                current_dt = if let Some(next_dt) =
+                    filter.transform_datatype(&current_dt)
+                {
+                    next_dt
+                } else {
+                    return Err(tiledb::error::Error::from(format!(
+                        "Error in filter pipeline construction: {} -> {:?}",
+                        datatype, filter_vec
+                    )));
+                }
+            }
+            for filter in filter_vec {
+                b = b.add_filter(Filter::create(context, filter)?)?;
             }
             Ok(b.build())
         })
+    })
+}
+
+pub fn arbitrary_list<'ctx>(
+    context: &'ctx Context,
+) -> impl Strategy<Value = TileDBResult<FilterList<'ctx>>> {
+    crate::datatype::arbitrary()
+        .prop_flat_map(|dt| arbitrary_list_for_datatype(context, dt))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// Test that the arbitrary attribute construction always succeeds
     #[test]
+    /// Test that the arbitrary filter construction always succeeds
     fn filter_arbitrary() {
         let ctx = Context::new().expect("Error creating context");
 
-        proptest!(|(_ in arbitrary(&ctx))| {});
+        proptest!(|(filt in arbitrary(&ctx))| {
+            filt.expect("Error constructing arbitrary filter");
+        });
+    }
+
+    /// Test that the arbitrary filter construction always succeeds with a supplied datatype
+    #[test]
+    fn filter_arbitrary_for_datatype() {
+        let ctx = Context::new().expect("Error creating context");
+
+        proptest!(|((dt, filt) in crate::datatype::arbitrary().prop_flat_map(|dt| (Just(dt), arbitrary_for_datatype(&ctx, dt))))| {
+            let filt = filt.expect("Error constructing arbitrary filter");
+
+            let filt_data = filt.filter_data().expect("Error reading filter data");
+            assert!(filt_data.transform_datatype(&dt).is_some());
+        });
     }
 
     #[test]
+    /// Test that the arbitrary filter list construction always succeeds
     fn filter_list_arbitrary() {
         let ctx = Context::new().expect("Error creating context");
 
-        proptest!(|(_ in arbitrary_list(&ctx))| {});
+        proptest!(|(fl in arbitrary_list(&ctx))| {
+            fl.expect("Error constructing arbitrary filter list");
+        });
+    }
+
+    #[test]
+    /// Test that the arbitrary filter list construction always succeeds with a supplied datatype
+    fn filter_list_arbitrary_for_datatype() {
+        let ctx = Context::new().expect("Error creating context");
+
+        proptest!(|((dt, fl) in crate::datatype::arbitrary_implemented().prop_flat_map(|dt| (Just(dt), arbitrary_list_for_datatype(&ctx, dt))))| {
+            let fl = fl.expect("Error constructing arbitrary filter");
+
+            let mut current_dt = dt;
+
+            let fl = fl.to_vec().expect("Error collecting filters");
+            for (fi, f) in fl.iter().enumerate() {
+                if let Some(next_dt) = f.filter_data().expect("Error reading filter data").transform_datatype(&current_dt) {
+                    current_dt = next_dt
+                } else {
+                    panic!("Constructed invalid filter list: {:?}, invalid at position {}", fl, fi)
+                }
+            }
+        });
     }
 
     #[test]

--- a/tiledb/test/src/lib.rs
+++ b/tiledb/test/src/lib.rs
@@ -6,5 +6,6 @@ pub mod attribute;
 pub mod datatype;
 pub mod dimension;
 pub mod domain;
+pub mod filter;
 pub mod schema;
 pub mod strategy;

--- a/tiledb/test/src/schema.rs
+++ b/tiledb/test/src/schema.rs
@@ -25,7 +25,7 @@ pub fn arbitrary(
             let mut b = SchemaBuilder::new(context, array_type, domain?)?;
             for attr in attrs {
                 /* TODO: how to ensure no duplicate names, assuming that matters? */
-                b = b.add_attribute(attr)?
+                b = b.add_attribute(attr?)?
             }
 
             Ok(b.build())


### PR DESCRIPTION
The missing piece from `Attribute::eq` was the filter pipeline.  To get this in there with the testing infrastructure we have and/or will need, we need to do `Debug`, `Eq`, `Serialize` and `Deserialize` for `FilterList` and `Filter`.

That turns out to require a bunch of things:
- to keep the `sys` crate with minimal dependencies, I moved `Datatype` to the `api` crate where it can `#[derive(Deserialize, Serialize)]`.  This also is a big step towards keeping `ffi::` out of the public APIs.
- not strictly a requirement, but the `enum FilterData` is really useful because it can `#[derive(PartialEq)]` which helps prevent us developers from making mistakes.  Now those mistakes can live in `Filter::create` and/or `Filter::filter_data` instead.
- `FilterData::transform_datatype` is an internal C API, but we need to use it for property-based testing to make sure that we construct valid filter pipelines.  The output of each filter in the pipeline needs to be a valid input to the next one.