### PR TITLE
Add comments to quickstart_dense.rs and also make Subarray::dimension_range_typed more flexible

### DIFF
--- a/tiledb/api/examples/quickstart_dense.rs
+++ b/tiledb/api/examples/quickstart_dense.rs
@@ -6,6 +6,7 @@ use tiledb::Result as TileDBResult;
 const QUICKSTART_DENSE_ARRAY_URI: &str = "quickstart_dense_array";
 const QUICKSTART_ATTRIBUTE_NAME: &str = "a";
 
+/// Returns whether the example array already exists
 fn array_exists() -> bool {
     let tdb = match tiledb::context::Context::new() {
         Err(_) => return false,
@@ -18,6 +19,12 @@ fn array_exists() -> bool {
     )
 }
 
+/// Creates a dense array at URI `QUICKSTART_DENSE_ARRAY_URI`.
+/// The array has two i32 dimensions ["rows", "columns"] with a single int32
+/// attribute "a" stored in each cell.
+/// Both "rows" and "columns" dimensions range from 1 to 4, and the tiles
+/// span all 4 elements on each dimension.
+/// Hence we have 16 cells of data and a single tile for the whole array.
 fn create_array() -> TileDBResult<()> {
     let tdb = tiledb::context::Context::new()?;
 
@@ -65,6 +72,12 @@ fn create_array() -> TileDBResult<()> {
     tiledb::Array::create(&tdb, QUICKSTART_DENSE_ARRAY_URI, schema)
 }
 
+/// Writes data into the array in row-major order from a 1D-array buffer.
+/// After the write, the contents of the array will be:
+/// [[ 1,  2,  3,  4],
+///  [ 5,  6,  7,  8],
+///  [ 9, 10, 11, 12],
+///  [13, 14, 15, 16]]
 fn write_array() -> TileDBResult<()> {
     let tdb = tiledb::context::Context::new()?;
 
@@ -88,6 +101,14 @@ fn write_array() -> TileDBResult<()> {
     query.submit().map(|_| ())
 }
 
+/// Query back a slice of our array and print the results to stdout.
+/// The slice on "rows" is [1, 2] and on "columns" is [2, 4],
+/// so the returned data should look like:
+/// [[ _,  2,  3,  4],
+///  [ _,  6,  7,  8],
+///  [ _,  _,  _,  _],
+///  [ _,  _,  _,  _]]]
+/// Data is emitted in row-major order, so this will print "2 3 4 6 7 8".
 fn read_array() -> TileDBResult<()> {
     let tdb = tiledb::context::Context::new()?;
 

--- a/tiledb/api/examples/quickstart_dense.rs
+++ b/tiledb/api/examples/quickstart_dense.rs
@@ -13,13 +13,11 @@ fn array_exists() -> bool {
         Ok(tdb) => tdb,
     };
 
-    matches!(
-        tdb.object_type(QUICKSTART_DENSE_ARRAY_URI),
-        Ok(Some(tiledb::context::ObjectType::Array))
-    )
+    tiledb::array::Array::exists(&tdb, QUICKSTART_DENSE_ARRAY_URI)
+        .expect("Error checking array existence")
 }
 
-/// Creates a dense array at URI `QUICKSTART_DENSE_ARRAY_URI`.
+/// Creates a dense array at URI `QUICKSTART_DENSE_ARRAY_URI()`.
 /// The array has two i32 dimensions ["rows", "columns"] with a single int32
 /// attribute "a" stored in each cell.
 /// Both "rows" and "columns" dimensions range from 1 to 4, and the tiles

--- a/tiledb/api/examples/quickstart_dense.rs
+++ b/tiledb/api/examples/quickstart_dense.rs
@@ -128,9 +128,9 @@ fn read_array() -> TileDBResult<()> {
                 results.as_mut_slice(),
             )?
             .add_subarray()?
-            .dimension_range_typed::<i32>(0, &[1, 2])?
+            .dimension_range_typed::<i32, _>("rows", &[1, 2])?
             .add_subarray()?
-            .dimension_range_typed::<i32>(1, &[2, 4])?
+            .dimension_range_typed::<i32, _>("columns", &[2, 4])?
             .build();
 
     query.submit()?;

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -13,7 +13,7 @@ pub mod schema;
 
 pub use attribute::{Attribute, AttributeData, Builder as AttributeBuilder};
 pub use dimension::{Builder as DimensionBuilder, Dimension, DimensionData};
-pub use domain::{Builder as DomainBuilder, Domain, DomainData};
+pub use domain::{Builder as DomainBuilder, DimensionKey, Domain, DomainData};
 pub use schema::{ArrayType, Builder as SchemaBuilder, Schema, SchemaData};
 
 pub enum Mode {

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -99,12 +99,15 @@ impl<'ctx> Array<'ctx> {
         *self.raw
     }
 
-    pub fn create(
+    pub fn create<S>(
         context: &'ctx Context,
-        name: &str,
+        name: S,
         schema: Schema,
-    ) -> TileDBResult<()> {
-        let c_name = cstring!(name);
+    ) -> TileDBResult<()>
+    where
+        S: AsRef<str>,
+    {
+        let c_name = cstring!(name.as_ref());
         if unsafe {
             ffi::tiledb_array_create(
                 context.capi(),
@@ -119,15 +122,28 @@ impl<'ctx> Array<'ctx> {
         }
     }
 
-    pub fn open(
+    pub fn exists<S>(context: &'ctx Context, uri: S) -> TileDBResult<bool>
+    where
+        S: AsRef<str>,
+    {
+        Ok(matches!(
+            context.object_type(uri)?,
+            Some(crate::context::ObjectType::Array)
+        ))
+    }
+
+    pub fn open<S>(
         context: &'ctx Context,
-        uri: &str,
+        uri: S,
         mode: Mode,
-    ) -> TileDBResult<Self> {
+    ) -> TileDBResult<Self>
+    where
+        S: AsRef<str>,
+    {
         let ctx = context.capi();
         let mut array_raw: *mut ffi::tiledb_array_t = std::ptr::null_mut();
 
-        let c_uri = cstring!(uri);
+        let c_uri = cstring!(uri.as_ref());
 
         if unsafe {
             ffi::tiledb_array_alloc(ctx, c_uri.as_ptr(), &mut array_raw)

--- a/tiledb/api/src/context.rs
+++ b/tiledb/api/src/context.rs
@@ -139,8 +139,11 @@ impl Context {
         }
     }
 
-    pub fn object_type(&self, name: &str) -> TileDBResult<Option<ObjectType>> {
-        let c_name = cstring!(name);
+    pub fn object_type<S>(&self, name: S) -> TileDBResult<Option<ObjectType>>
+    where
+        S: AsRef<str>,
+    {
+        let c_name = cstring!(name.as_ref());
         let mut c_objtype: ffi::tiledb_object_t = out_ptr!();
 
         let c_ret = unsafe {

--- a/tiledb/api/src/lib.rs
+++ b/tiledb/api/src/lib.rs
@@ -3,7 +3,7 @@ extern crate serde_json;
 extern crate tiledb_sys as ffi;
 
 macro_rules! cstring {
-    ($arg:ident) => {
+    ($arg:expr) => {
         match std::ffi::CString::new($arg) {
             Ok(c_arg) => c_arg,
             Err(nullity) => {


### PR DESCRIPTION
In a different branch I added `DimensionKey` to use the dimension range functions with an index or name lookup. This adds the same facility to `Subarray`.