### PR TITLE
Better programmatic information for Error type, and ensure Sync/Send

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,6 +1006,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tiledb"
 version = "0.1.0"
 dependencies = [
@@ -1013,6 +1033,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempdir",
+ "thiserror",
  "tiledb-sys",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+
+[[package]]
 name = "arrow"
 version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,6 +1035,7 @@ dependencies = [
 name = "tiledb"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "proptest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,6 +1048,7 @@ dependencies = [
 name = "tiledb-arrow"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "arrow",
  "arrow-schema",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.72"
 version = "0.1.0"
 
 [workspace.dependencies]
+anyhow = "1.0"
 serde_json = { version = "1.0.114", features = ["float_roundtrip"] }
 tiledb = { path = "tiledb/api", version = "0.1.0" }
 tiledb-sys = { path = "tiledb/sys", version = "0.1.0" }

--- a/tiledb/api/Cargo.toml
+++ b/tiledb/api/Cargo.toml
@@ -8,7 +8,7 @@ name = "tiledb"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = "1.0.58"

--- a/tiledb/api/Cargo.toml
+++ b/tiledb/api/Cargo.toml
@@ -8,6 +8,7 @@ name = "tiledb"
 path = "src/lib.rs"
 
 [dependencies]
+anyhow = "1.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = "1.0.58"

--- a/tiledb/api/Cargo.toml
+++ b/tiledb/api/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/lib.rs"
 [dependencies]
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { workspace = true }
+thiserror = "1.0.58"
 tiledb-sys = { workspace = true }
 
 [dev-dependencies]

--- a/tiledb/api/src/array/attribute.rs
+++ b/tiledb/api/src/array/attribute.rs
@@ -541,10 +541,15 @@ impl<'ctx> Factory<'ctx> for AttributeData {
         }
         if let Some(ref fill) = self.fill {
             b = fn_typed!(self.datatype, AT, {
-                let fill_value: AT =
-                    serde_json::from_value::<AT>(fill.data.clone()).map_err(
-                        |e| Error::Deserialization("fill value", anyhow!(e)),
-                    )?;
+                let fill_value: AT = serde_json::from_value::<AT>(
+                    fill.data.clone(),
+                )
+                .map_err(|e| {
+                    Error::Deserialization(
+                        format!("attribute '{}' fill value", self.name),
+                        anyhow!(e),
+                    )
+                })?;
                 if let Some(fill_nullability) = fill.nullability {
                     b.fill_value_nullability::<AT>(fill_value, fill_nullability)
                 } else {

--- a/tiledb/api/src/array/attribute.rs
+++ b/tiledb/api/src/array/attribute.rs
@@ -5,6 +5,7 @@ use std::convert::From;
 use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::ops::Deref;
 
+use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -540,15 +541,10 @@ impl<'ctx> Factory<'ctx> for AttributeData {
         }
         if let Some(ref fill) = self.fill {
             b = fn_typed!(self.datatype, AT, {
-                let fill_value: AT = serde_json::from_value::<AT>(
-                    fill.data.clone(),
-                )
-                .map_err(|e| {
-                    Error::from(format!(
-                        "Error deserializing fill value: {}",
-                        e
-                    ))
-                })?;
+                let fill_value: AT =
+                    serde_json::from_value::<AT>(fill.data.clone()).map_err(
+                        |e| Error::Deserialization("fill value", anyhow!(e)),
+                    )?;
                 if let Some(fill_nullability) = fill.nullability {
                     b.fill_value_nullability::<AT>(fill_value, fill_nullability)
                 } else {

--- a/tiledb/api/src/array/dimension.rs
+++ b/tiledb/api/src/array/dimension.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::ops::Deref;
 
+use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -365,21 +366,24 @@ impl<'ctx> Factory<'ctx> for DimensionData {
         let b = fn_typed!(self.datatype, DT, {
             let d0 = serde_json::from_value::<DT>(self.domain[0].clone())
                 .map_err(|e| {
-                    Error::from(format!(
-                        "Error deserializing domain lower bound: {}",
-                        e
-                    ))
+                    Error::Deserialization(
+                        format!("dimension '{}' lower bound", self.name),
+                        anyhow!(e),
+                    )
                 })?;
             let d1 = serde_json::from_value::<DT>(self.domain[1].clone())
                 .map_err(|e| {
-                    Error::from(format!(
-                        "Error deserializing domain lower bound: {}",
-                        e
-                    ))
+                    Error::Deserialization(
+                        format!("dimension '{}' upper bound", self.name),
+                        anyhow!(e),
+                    )
                 })?;
             let extent = serde_json::from_value::<DT>(self.extent.clone())
                 .map_err(|e| {
-                    Error::from(format!("Error deserializing extent: {}", e))
+                    Error::Deserialization(
+                        format!("dimension '{}' extent", self.name),
+                        anyhow!(e),
+                    )
                 })?;
             Builder::new::<DT>(
                 context,

--- a/tiledb/api/src/array/domain.rs
+++ b/tiledb/api/src/array/domain.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::ops::Deref;
 
+use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -128,12 +129,11 @@ impl<'ctx> Domain<'ctx> {
 
         let c_ret = match key.into() {
             DimensionKey::Index(idx) => {
-                let c_idx: u32 = idx.try_into().map_err(|e| {
-                    crate::error::Error::from(format!(
-                        "Invalid dimension: {}",
-                        e
-                    ))
-                })?;
+                let c_idx: u32 = idx.try_into().map_err(
+                    |e: <usize as TryInto<u32>>::Error| {
+                        crate::error::Error::InvalidArgument(anyhow!(e))
+                    },
+                )?;
                 unsafe {
                     ffi::tiledb_domain_get_dimension_from_index(
                         c_context,

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -61,7 +61,10 @@ impl TryFrom<ffi::tiledb_layout_t> for Layout {
             ffi::tiledb_layout_t_TILEDB_ROW_MAJOR => Ok(Layout::RowMajor),
             ffi::tiledb_layout_t_TILEDB_COL_MAJOR => Ok(Layout::ColumnMajor),
             ffi::tiledb_layout_t_TILEDB_HILBERT => Ok(Layout::Hilbert),
-            _ => Err(Self::Error::from(format!("Invalid layout: {}", value))),
+            _ => Err(Self::Error::LibTileDB(format!(
+                "Invalid layout: {}",
+                value
+            ))),
         }
     }
 }

--- a/tiledb/api/src/array/schema.rs
+++ b/tiledb/api/src/array/schema.rs
@@ -34,9 +34,10 @@ impl TryFrom<ffi::tiledb_array_type_t> for ArrayType {
         match value {
             ffi::tiledb_array_type_t_TILEDB_DENSE => Ok(ArrayType::Dense),
             ffi::tiledb_array_type_t_TILEDB_SPARSE => Ok(ArrayType::Sparse),
-            _ => {
-                Err(Self::Error::from(format!("Invalid array type: {}", value)))
-            }
+            _ => Err(Self::Error::LibTileDB(format!(
+                "Invalid array type: {}",
+                value
+            ))),
         }
     }
 }

--- a/tiledb/api/src/config.rs
+++ b/tiledb/api/src/config.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use crate::error::Error;
+use crate::error::{Error, RawError};
 use crate::Result as TileDBResult;
 
 pub(crate) enum RawConfig {
@@ -68,7 +68,7 @@ impl Config {
                 raw: RawConfig::Owned(c_cfg),
             })
         } else {
-            Err(Error::from(c_err))
+            Err(Error::from(RawError::Owned(c_err)))
         }
     }
 
@@ -90,7 +90,7 @@ impl Config {
         if res == ffi::TILEDB_OK {
             Ok(())
         } else {
-            Err(Error::from(c_err))
+            Err(Error::from(RawError::Owned(c_err)))
         }
     }
 
@@ -113,7 +113,7 @@ impl Config {
         } else if res == ffi::TILEDB_OK {
             Ok(None)
         } else {
-            Err(Error::from(c_err))
+            Err(Error::from(RawError::Owned(c_err)))
         }
     }
 
@@ -131,7 +131,7 @@ impl Config {
         if res == ffi::TILEDB_OK {
             Ok(())
         } else {
-            Err(Error::from(c_err))
+            Err(Error::from(RawError::Owned(c_err)))
         }
     }
 
@@ -149,7 +149,7 @@ impl Config {
         if res == ffi::TILEDB_OK {
             Ok(())
         } else {
-            Err(Error::from(c_err))
+            Err(Error::from(RawError::Owned(c_err)))
         }
     }
 
@@ -167,7 +167,7 @@ impl Config {
         if res == ffi::TILEDB_OK {
             Ok(())
         } else {
-            Err(Error::from(c_err))
+            Err(Error::from(RawError::Owned(c_err)))
         }
     }
 }

--- a/tiledb/api/src/context.rs
+++ b/tiledb/api/src/context.rs
@@ -53,7 +53,7 @@ impl Context {
                 raw: RawContext::Owned(c_ctx),
             })
         } else {
-            Err(Error::from("Error creating context."))
+            Err(Error::LibTileDB(String::from("Could not create context")))
         }
     }
 
@@ -98,9 +98,10 @@ impl Context {
     }
 
     pub fn expect_last_error(&self) -> Error {
-        self.get_last_error().unwrap_or(Error::from(
-            "TileDB internal error: expected error data but found none",
-        ))
+        self.get_last_error()
+            .unwrap_or(Error::Internal(String::from(
+                "libtiledb: expected error data but found none",
+            )))
     }
 
     pub fn is_supported_fs(&self, fs: ffi::Filesystem) -> bool {

--- a/tiledb/api/src/context.rs
+++ b/tiledb/api/src/context.rs
@@ -2,7 +2,7 @@ use std::convert::From;
 use std::ops::Deref;
 
 use crate::config::{Config, RawConfig};
-use crate::error::Error;
+use crate::error::{Error, RawError};
 use crate::Result as TileDBResult;
 
 pub enum ObjectType {
@@ -91,7 +91,7 @@ impl Context {
         let res =
             unsafe { ffi::tiledb_ctx_get_last_error(*self.raw, &mut c_err) };
         if res == ffi::TILEDB_OK && !c_err.is_null() {
-            Some(Error::from(c_err))
+            Some(Error::from(RawError::Owned(c_err)))
         } else {
             None
         }

--- a/tiledb/api/src/datatype.rs
+++ b/tiledb/api/src/datatype.rs
@@ -2,6 +2,7 @@ use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 
 use serde::{Deserialize, Serialize};
 
+use crate::error::DatatypeErrorKind;
 use crate::Result as TileDBResult;
 
 #[derive(Clone, Copy, Deserialize, Eq, PartialEq, Serialize)]
@@ -472,10 +473,9 @@ impl TryFrom<ffi::tiledb_datatype_t> for Datatype {
             ffi::tiledb_datatype_t_TILEDB_GEOM_WKB => Datatype::GeometryWkb,
             ffi::tiledb_datatype_t_TILEDB_GEOM_WKT => Datatype::GeometryWkt,
             _ => {
-                return Err(crate::error::Error::from(format!(
-                    "Invalid datatype: {}",
-                    value
-                )))
+                return Err(crate::error::Error::Datatype(
+                    DatatypeErrorKind::InvalidDiscriminant(value as u64),
+                ))
             }
         })
     }

--- a/tiledb/api/src/error.rs
+++ b/tiledb/api/src/error.rs
@@ -56,36 +56,17 @@ impl Display for DatatypeErrorKind {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, thiserror::Error)]
 pub enum Error {
     /// Error received from the libtiledb backend
+    #[error("libtiledb error: {0}")]
     LibTileDB(String),
     /// Error with datatype handling
+    #[error("Datatype error: {0}")]
     Datatype(DatatypeErrorKind),
     /// Any error which cannot be categorized as any of the above
+    #[error("{0}")]
     Other(String),
-}
-
-impl Error {
-    pub fn get_message(&self) -> String {
-        match self {
-            Error::LibTileDB(message) => message.clone(),
-            Error::Other(message) => message.clone(),
-            Error::Datatype(kind) => kind.to_string(),
-        }
-    }
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        write!(f, "{}", self.get_message())
-    }
-}
-
-impl From<Error> for String {
-    fn from(error: Error) -> String {
-        error.get_message()
-    }
 }
 
 impl From<RawError> for Error {
@@ -128,8 +109,6 @@ impl Serialize for Error {
     where
         S: Serializer,
     {
-        format!("<{}>", self.get_message()).serialize(serializer)
+        format!("<{}>", self.to_string()).serialize(serializer)
     }
 }
-
-impl std::error::Error for Error {}

--- a/tiledb/api/src/error.rs
+++ b/tiledb/api/src/error.rs
@@ -25,10 +25,27 @@ impl Drop for RawError {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
+pub enum DatatypeErrorKind {
+    InvalidDiscriminant(u64),
+}
+
+impl Display for DatatypeErrorKind {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        match self {
+            DatatypeErrorKind::InvalidDiscriminant(value) => {
+                write!(f, "Invalid datatype: {}", value)
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
 pub enum Error {
     /// Error received from the libtiledb backend
     LibTileDB(String),
+    /// Error with datatype handling
+    Datatype(DatatypeErrorKind),
     /// Any error which cannot be categorized as any of the above
     Other(String),
 }
@@ -38,13 +55,8 @@ impl Error {
         match self {
             Error::LibTileDB(message) => message.clone(),
             Error::Other(message) => message.clone(),
+            Error::Datatype(kind) => kind.to_string(),
         }
-    }
-}
-
-impl Debug for Error {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        write!(f, "{}", self.get_message())
     }
 }
 

--- a/tiledb/api/src/error.rs
+++ b/tiledb/api/src/error.rs
@@ -26,13 +26,19 @@ impl Drop for RawError {
 }
 
 #[derive(Clone)]
-pub struct Error {
-    message: String,
+pub enum Error {
+    /// Error received from the libtiledb backend
+    LibTileDB(String),
+    /// Any error which cannot be categorized as any of the above
+    Other(String),
 }
 
 impl Error {
     pub fn get_message(&self) -> String {
-        self.message.clone()
+        match self {
+            Error::LibTileDB(message) => message.clone(),
+            Error::Other(message) => message.clone(),
+        }
     }
 }
 
@@ -69,7 +75,7 @@ impl From<RawError> for Error {
         } else {
             String::from("Failed to retrieve an error message from TileDB.")
         };
-        Error { message }
+        Error::LibTileDB(message)
     }
 }
 
@@ -78,18 +84,14 @@ where
     S: AsRef<str>,
 {
     fn from(s: S) -> Error {
-        Error {
-            message: String::from(s.as_ref()),
-        }
+        Error::Other(String::from(s.as_ref()))
     }
 }
 
 impl FromStr for Error {
     type Err = (); /* always succeeds */
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Error {
-            message: String::from(s),
-        })
+        Ok(Error::Other(String::from(s)))
     }
 }
 

--- a/tiledb/api/src/error.rs
+++ b/tiledb/api/src/error.rs
@@ -56,7 +56,7 @@ impl Display for DatatypeErrorKind {
     }
 }
 
-#[derive(Clone, Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Error received from the libtiledb backend
     #[error("libtiledb error: {0}")]
@@ -64,6 +64,9 @@ pub enum Error {
     /// Error with datatype handling
     #[error("Datatype error: {0}")]
     Datatype(DatatypeErrorKind),
+    /// Error deserializing data
+    #[error("Deserialization error: {0}: {1}")]
+    Deserialization(&'static str, #[source] anyhow::Error),
     /// Any error which cannot be categorized as any of the above
     #[error("{0}")]
     Other(String),

--- a/tiledb/api/src/error.rs
+++ b/tiledb/api/src/error.rs
@@ -6,6 +6,8 @@ use std::str::FromStr;
 
 use serde::{Serialize, Serializer};
 
+use crate::Datatype;
+
 pub(crate) enum RawError {
     Owned(*mut ffi::tiledb_error_t),
 }
@@ -28,6 +30,10 @@ impl Drop for RawError {
 #[derive(Clone, Debug)]
 pub enum DatatypeErrorKind {
     InvalidDiscriminant(u64),
+    TypeMismatch {
+        user_type: &'static str,
+        tiledb_type: Datatype,
+    },
 }
 
 impl Display for DatatypeErrorKind {
@@ -35,6 +41,16 @@ impl Display for DatatypeErrorKind {
         match self {
             DatatypeErrorKind::InvalidDiscriminant(value) => {
                 write!(f, "Invalid datatype: {}", value)
+            }
+            DatatypeErrorKind::TypeMismatch {
+                user_type,
+                tiledb_type,
+            } => {
+                write!(
+                    f,
+                    "Type mismatch: requested {}, but found {}",
+                    user_type, tiledb_type
+                )
             }
         }
     }

--- a/tiledb/api/src/lib.rs
+++ b/tiledb/api/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate anyhow;
 extern crate serde;
 extern crate serde_json;
 extern crate thiserror;

--- a/tiledb/api/src/lib.rs
+++ b/tiledb/api/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate serde;
 extern crate serde_json;
+extern crate thiserror;
 extern crate tiledb_sys as ffi;
 
 macro_rules! cstring {

--- a/tiledb/api/src/lib.rs
+++ b/tiledb/api/src/lib.rs
@@ -9,7 +9,9 @@ macro_rules! cstring {
         match std::ffi::CString::new($arg) {
             Ok(c_arg) => c_arg,
             Err(nullity) => {
-                return Err(crate::error::Error::from(format!("{}", nullity)))
+                return Err(crate::error::Error::InvalidArgument(
+                    anyhow::anyhow!(nullity),
+                ))
             }
         }
     };

--- a/tiledb/api/src/vfs.rs
+++ b/tiledb/api/src/vfs.rs
@@ -631,7 +631,6 @@ impl<'ctx> VFSHandle<'ctx> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::error;
     use tempdir::TempDir;
 
     #[test]
@@ -648,12 +647,7 @@ mod tests {
         let cfg = Config::new()?;
         let vfs = VFS::new(&ctx, &cfg)?;
 
-        let tmp_dir = TempDir::new("test_rs_bdelit").map_err(|e| {
-            error::Error::from(format!(
-                "Error creating temporary directory: {}",
-                e
-            ))
-        })?;
+        let tmp_dir = TempDir::new("test_rs_bdelit").unwrap();
 
         let tmp_uri = String::from("file://")
             + tmp_dir.path().to_str().expect("Error creating tmp_uri");
@@ -730,12 +724,7 @@ mod tests {
         let cfg = Config::new()?;
         let vfs = VFS::new(&ctx, &cfg)?;
 
-        let tmp_dir = TempDir::new("test_rs_bdelit").map_err(|e| {
-            error::Error::from(format!(
-                "Error creating temporary directory: {}",
-                e
-            ))
-        })?;
+        let tmp_dir = TempDir::new("test_rs_bdelit").unwrap();
 
         let file1_uri = String::from("file://")
             + tmp_dir
@@ -855,12 +844,7 @@ mod tests {
         let cfg = Config::new()?;
         let vfs = VFS::new(&ctx, &cfg)?;
 
-        let tmp_dir = TempDir::new("test_rs_bdelit").map_err(|e| {
-            error::Error::from(format!(
-                "Error creating temporary directory: {}",
-                e
-            ))
-        })?;
+        let tmp_dir = TempDir::new("test_rs_bdelit").unwrap();
 
         create_test_dir_structure(&vfs, &tmp_dir)?;
 
@@ -891,12 +875,7 @@ mod tests {
         let cfg = Config::new()?;
         let vfs = VFS::new(&ctx, &cfg)?;
 
-        let tmp_dir = TempDir::new("test_rs_bdelit").map_err(|e| {
-            error::Error::from(format!(
-                "Error creating temporary directory: {}",
-                e
-            ))
-        })?;
+        let tmp_dir = TempDir::new("test_rs_bdelit").unwrap();
 
         let tmp_uri = tmp_dir.path().to_str().expect("Error getting tmp_uri");
         let mut count: u64 = 0;
@@ -922,12 +901,7 @@ mod tests {
         let cfg = Config::new()?;
         let vfs = VFS::new(&ctx, &cfg)?;
 
-        let tmp_dir = TempDir::new("test_rs_bdelit").map_err(|e| {
-            error::Error::from(format!(
-                "Error creating temporary directory: {}",
-                e
-            ))
-        })?;
+        let tmp_dir = TempDir::new("test_rs_bdelit").unwrap();
 
         create_test_dir_structure(&vfs, &tmp_dir)?;
 

--- a/tiledb/arrow/Cargo.toml
+++ b/tiledb/arrow/Cargo.toml
@@ -4,6 +4,7 @@ version = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+anyhow = { workspace = true }
 arrow = { version = "50.0.0", features = ["prettyprint"] }
 arrow-schema = { version = "50.0.0", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }

--- a/tiledb/arrow/src/lib.rs
+++ b/tiledb/arrow/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate anyhow;
 extern crate arrow;
 extern crate arrow_schema;
 extern crate serde;


### PR DESCRIPTION
This story is mostly about ensuring Sync and Send for our custom Error type.  To do that, we must remove the `*mut ffi::` raw pointer.  And then, since we're in the area, we can update our Error to have less reliance, a practice which is discouraged in the Rust documentation.

To that end, we change `Error` to be an `enum` for different error classes, and remove `From<String>`.

We add the dependency `thiserror` for use with our Error type, and add `anyhow` to generalize errors coming from other crates (such as with deserialization).

Resolves sc#44032.