### PR TITLE
Implement conversion between TIleDB Schema and Arrow Schema

### DIFF
--- a/tiledb/api/src/array/attribute.rs
+++ b/tiledb/api/src/array/attribute.rs
@@ -759,7 +759,7 @@ mod test {
     }
 
     #[test]
-    fn attribute_eq() {
+    fn test_eq() {
         let ctx = Context::new().unwrap();
 
         let start_attr =

--- a/tiledb/api/src/array/dimension.rs
+++ b/tiledb/api/src/array/dimension.rs
@@ -283,6 +283,14 @@ impl<'ctx> Builder<'ctx> {
         }
     }
 
+    pub fn context(&self) -> &'ctx Context {
+        self.dim.context
+    }
+
+    pub fn name(&self) -> TileDBResult<String> {
+        self.dim.name()
+    }
+
     pub fn cell_val_num(self, num: u32) -> TileDBResult<Self> {
         let c_context = self.dim.context.capi();
         let c_num = num as std::ffi::c_uint;

--- a/tiledb/api/src/array/dimension.rs
+++ b/tiledb/api/src/array/dimension.rs
@@ -524,4 +524,105 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_eq() {
+        let context = Context::new().unwrap();
+
+        let base = Builder::new::<i32>(
+            &context,
+            "d1",
+            Datatype::Int32,
+            &[0, 1000],
+            &100,
+        )
+        .unwrap()
+        .build();
+        assert_eq!(base, base);
+
+        // change name
+        {
+            let cmp = Builder::new::<i32>(
+                &context,
+                "d2",
+                Datatype::Int32,
+                &[0, 1000],
+                &100,
+            )
+            .unwrap()
+            .build();
+            assert_eq!(cmp, cmp);
+            assert_ne!(base, cmp);
+        }
+
+        // change type
+        {
+            let cmp = Builder::new::<i32>(
+                &context,
+                "d1",
+                Datatype::UInt32,
+                &[0, 1000],
+                &100,
+            )
+            .unwrap()
+            .build();
+            assert_eq!(cmp, cmp);
+            assert_ne!(base, cmp);
+        }
+
+        // change domain
+        {
+            let cmp = Builder::new::<i32>(
+                &context,
+                "d1",
+                Datatype::Int32,
+                &[1, 1000],
+                &100,
+            )
+            .unwrap()
+            .build();
+            assert_eq!(cmp, cmp);
+            assert_ne!(base, cmp);
+        }
+
+        // change extent
+        {
+            let cmp = Builder::new::<i32>(
+                &context,
+                "d1",
+                Datatype::Int32,
+                &[0, 1000],
+                &99,
+            )
+            .unwrap()
+            .build();
+            assert_eq!(cmp, cmp);
+            assert_ne!(base, cmp);
+        }
+
+        // change filters
+        {
+            let cmp = Builder::new::<i32>(
+                &context,
+                "d1",
+                Datatype::Int32,
+                &[0, 1000],
+                &99,
+            )
+            .unwrap()
+            .filters(
+                FilterListBuilder::new(&context)
+                    .unwrap()
+                    .add_filter_data(FilterData::Compression(
+                        CompressionData::new(CompressionType::Lz4),
+                    ))
+                    .unwrap()
+                    .build(),
+            )
+            .unwrap()
+            .build();
+            assert_eq!(cmp, cmp);
+            assert_ne!(base, cmp);
+        }
+    }
 }

--- a/tiledb/api/src/array/dimension.rs
+++ b/tiledb/api/src/array/dimension.rs
@@ -45,6 +45,20 @@ impl<'ctx> Dimension<'ctx> {
         Dimension { context, raw }
     }
 
+    pub fn name(&self) -> TileDBResult<String> {
+        let c_context = self.context.capi();
+        let mut c_name = std::ptr::null::<std::ffi::c_char>();
+        let res = unsafe {
+            ffi::tiledb_dimension_get_name(c_context, *self.raw, &mut c_name)
+        };
+        if res == ffi::TILEDB_OK {
+            let c_name = unsafe { std::ffi::CStr::from_ptr(c_name) };
+            Ok(String::from(c_name.to_string_lossy()))
+        } else {
+            Err(self.context.expect_last_error())
+        }
+    }
+
     pub fn datatype(&self) -> Datatype {
         let c_context = self.context.capi();
         let c_dimension = self.capi();
@@ -60,6 +74,21 @@ impl<'ctx> Dimension<'ctx> {
         assert_eq!(ffi::TILEDB_OK, c_ret);
 
         Datatype::try_from(c_datatype).expect("Invalid dimension type")
+    }
+
+    pub fn cell_val_num(&self) -> TileDBResult<u32> {
+        let c_context = self.context.capi();
+        let mut c_num: std::ffi::c_uint = 0;
+        let res = unsafe {
+            ffi::tiledb_dimension_get_cell_val_num(
+                c_context, *self.raw, &mut c_num,
+            )
+        };
+        if res == ffi::TILEDB_OK {
+            Ok(c_num as u32)
+        } else {
+            Err(self.context.expect_last_error())
+        }
     }
 
     pub fn domain<Conv: CAPIConverter>(&self) -> TileDBResult<[Conv; 2]> {
@@ -82,6 +111,27 @@ impl<'ctx> Dimension<'ctx> {
             unsafe { &*c_domain_ptr.cast::<[Conv::CAPIType; 2]>() };
 
         Ok([Conv::to_rust(&c_domain[0]), Conv::to_rust(&c_domain[1])])
+    }
+
+    /// Returns the tile extent of this dimension.
+    pub fn extent<Conv: CAPIConverter>(&self) -> TileDBResult<Conv> {
+        let c_context = self.context.capi();
+        let c_dimension = self.capi();
+        let mut c_extent_ptr: *const ::std::ffi::c_void = out_ptr!();
+
+        let c_ret = unsafe {
+            ffi::tiledb_dimension_get_tile_extent(
+                c_context,
+                c_dimension,
+                &mut c_extent_ptr,
+            )
+        };
+        if c_ret == ffi::TILEDB_OK {
+            let c_extent = unsafe { &*c_extent_ptr.cast::<Conv::CAPIType>() };
+            Ok(Conv::to_rust(c_extent))
+        } else {
+            Err(self.context.expect_last_error())
+        }
     }
 
     pub fn filters(&self) -> FilterList {
@@ -171,6 +221,23 @@ impl<'ctx> Builder<'ctx> {
         }
     }
 
+    pub fn cell_val_num(self, num: u32) -> TileDBResult<Self> {
+        let c_context = self.dim.context.capi();
+        let c_num = num as std::ffi::c_uint;
+        let res = unsafe {
+            ffi::tiledb_dimension_set_cell_val_num(
+                c_context,
+                *self.dim.raw,
+                c_num,
+            )
+        };
+        if res == ffi::TILEDB_OK {
+            Ok(self)
+        } else {
+            Err(self.dim.context.expect_last_error())
+        }
+    }
+
     pub fn filters(self, filters: FilterList) -> TileDBResult<Self> {
         let c_context = self.dim.context.capi();
         let c_dimension = self.dim.capi();
@@ -209,16 +276,20 @@ mod tests {
 
         // normal use case, should succeed, no memory issues
         {
+            let name = "test_dimension_alloc";
             let domain: [i32; 2] = [1, 4];
             let extent: i32 = 4;
-            Builder::new::<i32>(
+            let dimension = Builder::new::<i32>(
                 &context,
-                "test_dimension_alloc",
+                name,
                 Datatype::Int32,
                 &domain,
                 &extent,
             )
-            .unwrap();
+            .unwrap()
+            .build();
+
+            assert_eq!(name, dimension.name().unwrap());
         }
 
         // bad domain, should error
@@ -257,13 +328,13 @@ mod tests {
         // normal use case, should succeed, no memory issues
         {
             let domain_in: [i32; 2] = [1, 4];
-            let extent: i32 = 4;
+            let extent_in: i32 = 4;
             let dim = Builder::new::<i32>(
                 &context,
                 "test_dimension_domain",
                 Datatype::Int32,
                 &domain_in,
-                &extent,
+                &extent_in,
             )
             .unwrap()
             .build();
@@ -273,6 +344,52 @@ mod tests {
             let domain_out = dim.domain::<i32>().unwrap();
             assert_eq!(domain_in[0], domain_out[0]);
             assert_eq!(domain_in[1], domain_out[1]);
+
+            let extent_out = dim.extent::<i32>().unwrap();
+            assert_eq!(extent_in, extent_out);
+        }
+    }
+
+    #[test]
+    fn test_dimension_cell_val_num() {
+        let context = Context::new().unwrap();
+
+        // only 1 is currently supported
+        {
+            let cell_val_num = 1;
+            let dimension = {
+                let domain_in: [i32; 2] = [1, 4];
+                let extent: i32 = 4;
+                Builder::new::<i32>(
+                    &context,
+                    "test_dimension_cell_val_num",
+                    Datatype::Int32,
+                    &domain_in,
+                    &extent,
+                )
+                .unwrap()
+                .cell_val_num(cell_val_num)
+                .unwrap()
+                .build()
+            };
+
+            assert_eq!(cell_val_num, dimension.cell_val_num().unwrap());
+        }
+
+        // anything else should error
+        for cell_val_num in vec![0, 2, 4].into_iter() {
+            let domain_in: [i32; 2] = [1, 4];
+            let extent: i32 = 4;
+            let b = Builder::new::<i32>(
+                &context,
+                "test_dimension_cell_val_num",
+                Datatype::Int32,
+                &domain_in,
+                &extent,
+            )
+            .unwrap()
+            .cell_val_num(cell_val_num);
+            assert!(b.is_err());
         }
     }
 

--- a/tiledb/api/src/array/domain.rs
+++ b/tiledb/api/src/array/domain.rs
@@ -399,4 +399,51 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_eq() {
+        let context = Context::new().unwrap();
+
+        let domain_d0 = Builder::new(&context).unwrap().build();
+        assert_eq!(domain_d0, domain_d0);
+
+        // adding a dimension should no longer be eq
+        let domain_d1_int32 = Builder::new(&context)
+            .unwrap()
+            .add_dimension(
+                DimensionBuilder::new::<i32>(
+                    &context,
+                    "d1",
+                    Datatype::Int32,
+                    &[0, 1000],
+                    &100,
+                )
+                .unwrap()
+                .build(),
+            )
+            .unwrap()
+            .build();
+        assert_eq!(domain_d1_int32, domain_d1_int32);
+        assert_ne!(domain_d0, domain_d1_int32);
+
+        // a different dimension should no longer be eq
+        let domain_d1_float64 = Builder::new(&context)
+            .unwrap()
+            .add_dimension(
+                DimensionBuilder::new::<f64>(
+                    &context,
+                    "d1",
+                    Datatype::Float64,
+                    &[0f64, 1000f64],
+                    &100f64,
+                )
+                .unwrap()
+                .build(),
+            )
+            .unwrap()
+            .build();
+        assert_eq!(domain_d1_float64, domain_d1_float64);
+        assert_ne!(domain_d0, domain_d1_float64);
+        assert_ne!(domain_d1_int32, domain_d1_float64);
+    }
 }

--- a/tiledb/api/src/array/domain.rs
+++ b/tiledb/api/src/array/domain.rs
@@ -153,6 +153,27 @@ impl<'ctx> Debug for Domain<'ctx> {
     }
 }
 
+impl<'c1, 'c2> PartialEq<Domain<'c2>> for Domain<'c1> {
+    fn eq(&self, other: &Domain<'c2>) -> bool {
+        let ndim_match = self.ndim() == other.ndim();
+        if !ndim_match {
+            return false;
+        }
+
+        for d in 0..self.ndim() {
+            let dim_match = match (self.dimension(d), other.dimension(d)) {
+                (Ok(mine), Ok(theirs)) => mine == theirs,
+                _ => false,
+            };
+            if !dim_match {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
 pub struct Builder<'ctx> {
     domain: Domain<'ctx>,
 }

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -1,6 +1,8 @@
 use std::convert::TryFrom;
 use std::ops::Deref;
 
+use serde::{Deserialize, Serialize};
+
 use crate::context::Context;
 use crate::Result as TileDBResult;
 
@@ -32,7 +34,7 @@ impl Mode {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Layout {
     Unordered,
     RowMajor,

--- a/tiledb/api/src/array/schema.rs
+++ b/tiledb/api/src/array/schema.rs
@@ -64,6 +64,12 @@ impl Drop for RawSchema {
     }
 }
 
+type FnFilterListGet = unsafe extern "C" fn(
+    *mut ffi::tiledb_ctx_t,
+    *mut ffi::tiledb_array_schema_t,
+    *mut *mut ffi::tiledb_filter_list_t,
+) -> i32;
+
 pub struct Schema<'ctx> {
     context: &'ctx Context,
     raw: RawSchema,
@@ -245,11 +251,7 @@ impl<'ctx> Schema<'ctx> {
 
     fn filter_list(
         &self,
-        ffi_function: unsafe extern "C" fn(
-            *mut ffi::tiledb_ctx_t,
-            *mut ffi::tiledb_array_schema_t,
-            *mut *mut ffi::tiledb_filter_list_t,
-        ) -> i32,
+        ffi_function: FnFilterListGet,
     ) -> TileDBResult<FilterList> {
         let c_context = self.context.capi();
         let c_schema = *self.raw;
@@ -393,6 +395,12 @@ impl<'c1, 'c2> PartialEq<Schema<'c2>> for Schema<'c1> {
     }
 }
 
+type FnFilterListSet = unsafe extern "C" fn(
+    *mut ffi::tiledb_ctx_t,
+    *mut ffi::tiledb_array_schema_t,
+    *mut ffi::tiledb_filter_list_t,
+) -> i32;
+
 pub struct Builder<'ctx> {
     schema: Schema<'ctx>,
 }
@@ -513,11 +521,7 @@ impl<'ctx> Builder<'ctx> {
     fn filter_list(
         self,
         filters: &FilterList,
-        ffi_function: unsafe extern "C" fn(
-            *mut ffi::tiledb_ctx_t,
-            *mut ffi::tiledb_array_schema_t,
-            *mut ffi::tiledb_filter_list_t,
-        ) -> i32,
+        ffi_function: FnFilterListSet,
     ) -> TileDBResult<Self> {
         let c_context = self.schema.context.capi();
         let c_ret = unsafe {

--- a/tiledb/api/src/array/schema.rs
+++ b/tiledb/api/src/array/schema.rs
@@ -3,6 +3,8 @@ use std::convert::TryFrom;
 use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::ops::Deref;
 
+use serde::{Deserialize, Serialize};
+
 use crate::array::attribute::RawAttribute;
 use crate::array::domain::RawDomain;
 use crate::array::{Attribute, Domain, Layout};
@@ -10,7 +12,7 @@ use crate::context::Context;
 use crate::filter_list::{FilterList, RawFilterList};
 use crate::Result as TileDBResult;
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum ArrayType {
     Dense,
     Sparse,

--- a/tiledb/arrow/src/attribute.rs
+++ b/tiledb/arrow/src/attribute.rs
@@ -3,41 +3,11 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tiledb::context::Context as TileDBContext;
-use tiledb::filter::{FilterData, FilterListBuilder};
+use tiledb::filter::FilterListBuilder;
 use tiledb::{error::Error as TileDBError, fn_typed, Result as TileDBResult};
 
 use crate::datatype::{arrow_type_physical, tiledb_type_physical};
-
-/// Encapsulates TileDB filter data for storage in Arrow Field metadata
-#[derive(Deserialize, Serialize)]
-pub struct FilterMetadata {
-    filters: Vec<FilterData>,
-}
-
-impl FilterMetadata {
-    pub fn new(
-        filters: &tiledb::filter_list::FilterList,
-    ) -> TileDBResult<Self> {
-        Ok(FilterMetadata {
-            filters: filters
-                .to_vec()?
-                .into_iter()
-                .map(|f| f.filter_data())
-                .collect::<TileDBResult<Vec<FilterData>>>()?,
-        })
-    }
-
-    /// Updates a FilterListBuilder with the contents of this object
-    pub fn apply<'ctx>(
-        &self,
-        mut filters: FilterListBuilder<'ctx>,
-    ) -> TileDBResult<FilterListBuilder<'ctx>> {
-        for filter in self.filters.iter() {
-            filters = filters.add_filter_data(filter.clone())?;
-        }
-        Ok(filters)
-    }
-}
+use crate::filter::FilterMetadata;
 
 /// Encapsulates TileDB Attribute fill value data for storage in Arrow field metadata
 #[derive(Deserialize, Serialize)]

--- a/tiledb/arrow/src/dimension.rs
+++ b/tiledb/arrow/src/dimension.rs
@@ -1,0 +1,134 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tiledb::context::Context as TileDBContext;
+use tiledb::filter::FilterListBuilder;
+use tiledb::{error::Error as TileDBError, fn_typed, Result as TileDBResult};
+
+use crate::datatype::{arrow_type_physical, tiledb_type_physical};
+use crate::filter::FilterMetadata;
+
+/// Encapsulates fields of a TileDB dimension which are not part of an Arrow field
+#[derive(Deserialize, Serialize)]
+pub struct DimensionMetadata {
+    pub cell_val_num: u32,
+    pub domain: [serde_json::value::Value; 2],
+    pub extent: serde_json::value::Value,
+    pub filters: FilterMetadata,
+}
+
+impl DimensionMetadata {
+    pub fn new(dim: &tiledb::array::Dimension) -> TileDBResult<Self> {
+        fn_typed!(dim.datatype(), DT, {
+            let domain = dim.domain::<DT>()?;
+            let extent = dim.extent::<DT>()?;
+
+            Ok(DimensionMetadata {
+                cell_val_num: dim.cell_val_num()?,
+                domain: [json!(domain[0]), json!(domain[1])],
+                extent: json!(extent),
+                filters: FilterMetadata::new(&dim.filters())?,
+            })
+        })
+    }
+}
+
+/// Tries to construct an Arrow Field from the TileDB Dimension.
+/// Details about the Dimension are stored under the key "tiledb"
+/// in the Field's metadata.
+pub fn arrow_field(
+    dim: &tiledb::array::Dimension,
+) -> TileDBResult<Option<arrow_schema::Field>> {
+    if let Some(arrow_dt) = arrow_type_physical(&dim.datatype()) {
+        let name = dim.name()?;
+        let metadata = serde_json::ser::to_string(&DimensionMetadata::new(
+            dim,
+        )?)
+        .map_err(|e| {
+            TileDBError::from(format!(
+                "Error serializing metadata for dimension {}: {}",
+                name, e
+            ))
+        })?;
+        Ok(Some(
+            arrow_schema::Field::new(name, arrow_dt, false).with_metadata(
+                HashMap::<String, String>::from([(
+                    String::from("tiledb"),
+                    metadata,
+                )]),
+            ),
+        ))
+    } else {
+        Ok(None)
+    }
+}
+
+pub fn tiledb_dimension<'ctx>(
+    context: &'ctx TileDBContext,
+    field: &arrow_schema::Field,
+) -> TileDBResult<Option<tiledb::array::DimensionBuilder<'ctx>>> {
+    let tiledb_datatype = match tiledb_type_physical(field.data_type()) {
+        Some(dt) => dt,
+        None => return Ok(None),
+    };
+    let metadata = match field.metadata().get("tiledb") {
+        Some(metadata) => serde_json::from_str::<DimensionMetadata>(metadata)
+            .map_err(|e| {
+            TileDBError::from(format!(
+                "Error deserializing metadata for dimension {}: {}",
+                field.name(),
+                e
+            ))
+        })?,
+        None => return Ok(None),
+    };
+
+    let dim = fn_typed!(tiledb_datatype, DT, {
+        let deser = |v: &serde_json::value::Value| {
+            serde_json::from_value::<DT>(v.clone()).map_err(|e| {
+                TileDBError::from(format!(
+                    "Error deserializing dimension domain: {}",
+                    e
+                ))
+            })
+        };
+
+        let domain = [deser(&metadata.domain[0])?, deser(&metadata.domain[1])?];
+        let extent = deser(&metadata.extent)?;
+
+        tiledb::array::DimensionBuilder::new::<DT>(
+            context,
+            field.name(),
+            tiledb_datatype,
+            &domain,
+            &extent,
+        )
+    })?;
+
+    let fl = metadata
+        .filters
+        .apply(FilterListBuilder::new(dim.context())?)?
+        .build();
+
+    Ok(Some(dim.cell_val_num(metadata.cell_val_num)?.filters(fl)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn test_tiledb_arrow_tiledb() {
+        let c: TileDBContext = TileDBContext::new().unwrap();
+
+        proptest!(|(tdb_in in tiledb_test::dimension::arbitrary(&c))| {
+            let tdb_in = tdb_in.expect("Error constructing arbitrary tiledb dimension");
+            if let Some(arrow_dimension) = arrow_field(&tdb_in).expect("Error constructing arrow field") {
+                let tdb_out = tiledb_dimension(&c, &arrow_dimension).expect("Error converting back to tiledb dimension").unwrap().build();
+                assert_eq!(tdb_in, tdb_out);
+            }
+        });
+    }
+}

--- a/tiledb/arrow/src/filter.rs
+++ b/tiledb/arrow/src/filter.rs
@@ -32,3 +32,23 @@ impl FilterMetadata {
         Ok(filters)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use tiledb::context::Context as TileDBContext;
+
+    #[test]
+    fn test_serialize_invertibility() {
+        let c: TileDBContext = TileDBContext::new().unwrap();
+
+        proptest!(|(filters_in in tiledb_test::filter::arbitrary_list(&c))| {
+            let filters_in = filters_in.expect("Error constructing arbitrary filter list");
+            let metadata = FilterMetadata::new(&filters_in).expect("Error serializing filter list");
+            let filters_out = metadata.apply(FilterListBuilder::new(&c).unwrap()).expect("Error deserializing filter list").build();
+
+            assert_eq!(filters_in, filters_out);
+        });
+    }
+}

--- a/tiledb/arrow/src/filter.rs
+++ b/tiledb/arrow/src/filter.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+use tiledb::filter::{FilterData, FilterListBuilder};
+use tiledb::Result as TileDBResult;
+
+/// Encapsulates TileDB filter data for storage in Arrow Field metadata
+#[derive(Deserialize, Serialize)]
+pub struct FilterMetadata {
+    filters: Vec<FilterData>,
+}
+
+impl FilterMetadata {
+    pub fn new(
+        filters: &tiledb::filter_list::FilterList,
+    ) -> TileDBResult<Self> {
+        Ok(FilterMetadata {
+            filters: filters
+                .to_vec()?
+                .into_iter()
+                .map(|f| f.filter_data())
+                .collect::<TileDBResult<Vec<FilterData>>>()?,
+        })
+    }
+
+    /// Updates a FilterListBuilder with the contents of this object
+    pub fn apply<'ctx>(
+        &self,
+        mut filters: FilterListBuilder<'ctx>,
+    ) -> TileDBResult<FilterListBuilder<'ctx>> {
+        for filter in self.filters.iter() {
+            filters = filters.add_filter_data(filter.clone())?;
+        }
+        Ok(filters)
+    }
+}

--- a/tiledb/arrow/src/lib.rs
+++ b/tiledb/arrow/src/lib.rs
@@ -11,4 +11,5 @@ extern crate tiledb_test;
 
 pub mod attribute;
 pub mod datatype;
+pub mod dimension;
 pub mod filter;

--- a/tiledb/arrow/src/lib.rs
+++ b/tiledb/arrow/src/lib.rs
@@ -13,3 +13,4 @@ pub mod attribute;
 pub mod datatype;
 pub mod dimension;
 pub mod filter;
+pub mod schema;

--- a/tiledb/arrow/src/lib.rs
+++ b/tiledb/arrow/src/lib.rs
@@ -11,3 +11,4 @@ extern crate tiledb_test;
 
 pub mod attribute;
 pub mod datatype;
+pub mod filter;

--- a/tiledb/arrow/src/schema.rs
+++ b/tiledb/arrow/src/schema.rs
@@ -87,7 +87,6 @@ pub fn arrow_schema<'ctx>(
 /// A TileDB schema must have domain and dimension details.
 /// These are expected to be in the schema `metadata` beneath the key `tiledb`.
 /// This metadata is expected to be a JSON object with the following fields:
-/// TODO
 pub fn tiledb_schema<'ctx>(
     context: &'ctx TileDBContext,
     schema: &ArrowSchema,
@@ -103,7 +102,10 @@ pub fn tiledb_schema<'ctx>(
         None => return Ok(None),
     };
 
-    if schema.fields.len() < metadata.ndim { /* TODO: return error */ }
+    if schema.fields.len() < metadata.ndim {
+        return Err(TileDBError::from(format!("Input error: expected at least {} dimension fields but only found {}",
+                    metadata.ndim, schema.fields.len())));
+    }
 
     let dimensions = schema.fields.iter().take(metadata.ndim);
     let attributes = schema.fields.iter().skip(metadata.ndim);

--- a/tiledb/arrow/src/schema.rs
+++ b/tiledb/arrow/src/schema.rs
@@ -1,0 +1,166 @@
+use arrow_schema::Schema as ArrowSchema;
+use serde::{Deserialize, Serialize};
+use tiledb::array::{DomainBuilder, Schema, SchemaBuilder};
+use tiledb::{
+    context::Context as TileDBContext, error::Error as TileDBError,
+    Result as TileDBResult,
+};
+
+use crate::filter::FilterMetadata;
+
+/// Represents required metadata to convert from an arrow schema
+/// to a TileDB schema.
+#[derive(Deserialize, Serialize)]
+pub struct SchemaMetadata {
+    array_type: tiledb::array::ArrayType,
+    version: i64,
+    capacity: u64,
+    allows_duplicates: bool,
+    cell_order: tiledb::array::Layout,
+    tile_order: tiledb::array::Layout,
+    coordinate_filters: FilterMetadata,
+    offsets_filters: FilterMetadata,
+    nullity_filters: FilterMetadata,
+
+    /// Number of dimensions in this schema. The first `ndim` Fields are Dimensions, not Attributes
+    ndim: usize,
+}
+
+impl SchemaMetadata {
+    pub fn new(schema: &Schema) -> TileDBResult<Self> {
+        Ok(SchemaMetadata {
+            array_type: schema.array_type(),
+            version: schema.version(),
+            capacity: schema.capacity(),
+            allows_duplicates: schema.allows_duplicates(),
+            cell_order: schema.cell_order(),
+            tile_order: schema.tile_order(),
+            coordinate_filters: FilterMetadata::new(
+                &schema.coordinate_filters()?,
+            )?,
+            offsets_filters: FilterMetadata::new(&schema.offsets_filters()?)?,
+            nullity_filters: FilterMetadata::new(&schema.nullity_filters()?)?,
+            ndim: schema.domain()?.ndim(),
+        })
+    }
+}
+
+pub fn arrow_schema<'ctx>(
+    tiledb: &'ctx Schema<'ctx>,
+) -> TileDBResult<Option<ArrowSchema>> {
+    let mut builder =
+        arrow_schema::SchemaBuilder::with_capacity(tiledb.nattributes());
+
+    for d in 0..tiledb.domain()?.ndim() {
+        let dim = tiledb.domain()?.dimension(d)?;
+        if let Some(field) = crate::dimension::arrow_field(&dim)? {
+            builder.push(field)
+        } else {
+            return Ok(None);
+        }
+    }
+
+    for a in 0..tiledb.nattributes() {
+        let attr = tiledb.attribute(a)?;
+        if let Some(field) = crate::attribute::arrow_field(&attr)? {
+            builder.push(field)
+        } else {
+            return Ok(None);
+        }
+    }
+
+    let metadata = serde_json::ser::to_string(&SchemaMetadata::new(tiledb)?)
+        .map_err(|e| {
+            TileDBError::from(format!(
+                "Error serializing metadata for schema: {}",
+                e
+            ))
+        })?;
+    builder
+        .metadata_mut()
+        .insert(String::from("tiledb"), metadata);
+
+    Ok(Some(builder.finish()))
+}
+
+/// Construct a TileDB schema from an Arrow schema.
+/// A TileDB schema must have domain and dimension details.
+/// These are expected to be in the schema `metadata` beneath the key `tiledb`.
+/// This metadata is expected to be a JSON object with the following fields:
+/// TODO
+pub fn tiledb_schema<'ctx>(
+    context: &'ctx TileDBContext,
+    schema: &ArrowSchema,
+) -> TileDBResult<Option<SchemaBuilder<'ctx>>> {
+    let metadata = match schema.metadata().get("tiledb") {
+        Some(metadata) => serde_json::from_str::<SchemaMetadata>(metadata)
+            .map_err(|e| {
+                TileDBError::from(format!(
+                    "Error deserializing metadata: {}",
+                    e
+                ))
+            })?,
+        None => return Ok(None),
+    };
+
+    if schema.fields.len() < metadata.ndim { /* TODO: return error */ }
+
+    let dimensions = schema.fields.iter().take(metadata.ndim);
+    let attributes = schema.fields.iter().skip(metadata.ndim);
+
+    let domain = {
+        let mut b = DomainBuilder::new(context)?;
+        for f in dimensions {
+            if let Some(dimension) =
+                crate::dimension::tiledb_dimension(context, f)?
+            {
+                b = b.add_dimension(dimension.build())?;
+            } else {
+                return Ok(None);
+            }
+        }
+        b.build()
+    };
+
+    let mut b = SchemaBuilder::new(context, metadata.array_type, domain)?
+        .capacity(metadata.capacity)?
+        .allow_duplicates(metadata.allows_duplicates)?
+        .cell_order(metadata.cell_order)?
+        .tile_order(metadata.tile_order)?
+        .coordinate_filters(&metadata.coordinate_filters.create(context)?)?
+        .offsets_filters(&metadata.offsets_filters.create(context)?)?
+        .nullity_filters(&metadata.nullity_filters.create(context)?)?;
+
+    for f in attributes {
+        if let Some(attr) = crate::attribute::tiledb_attribute(context, f)? {
+            b = b.add_attribute(attr.build())?;
+        } else {
+            return Ok(None);
+        }
+    }
+
+    Ok(Some(b))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn test_tiledb_arrow_tiledb() -> TileDBResult<()> {
+        let c: TileDBContext = TileDBContext::new()?;
+
+        /* tiledb => arrow => tiledb */
+        proptest!(|(tdb_in in tiledb_test::schema::arbitrary(&c))| {
+            let tdb_in = tdb_in.expect("Error constructing arbitrary tiledb attribute");
+            if let Some(arrow_schema) = arrow_schema(&tdb_in).expect("Error reading tiledb schema") {
+                // convert back to TileDB attribute
+                let tdb_out = tiledb_schema(&c, &arrow_schema)?.expect("Arrow schema did not invert").build();
+                assert_eq!(tdb_in, tdb_out);
+            }
+        });
+
+        Ok(())
+    }
+}

--- a/tiledb/test/src/domain.rs
+++ b/tiledb/test/src/domain.rs
@@ -25,7 +25,7 @@ pub fn arbitrary(
             })
             .bind(),
         ArrayType::Sparse => proptest::collection::vec(
-            crate::dimension::arbitrary(context, array_type),
+            crate::dimension::arbitrary_for_array_type(context, array_type),
             MIN_DIMENSIONS..=MAX_DIMENSIONS,
         )
         .bind(),

--- a/tiledb/test/src/domain.rs
+++ b/tiledb/test/src/domain.rs
@@ -5,7 +5,7 @@ use tiledb::Result as TileDBResult;
 
 use crate::strategy::LifetimeBoundStrategy;
 
-pub fn arbitrary(
+pub fn arbitrary_for_array_type(
     context: &Context,
     array_type: ArrayType,
 ) -> impl Strategy<Value = TileDBResult<Domain>> {
@@ -39,17 +39,34 @@ pub fn arbitrary(
     })
 }
 
+pub fn arbitrary(
+    context: &Context,
+) -> impl Strategy<Value = TileDBResult<Domain>> {
+    prop_oneof![Just(ArrayType::Dense), Just(ArrayType::Sparse)]
+        .prop_flat_map(|atype| arbitrary_for_array_type(context, atype))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     /// Test that the arbitrary domain construction always succeeds
     #[test]
-    fn domain_arbitrary_sparse() {
+    fn domain_arbitrary() {
         let ctx = Context::new().expect("Error creating context");
 
-        proptest!(|(maybe_domain in arbitrary(&ctx, ArrayType::Sparse))| {
+        proptest!(|(maybe_domain in arbitrary(&ctx))| {
             maybe_domain.expect("Error constructing arbitrary domain");
+        });
+    }
+
+    #[test]
+    fn domain_eq_reflexivity() {
+        let ctx = Context::new().expect("Error creating context");
+
+        proptest!(|(maybe_domain in arbitrary(&ctx))| {
+            let domain = maybe_domain.expect("Error constructing arbitrary domain");
+            assert_eq!(domain, domain);
         });
     }
 }

--- a/tiledb/test/src/schema.rs
+++ b/tiledb/test/src/schema.rs
@@ -17,7 +17,7 @@ pub fn arbitrary(
         .prop_flat_map(move |array_type|
             (
                 Just(array_type),
-                crate::domain::arbitrary(context, array_type),
+                crate::domain::arbitrary_for_array_type(context, array_type),
                 proptest::collection::vec(crate::attribute::arbitrary(context), MIN_ATTRS..=MAX_ATTRS)
             ))
         .prop_map(|(array_type, domain, attrs)| {

--- a/tiledb/test/src/schema.rs
+++ b/tiledb/test/src/schema.rs
@@ -43,7 +43,7 @@ pub fn arbitrary(
     context: &Context,
 ) -> impl Strategy<Value = TileDBResult<Schema>> {
     const MIN_ATTRS: usize = 1;
-    const MAX_ATTRS: usize = 128;
+    const MAX_ATTRS: usize = 32;
 
     arbitrary_array_type()
         .prop_flat_map(move |array_type|
@@ -79,6 +79,16 @@ mod tests {
 
         proptest!(|(maybe_schema in arbitrary(&ctx))| {
             maybe_schema.expect("Error constructing arbitrary schema");
+        });
+    }
+
+    #[test]
+    fn schema_eq_reflexivity() {
+        let ctx = Context::new().expect("Error creating context");
+
+        proptest!(|(maybe_schema in arbitrary(&ctx))| {
+            let schema = maybe_schema.expect("Error constructing arbitrary schema");
+            assert_eq!(schema, schema);
         });
     }
 }

--- a/tiledb/test/src/schema.rs
+++ b/tiledb/test/src/schema.rs
@@ -3,8 +3,40 @@ use tiledb::array::{ArrayType, Schema, SchemaBuilder};
 use tiledb::context::Context;
 use tiledb::Result as TileDBResult;
 
+use crate::strategy::LifetimeBoundStrategy;
+
 pub fn arbitrary_array_type() -> impl Strategy<Value = ArrayType> {
     prop_oneof![Just(ArrayType::Dense), Just(ArrayType::Sparse),]
+}
+
+pub fn arbitrary_cell_order(
+    array_type: ArrayType,
+) -> impl Strategy<Value = tiledb::array::Layout> {
+    use tiledb::array::Layout;
+    match array_type {
+        ArrayType::Sparse => prop_oneof![
+            Just(Layout::Unordered),
+            Just(Layout::RowMajor),
+            Just(Layout::ColumnMajor),
+            Just(Layout::Hilbert),
+        ]
+        .bind(),
+        ArrayType::Dense => prop_oneof![
+            Just(Layout::Unordered),
+            Just(Layout::RowMajor),
+            Just(Layout::ColumnMajor),
+        ]
+        .bind(),
+    }
+}
+
+pub fn arbitrary_tile_order() -> impl Strategy<Value = tiledb::array::Layout> {
+    use tiledb::array::Layout;
+    prop_oneof![
+        Just(Layout::Unordered),
+        Just(Layout::RowMajor),
+        Just(Layout::ColumnMajor),
+    ]
 }
 
 pub fn arbitrary(
@@ -17,12 +49,16 @@ pub fn arbitrary(
         .prop_flat_map(move |array_type|
             (
                 Just(array_type),
+                arbitrary_cell_order(array_type),
+                arbitrary_tile_order(),
                 crate::domain::arbitrary_for_array_type(context, array_type),
                 proptest::collection::vec(crate::attribute::arbitrary(context), MIN_ATTRS..=MAX_ATTRS)
             ))
-        .prop_map(|(array_type, domain, attrs)| {
+        .prop_map(|(array_type, cell_order, tile_order, domain, attrs)| {
             /* TODO: cell order, tile order, capacity, duplicates */
-            let mut b = SchemaBuilder::new(context, array_type, domain?)?;
+            let mut b = SchemaBuilder::new(context, array_type, domain?)?
+                .cell_order(cell_order)?
+                .tile_order(tile_order)?;
             for attr in attrs {
                 /* TODO: how to ensure no duplicate names, assuming that matters? */
                 b = b.add_attribute(attr?)?


### PR DESCRIPTION
This pull request implements functions to convert between TileDB schema and Arrow schema.

As in #28, we use a serializable objects to store details about the TileDB schema and/or dimension which do not have a natural field in the Arrow Schema.

There aren't any notable new designs here, just lots of details which were missing including several `PartialEq` implementations, some fields from `Debug`, some `ffi` methods which were not implemented yet, and some updates to the proptest strategies.  Among the missing methods were the Schema's filter list setters and getters - these depend on the Domain to generate sound values, so I was unable to add them to proptest as we have discussed as length in Slack.

Resolves sc#43826.