### PR TITLE
Update proptest strategies to produce a set of inputs to our APIs, instead of the structs directly

### DIFF
--- a/tiledb/api/src/array/domain.rs
+++ b/tiledb/api/src/array/domain.rs
@@ -250,7 +250,7 @@ impl<'ctx> From<Builder<'ctx>> for Domain<'ctx> {
 /// Encapsulation of data needed to construct a Domain
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct DomainData {
-    dimension: Vec<DimensionData>,
+    pub dimension: Vec<DimensionData>,
 }
 
 impl<'ctx> TryFrom<&Domain<'ctx>> for DomainData {

--- a/tiledb/api/src/array/domain.rs
+++ b/tiledb/api/src/array/domain.rs
@@ -1,10 +1,14 @@
-use serde_json::json;
 use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::ops::Deref;
 
-use crate::array::{dimension::RawDimension, Dimension};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::array::{
+    dimension::DimensionData, dimension::RawDimension, Dimension,
+};
 use crate::context::Context;
-use crate::Result as TileDBResult;
+use crate::{Factory, Result as TileDBResult};
 
 pub(crate) enum RawDomain {
     Owned(*mut ffi::tiledb_domain_t),
@@ -164,18 +168,9 @@ impl<'ctx> Domain<'ctx> {
 
 impl<'ctx> Debug for Domain<'ctx> {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        let json = json!({
-            "dimensions": (0..self.ndim())
-                .map(|d| {
-                    serde_json::value::Value::String(match self.dimension(d) {
-                        Ok(d) => format!("{:?}", d),
-                        Err(e) => format!("<{}>", e),
-                    })
-                })
-                .collect::<Vec<_>>(),
-            "raw": format!("{:p}", *self.raw)
-                /* TODO: what other fields? */
-        });
+        let data = DomainData::try_from(self).map_err(|_| std::fmt::Error)?;
+        let mut json = json!(data);
+        json["raw"] = json!(format!("{:p}", *self.raw));
 
         write!(f, "{}", json)
     }
@@ -249,6 +244,38 @@ impl<'ctx> Builder<'ctx> {
 impl<'ctx> From<Builder<'ctx>> for Domain<'ctx> {
     fn from(builder: Builder<'ctx>) -> Domain<'ctx> {
         builder.build()
+    }
+}
+
+/// Encapsulation of data needed to construct a Domain
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct DomainData {
+    dimension: Vec<DimensionData>,
+}
+
+impl<'ctx> TryFrom<&Domain<'ctx>> for DomainData {
+    type Error = crate::error::Error;
+
+    fn try_from(domain: &Domain<'ctx>) -> TileDBResult<Self> {
+        Ok(DomainData {
+            dimension: (0..domain.ndim())
+                .map(|d| DimensionData::try_from(&domain.dimension(d)?))
+                .collect::<TileDBResult<Vec<DimensionData>>>()?,
+        })
+    }
+}
+
+impl<'ctx> Factory<'ctx> for DomainData {
+    type Item = Domain<'ctx>;
+
+    fn create(&self, context: &'ctx Context) -> TileDBResult<Self::Item> {
+        Ok(self
+            .dimension
+            .iter()
+            .try_fold(Builder::new(context)?, |b, d| {
+                b.add_dimension(d.create(context)?)
+            })?
+            .build())
     }
 }
 

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -6,15 +6,15 @@ use serde::{Deserialize, Serialize};
 use crate::context::Context;
 use crate::Result as TileDBResult;
 
-mod attribute;
-mod dimension;
-mod domain;
-mod schema;
+pub mod attribute;
+pub mod dimension;
+pub mod domain;
+pub mod schema;
 
-pub use attribute::{Attribute, Builder as AttributeBuilder};
-pub use dimension::{Builder as DimensionBuilder, Dimension};
-pub use domain::{Builder as DomainBuilder, Domain};
-pub use schema::{ArrayType, Builder as SchemaBuilder, Schema};
+pub use attribute::{Attribute, AttributeData, Builder as AttributeBuilder};
+pub use dimension::{Builder as DimensionBuilder, Dimension, DimensionData};
+pub use domain::{Builder as DomainBuilder, Domain, DomainData};
+pub use schema::{ArrayType, Builder as SchemaBuilder, Schema, SchemaData};
 
 pub enum Mode {
     Read,

--- a/tiledb/api/src/array/schema.rs
+++ b/tiledb/api/src/array/schema.rs
@@ -568,16 +568,16 @@ impl<'ctx> From<Builder<'ctx>> for Schema<'ctx> {
 /// Encapsulation of data needed to construct a Schema
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct SchemaData {
-    array_type: ArrayType,
-    domain: DomainData,
-    capacity: Option<u64>,
-    cell_order: Option<Layout>,
-    tile_order: Option<Layout>,
-    allow_duplicates: Option<bool>,
-    attributes: Vec<AttributeData>,
-    coordinate_filters: FilterListData,
-    offsets_filters: FilterListData,
-    nullity_filters: FilterListData,
+    pub array_type: ArrayType,
+    pub domain: DomainData,
+    pub capacity: Option<u64>,
+    pub cell_order: Option<Layout>,
+    pub tile_order: Option<Layout>,
+    pub allow_duplicates: Option<bool>,
+    pub attributes: Vec<AttributeData>,
+    pub coordinate_filters: FilterListData,
+    pub offsets_filters: FilterListData,
+    pub nullity_filters: FilterListData,
 }
 
 impl<'ctx> TryFrom<&Schema<'ctx>> for SchemaData {

--- a/tiledb/api/src/lib.rs
+++ b/tiledb/api/src/lib.rs
@@ -47,6 +47,7 @@ pub fn version() -> (i32, i32, i32) {
 }
 
 pub use array::Array;
+pub use context::Context;
 pub use datatype::Datatype;
 pub use query::{Builder as QueryBuilder, Query, QueryType};
 pub type Result<T> = std::result::Result<T, error::Error>;

--- a/tiledb/api/src/lib.rs
+++ b/tiledb/api/src/lib.rs
@@ -50,3 +50,9 @@ pub use array::Array;
 pub use datatype::Datatype;
 pub use query::{Builder as QueryBuilder, Query, QueryType};
 pub type Result<T> = std::result::Result<T, error::Error>;
+
+pub trait Factory<'ctx> {
+    type Item;
+
+    fn create(&self, context: &'ctx context::Context) -> Result<Self::Item>;
+}

--- a/tiledb/arrow/src/attribute.rs
+++ b/tiledb/arrow/src/attribute.rs
@@ -136,6 +136,7 @@ pub fn tiledb_attribute<'ctx>(
 pub mod tests {
     use super::*;
     use proptest::prelude::*;
+    use tiledb::Factory;
 
     pub fn arbitrary_arrow_field() -> impl Strategy<Value = arrow_schema::Field>
     {
@@ -160,8 +161,8 @@ pub mod tests {
         let c: TileDBContext = TileDBContext::new()?;
 
         /* tiledb => arrow => tiledb */
-        proptest!(|(tdb_in in tiledb_test::attribute::arbitrary(&c))| {
-            let tdb_in = tdb_in.expect("Error constructing arbitrary tiledb attribute");
+        proptest!(|(tdb_in in tiledb_test::attribute::arbitrary())| {
+            let tdb_in = tdb_in.create(&c).expect("Error constructing arbitrary tiledb attribute");
             if let Some(arrow_field) = arrow_field(&tdb_in).expect("Error reading tiledb attribute") {
                 // convert back to TileDB attribute
                 let tdb_out = tiledb_attribute(&c, &arrow_field)?.expect("Arrow attribute did not invert").build();

--- a/tiledb/arrow/src/dimension.rs
+++ b/tiledb/arrow/src/dimension.rs
@@ -118,13 +118,14 @@ pub fn tiledb_dimension<'ctx>(
 mod tests {
     use super::*;
     use proptest::prelude::*;
+    use tiledb::Factory;
 
     #[test]
     fn test_tiledb_arrow_tiledb() {
         let c: TileDBContext = TileDBContext::new().unwrap();
 
-        proptest!(|(tdb_in in tiledb_test::dimension::arbitrary(&c))| {
-            let tdb_in = tdb_in.expect("Error constructing arbitrary tiledb dimension");
+        proptest!(|(tdb_in in tiledb_test::dimension::arbitrary())| {
+            let tdb_in = tdb_in.create(&c).expect("Error constructing arbitrary tiledb dimension");
             if let Some(arrow_dimension) = arrow_field(&tdb_in).expect("Error constructing arrow field") {
                 let tdb_out = tiledb_dimension(&c, &arrow_dimension).expect("Error converting back to tiledb dimension").unwrap().build();
                 assert_eq!(tdb_in, tdb_out);

--- a/tiledb/arrow/src/filter.rs
+++ b/tiledb/arrow/src/filter.rs
@@ -45,13 +45,14 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
     use tiledb::context::Context as TileDBContext;
+    use tiledb::Factory;
 
     #[test]
     fn test_serialize_invertibility() {
         let c: TileDBContext = TileDBContext::new().unwrap();
 
-        proptest!(|(filters_in in tiledb_test::filter::arbitrary_list(&c))| {
-            let filters_in = filters_in.expect("Error constructing arbitrary filter list");
+        proptest!(|(filters_in in tiledb_test::filter::arbitrary_list())| {
+            let filters_in = filters_in.create(&c).expect("Error constructing arbitrary filter list");
             let metadata = FilterMetadata::new(&filters_in).expect("Error serializing filter list");
             let filters_out = metadata.create(&c).expect("Error deserializing filter list");
 

--- a/tiledb/arrow/src/schema.rs
+++ b/tiledb/arrow/src/schema.rs
@@ -148,14 +148,15 @@ pub fn tiledb_schema<'ctx>(
 mod tests {
     use super::*;
     use proptest::prelude::*;
+    use tiledb::Factory;
 
     #[test]
     fn test_tiledb_arrow_tiledb() -> TileDBResult<()> {
         let c: TileDBContext = TileDBContext::new()?;
 
         /* tiledb => arrow => tiledb */
-        proptest!(|(tdb_in in tiledb_test::schema::arbitrary(&c))| {
-            let tdb_in = tdb_in.expect("Error constructing arbitrary tiledb attribute");
+        proptest!(|(tdb_in in tiledb_test::schema::arbitrary())| {
+            let tdb_in = tdb_in.create(&c).expect("Error constructing arbitrary tiledb attribute");
             if let Some(arrow_schema) = arrow_schema(&tdb_in).expect("Error reading tiledb schema") {
                 // convert back to TileDB attribute
                 let tdb_out = tiledb_schema(&c, &arrow_schema)?.expect("Arrow schema did not invert").build();

--- a/tiledb/test/src/filter.rs
+++ b/tiledb/test/src/filter.rs
@@ -2,10 +2,10 @@ use std::collections::VecDeque;
 
 use proptest::prelude::*;
 use proptest::strategy::Just;
-use tiledb::context::Context;
+
 use tiledb::filter::*;
-use tiledb::filter_list::FilterList;
-use tiledb::{Datatype, Result as TileDBResult};
+use tiledb::filter_list::FilterListData;
+use tiledb::Datatype;
 
 use crate::strategy::LifetimeBoundStrategy;
 
@@ -99,7 +99,7 @@ pub fn arbitrary_webp() -> impl Strategy<Value = FilterData> {
         })
 }
 
-pub fn arbitrary_data() -> impl Strategy<Value = FilterData> {
+pub fn arbitrary() -> impl Strategy<Value = FilterData> {
     prop_oneof![
         Just(FilterData::BitShuffle),
         Just(FilterData::ByteShuffle),
@@ -114,27 +114,13 @@ pub fn arbitrary_data() -> impl Strategy<Value = FilterData> {
     ]
 }
 
-pub fn arbitrary_data_for_datatype(
+pub fn arbitrary_for_datatype(
     input_datatype: Datatype,
 ) -> impl Strategy<Value = FilterData> {
-    arbitrary_data()
+    arbitrary()
         .prop_filter("Filter does not accept input type", move |filter| {
             filter.transform_datatype(&input_datatype).is_some()
         })
-}
-
-pub fn arbitrary_for_datatype(
-    context: &Context,
-    input_datatype: Datatype,
-) -> impl Strategy<Value = TileDBResult<Filter>> {
-    arbitrary_data_for_datatype(input_datatype)
-        .prop_map(|filter| Filter::create(context, filter))
-}
-
-pub fn arbitrary(
-    context: &Context,
-) -> impl Strategy<Value = TileDBResult<Filter>> {
-    arbitrary_data().prop_map(|filter| Filter::create(context, filter))
 }
 
 fn arbitrary_pipeline(
@@ -144,66 +130,61 @@ fn arbitrary_pipeline(
     if nfilters == 0 {
         Just(VecDeque::new()).boxed()
     } else {
-        arbitrary_data_for_datatype(start).prop_flat_map(move |filter| {
-            /* the transform type must be Some per filter in `arbitrary_data` */
-            let next = filter.transform_datatype(&start).unwrap();
-            arbitrary_pipeline(next, nfilters - 1).bind().prop_map(move |mut filter_vec| {
-                filter_vec.push_front(filter.clone());
-                filter_vec
+        arbitrary_for_datatype(start)
+            .prop_flat_map(move |filter| {
+                /* the transform type must be Some per filter in `arbitrary` */
+                let next = filter.transform_datatype(&start).unwrap();
+                arbitrary_pipeline(next, nfilters - 1).bind().prop_map(
+                    move |mut filter_vec| {
+                        filter_vec.push_front(filter.clone());
+                        filter_vec
+                    },
+                )
             })
-        }).boxed()
+            .boxed()
     }
 }
 
 pub fn arbitrary_list_for_datatype(
-    context: &Context,
     datatype: Datatype,
-) -> impl Strategy<Value = TileDBResult<FilterList>> {
+) -> impl Strategy<Value = FilterListData> {
     const MIN_FILTERS: usize = 0;
     const MAX_FILTERS: usize = 4;
 
     (MIN_FILTERS..=MAX_FILTERS).prop_flat_map(move |nfilters| {
-        arbitrary_pipeline(datatype, nfilters).prop_map(move |filter_vec| {
-            let mut b = tiledb::filter_list::Builder::new(context)?;
+        arbitrary_pipeline(datatype, nfilters).prop_map(move |filter_deque| {
             let mut current_dt = datatype;
-            for filter in filter_vec.iter() {
+            for filter in filter_deque.iter() {
                 current_dt = if let Some(next_dt) =
                     filter.transform_datatype(&current_dt)
                 {
                     next_dt
                 } else {
-                    return Err(tiledb::error::Error::from(format!(
-                        "Error in filter pipeline construction: {} -> {:?}",
-                        datatype, filter_vec
-                    )));
+                    unreachable!("Error in filter pipeline construction: {:?} does not accept input type {} in pipeline {:?}",
+                        filter, current_dt, filter_deque)
                 }
             }
-            for filter in filter_vec {
-                b = b.add_filter(Filter::create(context, filter)?)?;
-            }
-            Ok(b.build())
+            filter_deque.into_iter().collect::<FilterListData>()
         })
     })
 }
 
-pub fn arbitrary_list(
-    context: &Context,
-) -> impl Strategy<Value = TileDBResult<FilterList>> {
-    crate::datatype::arbitrary()
-        .prop_flat_map(|dt| arbitrary_list_for_datatype(context, dt))
+pub fn arbitrary_list() -> impl Strategy<Value = FilterListData> {
+    crate::datatype::arbitrary().prop_flat_map(arbitrary_list_for_datatype)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tiledb::{Context, Factory};
 
     #[test]
     /// Test that the arbitrary filter construction always succeeds
     fn filter_arbitrary() {
         let ctx = Context::new().expect("Error creating context");
 
-        proptest!(|(filt in arbitrary(&ctx))| {
-            filt.expect("Error constructing arbitrary filter");
+        proptest!(|(filt in arbitrary())| {
+            filt.create(&ctx).expect("Error constructing arbitrary filter");
         });
     }
 
@@ -212,8 +193,8 @@ mod tests {
     fn filter_arbitrary_for_datatype() {
         let ctx = Context::new().expect("Error creating context");
 
-        proptest!(|((dt, filt) in crate::datatype::arbitrary().prop_flat_map(|dt| (Just(dt), arbitrary_for_datatype(&ctx, dt))))| {
-            let filt = filt.expect("Error constructing arbitrary filter");
+        proptest!(|((dt, filt) in crate::datatype::arbitrary().prop_flat_map(|dt| (Just(dt), arbitrary_for_datatype(dt))))| {
+            let filt = filt.create(&ctx).expect("Error constructing arbitrary filter");
 
             let filt_data = filt.filter_data().expect("Error reading filter data");
             assert!(filt_data.transform_datatype(&dt).is_some());
@@ -225,8 +206,8 @@ mod tests {
     fn filter_list_arbitrary() {
         let ctx = Context::new().expect("Error creating context");
 
-        proptest!(|(fl in arbitrary_list(&ctx))| {
-            fl.expect("Error constructing arbitrary filter list");
+        proptest!(|(fl in arbitrary_list())| {
+            fl.create(&ctx).expect("Error constructing arbitrary filter list");
         });
     }
 
@@ -235,8 +216,8 @@ mod tests {
     fn filter_list_arbitrary_for_datatype() {
         let ctx = Context::new().expect("Error creating context");
 
-        proptest!(|((dt, fl) in crate::datatype::arbitrary_implemented().prop_flat_map(|dt| (Just(dt), arbitrary_list_for_datatype(&ctx, dt))))| {
-            let fl = fl.expect("Error constructing arbitrary filter");
+        proptest!(|((dt, fl) in crate::datatype::arbitrary_implemented().prop_flat_map(|dt| (Just(dt), arbitrary_list_for_datatype(dt))))| {
+            let fl = fl.create(&ctx).expect("Error constructing arbitrary filter");
 
             let mut current_dt = dt;
 
@@ -267,8 +248,8 @@ mod tests {
     fn filter_eq_reflexivity() {
         let ctx = Context::new().expect("Error creating context");
 
-        proptest!(|(attr in arbitrary(&ctx))| {
-            let attr = attr.expect("Error constructing arbitrary filter");
+        proptest!(|(attr in arbitrary())| {
+            let attr = attr.create(&ctx).expect("Error constructing arbitrary filter");
             assert_eq!(attr, attr);
         });
     }


### PR DESCRIPTION
Prior to this pull request, our proptest strategies have generated our API structs directly - the Attribute, Dimension, Domain, Schema, etc.  This has led to a lot of difficulty as our strategies get more and more complex. Without being able to deeply clone an object we have no way to have a strategy depend on the contents of a Domain, for example, and we are reluctant to add a deep clone function.

This pull request modifies our strategies to instead produce a set of input values which can be used to construct our structures instead.  This way we can have no qualms about deep cloning, and we might even be able to benefit further from the new cloneable objects in the future.

There are other benefits briefly described in the shortcut story.

For each of our API objects, we add another companion structure which I have called `Data` - e.g. for `Attribute`, there is an `AttributeData`, and so on.  These companions implement `TryFrom` to be created from the thing they want to represent, and they implement a new trait `Factory` for creating objects of the thing they want to represent.  We use the former trait as a new way of implementing `Debug`, and we use the latter to create the structures from what we are given by proptest.

Finally, we see some payoff in the `tiledb_test::schema::arbitrary` strategy, which can now read the generated Domain in order to avoid choosing incompatible coordinate filters.

Resolves sc#43928.