### PR TITLE
Fix nightly build CI workflow

### DIFF
--- a/.github/actions/install-tiledb/action.yml
+++ b/.github/actions/install-tiledb/action.yml
@@ -1,0 +1,25 @@
+
+name: Install TileDB
+
+inputs:
+  version:
+   required: false
+   description: "The version of TileDB to Install"
+   default: "2.21.0/tiledb-linux-x86_64-2.21.0-0ea9c13"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install TileDB
+      shell: bash
+      env:
+        RELEASES_URL: "https://github.com/TileDB-Inc/TileDB/releases/download"
+        VERSION: ${{ inputs.version }}
+      run: |
+        set -e pipefail
+        mkdir -p /opt/tiledb
+        cd /opt/tiledb
+        wget -nv ${RELEASES_URL}/${VERSION}.tar.gz
+        wget -nv ${RELEASES_URL}/${VERSION}.tar.gz.sha256
+        sha256sum tiledb*.sha256
+        tar -C /opt/tiledb -xzf tiledb*.tar.gz

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,26 +16,18 @@ concurrency:
 
 name: Stable Build and Test
 
-# Make sure CI fails on all warnings, including Clippy lints
-env:
-  RELEASES_URL: "https://github.com/TileDB-Inc/TileDB/releases/download"
-
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - name: Checkout tiledb-rs
+        uses: actions/checkout@v4
+      - name: Install Rust Stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: Setup Rustc Cache
+        uses: Swatinem/rust-cache@v2
       - name: Install TileDB
-        run: |
-          set -e pipefail
-          mkdir -p /opt/tiledb
-          cd /opt/tiledb
-          wget -q ${RELEASES_URL}/2.21.0/tiledb-linux-x86_64-2.21.0-0ea9c13.tar.gz
-          wget -q ${RELEASES_URL}/2.21.0/tiledb-linux-x86_64-2.21.0-0ea9c13.tar.gz.sha256
-          sha256sum tiledb*.sha256
-          tar -C /opt/tiledb -xzf tiledb*.tar.gz
+        uses: ./.github/actions/install-tiledb
       - name: Check Formatting
         run: cargo fmt --quiet --check
       - name: Lint

--- a/.github/workflows/nigthtly-stable.yml
+++ b/.github/workflows/nigthtly-stable.yml
@@ -10,17 +10,12 @@ jobs:
   update_build_and_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Checkout tiledb-rs
+        uses: actions/checkout@v4
+      - name: Install Rust Stable
+        uses: dtolnay/rust-toolchain@stable
       - name: Install TileDB
-        run: |
-          set -e pipefail
-          mkdir -p /opt/tiledb
-          cd /opt/tiledb
-          wget -q ${RELEASES_URL}/2.21.0/tiledb-linux-x86_64-2.21.0-0ea9c13.tar.gz
-          wget -q ${RELEASES_URL}/2.21.0/tiledb-linux-x86_64-2.21.0-0ea9c13.tar.gz.sha256
-          sha256sum tiledb*.sha256
-          tar -C /opt/tiledb -xzf tiledb*.tar.gz
+        uses: ./.github/actions/install-tiledb
       - name: Check Formatting
         run: cargo fmt --quiet --check
       - name: Update Dependencies


### PR DESCRIPTION
This moves the installation of TileDB to a composite action so it can be reused between workflows. The nightly workflow was broken because I forgot to set the `RELEASES_URL` environment variable.