### PR TITLE
use pkg-config to find system libtildb

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,1 @@
 [build]
-rustflags = ["-C", "link-args=-Wl,-rpath,/opt/tiledb/lib"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,6 +701,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,6 +1036,9 @@ dependencies = [
 [[package]]
 name = "tiledb-sys"
 version = "0.1.0"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "tiledb-test"

--- a/tiledb/sys/Cargo.toml
+++ b/tiledb/sys/Cargo.toml
@@ -2,3 +2,6 @@
 name = "tiledb-sys"
 version = { workspace = true }
 edition = { workspace = true }
+
+[build-dependencies]
+pkg-config = "0.3.30"

--- a/tiledb/sys/build.rs
+++ b/tiledb/sys/build.rs
@@ -1,25 +1,11 @@
-use std::env;
-use std::str::FromStr;
-
-const INSTALL_ENVVAR: &str = "CMAKE_INSTALL_PREFIX";
-const INSTALL_DEFAULT: &str = "/opt/tiledb/lib";
-
 fn main() {
     // Hard coded for now
     println!("cargo:rustc-link-lib=tiledb");
-    println!(
-        "cargo:rustc-link-search=all={}",
-        match env::var(INSTALL_ENVVAR) {
-            Ok(dir) => dir,
-            Err(e) =>
-                if let env::VarError::NotPresent = e {
-                    String::from_str(INSTALL_DEFAULT).expect("&'static str")
-                } else {
-                    panic!(
-                        "Error reading environment variable '{}': {}",
-                        INSTALL_ENVVAR, e
-                    );
-                },
-        }
-    );
+
+    // Use the system's tiledb library
+    // Cargo metadata will be printed to stdout if the search was successful
+    pkg_config::Config::new()
+        .atleast_version("2.4.0")
+        .probe("tiledb")
+        .expect("Build-time TileDB library missing, version >= 2.4 not found. Try the vendored feature.");
 }

--- a/tiledb/sys/build.rs
+++ b/tiledb/sys/build.rs
@@ -7,5 +7,5 @@ fn main() {
     pkg_config::Config::new()
         .atleast_version("2.4.0")
         .probe("tiledb")
-        .expect("Build-time TileDB library missing, version >= 2.4 not found. Try the vendored feature.");
+        .expect("Build-time TileDB library missing, version >= 2.4 not found.");
 }


### PR DESCRIPTION
:wave: Excited to see the rust bindings taking shape! To build against install prefixes outside of `/opt/tiledb`, the [pkg-config](https://docs.rs/pkg-config/latest/pkg_config/) package is one potential solution. It grabs all the system information at build time, tries to find `libtiledb > 2.4.0` (version TBD), and emits the appropriate flags. Working well locally but gh actions needs convincing.

TODO

* [ ] fix CI to install to a known prefix?
* [ ] minimum supported libtiledb version?