### PR TITLE
capi_return function, ContextBound trait, fix methods which do not return Result

### DIFF
--- a/tiledb/api/src/array/dimension.rs
+++ b/tiledb/api/src/array/dimension.rs
@@ -74,7 +74,7 @@ impl<'ctx> Dimension<'ctx> {
             )
         })?;
 
-        Ok(Datatype::try_from(c_datatype)?)
+        Datatype::try_from(c_datatype)
     }
 
     pub fn cell_val_num(&self) -> TileDBResult<u32> {

--- a/tiledb/api/src/array/dimension.rs
+++ b/tiledb/api/src/array/dimension.rs
@@ -5,7 +5,7 @@ use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use crate::context::Context;
+use crate::context::{CApiInterface, Context, ContextBound};
 use crate::convert::CAPIConverter;
 use crate::error::Error;
 use crate::filter_list::{FilterList, FilterListData, RawFilterList};
@@ -36,6 +36,12 @@ pub struct Dimension<'ctx> {
     pub(crate) raw: RawDimension,
 }
 
+impl<'ctx> ContextBound<'ctx> for Dimension<'ctx> {
+    fn context(&self) -> &'ctx Context {
+        self.context
+    }
+}
+
 impl<'ctx> Dimension<'ctx> {
     pub(crate) fn capi(&self) -> *mut ffi::tiledb_dimension_t {
         *self.raw
@@ -49,47 +55,37 @@ impl<'ctx> Dimension<'ctx> {
     pub fn name(&self) -> TileDBResult<String> {
         let c_context = self.context.capi();
         let mut c_name = std::ptr::null::<std::ffi::c_char>();
-        let res = unsafe {
+        self.capi_return(unsafe {
             ffi::tiledb_dimension_get_name(c_context, *self.raw, &mut c_name)
-        };
-        if res == ffi::TILEDB_OK {
-            let c_name = unsafe { std::ffi::CStr::from_ptr(c_name) };
-            Ok(String::from(c_name.to_string_lossy()))
-        } else {
-            Err(self.context.expect_last_error())
-        }
+        })?;
+        let c_name = unsafe { std::ffi::CStr::from_ptr(c_name) };
+        Ok(String::from(c_name.to_string_lossy()))
     }
 
-    pub fn datatype(&self) -> Datatype {
+    pub fn datatype(&self) -> TileDBResult<Datatype> {
         let c_context = self.context.capi();
         let c_dimension = self.capi();
         let mut c_datatype: ffi::tiledb_datatype_t = out_ptr!();
-        let c_ret = unsafe {
+        self.capi_return(unsafe {
             ffi::tiledb_dimension_get_type(
                 c_context,
                 c_dimension,
                 &mut c_datatype,
             )
-        };
+        })?;
 
-        assert_eq!(ffi::TILEDB_OK, c_ret);
-
-        Datatype::try_from(c_datatype).expect("Invalid dimension type")
+        Ok(Datatype::try_from(c_datatype)?)
     }
 
     pub fn cell_val_num(&self) -> TileDBResult<u32> {
         let c_context = self.context.capi();
         let mut c_num: std::ffi::c_uint = 0;
-        let res = unsafe {
+        self.capi_return(unsafe {
             ffi::tiledb_dimension_get_cell_val_num(
                 c_context, *self.raw, &mut c_num,
             )
-        };
-        if res == ffi::TILEDB_OK {
-            Ok(c_num as u32)
-        } else {
-            Err(self.context.expect_last_error())
-        }
+        })?;
+        Ok(c_num as u32)
     }
 
     pub fn domain<Conv: CAPIConverter>(&self) -> TileDBResult<[Conv; 2]> {
@@ -97,16 +93,13 @@ impl<'ctx> Dimension<'ctx> {
         let c_dimension = self.capi();
         let mut c_domain_ptr: *const std::ffi::c_void = out_ptr!();
 
-        let c_ret = unsafe {
+        self.capi_return(unsafe {
             ffi::tiledb_dimension_get_domain(
                 c_context,
                 c_dimension,
                 &mut c_domain_ptr,
             )
-        };
-
-        // the only errors are possible via mis-use of the C API, which Rust prevents
-        assert_eq!(ffi::TILEDB_OK, c_ret);
+        })?;
 
         let c_domain: &[Conv::CAPIType; 2] =
             unsafe { &*c_domain_ptr.cast::<[Conv::CAPIType; 2]>() };
@@ -120,41 +113,34 @@ impl<'ctx> Dimension<'ctx> {
         let c_dimension = self.capi();
         let mut c_extent_ptr: *const ::std::ffi::c_void = out_ptr!();
 
-        let c_ret = unsafe {
+        self.capi_return(unsafe {
             ffi::tiledb_dimension_get_tile_extent(
                 c_context,
                 c_dimension,
                 &mut c_extent_ptr,
             )
-        };
-        if c_ret == ffi::TILEDB_OK {
-            let c_extent = unsafe { &*c_extent_ptr.cast::<Conv::CAPIType>() };
-            Ok(Conv::to_rust(c_extent))
-        } else {
-            Err(self.context.expect_last_error())
-        }
+        })?;
+        let c_extent = unsafe { &*c_extent_ptr.cast::<Conv::CAPIType>() };
+        Ok(Conv::to_rust(c_extent))
     }
 
-    pub fn filters(&self) -> FilterList {
+    pub fn filters(&self) -> TileDBResult<FilterList> {
         let mut c_fl: *mut ffi::tiledb_filter_list_t = out_ptr!();
 
         let c_context = self.context.capi();
         let c_dimension = self.capi();
-        let c_ret = unsafe {
+        self.capi_return(unsafe {
             ffi::tiledb_dimension_get_filter_list(
                 c_context,
                 c_dimension,
                 &mut c_fl,
             )
-        };
+        })?;
 
-        // only fails if dimension is invalid, which Rust API will prevent
-        assert_eq!(ffi::TILEDB_OK, c_ret);
-
-        FilterList {
+        Ok(FilterList {
             context: self.context,
             raw: RawFilterList::Owned(c_fl),
-        }
+        })
     }
 }
 
@@ -171,55 +157,18 @@ impl<'ctx> Debug for Dimension<'ctx> {
 
 impl<'c1, 'c2> PartialEq<Dimension<'c2>> for Dimension<'c1> {
     fn eq(&self, other: &Dimension<'c2>) -> bool {
-        let name_match = match (self.name(), other.name()) {
-            (Ok(mine), Ok(theirs)) => mine == theirs,
-            _ => false,
-        };
-        if !name_match {
-            return false;
-        }
+        eq_helper!(self.name(), other.name());
+        eq_helper!(self.datatype(), other.datatype());
+        eq_helper!(self.cell_val_num(), other.cell_val_num());
+        eq_helper!(self.filters(), other.filters());
 
-        let type_match = self.datatype() == other.datatype();
-        if !type_match {
-            return false;
-        }
+        fn_typed!(self.datatype().unwrap(), DT, {
+            eq_helper!(self.domain::<DT>(), other.domain::<DT>())
+        });
 
-        let cell_val_match = match (self.cell_val_num(), other.cell_val_num()) {
-            (Ok(mine), Ok(theirs)) => mine == theirs,
-            _ => false,
-        };
-        if !cell_val_match {
-            return false;
-        }
-
-        let domain_match = fn_typed!(
-            self.datatype(),
-            DT,
-            match (self.domain::<DT>(), other.domain::<DT>()) {
-                (Ok(mine), Ok(theirs)) => mine == theirs,
-                _ => false,
-            }
-        );
-        if !domain_match {
-            return false;
-        }
-
-        let extent_match = fn_typed!(
-            self.datatype(),
-            DT,
-            match (self.extent::<DT>(), other.extent::<DT>()) {
-                (Ok(mine), Ok(theirs)) => mine == theirs,
-                _ => false,
-            }
-        );
-        if !extent_match {
-            return false;
-        }
-
-        let filters_match = self.filters() == other.filters();
-        if !filters_match {
-            return false;
-        }
+        fn_typed!(self.datatype().unwrap(), DT, {
+            eq_helper!(self.extent::<DT>(), other.extent::<DT>())
+        });
 
         true
     }
@@ -227,6 +176,12 @@ impl<'c1, 'c2> PartialEq<Dimension<'c2>> for Dimension<'c1> {
 
 pub struct Builder<'ctx> {
     dim: Dimension<'ctx>,
+}
+
+impl<'ctx> ContextBound<'ctx> for Builder<'ctx> {
+    fn context(&self) -> &'ctx Context {
+        self.dim.context
+    }
 }
 
 impl<'ctx> Builder<'ctx> {
@@ -251,7 +206,7 @@ impl<'ctx> Builder<'ctx> {
         let mut c_dimension: *mut ffi::tiledb_dimension_t =
             std::ptr::null_mut();
 
-        if unsafe {
+        context.capi_return(unsafe {
             ffi::tiledb_dimension_alloc(
                 c_context,
                 c_name.as_ptr(),
@@ -261,17 +216,13 @@ impl<'ctx> Builder<'ctx> {
                 &c_extent as *const <Conv>::CAPIType as *const std::ffi::c_void,
                 &mut c_dimension,
             )
-        } == ffi::TILEDB_OK
-        {
-            Ok(Builder {
-                dim: Dimension {
-                    context,
-                    raw: RawDimension::Owned(c_dimension),
-                },
-            })
-        } else {
-            Err(context.expect_last_error())
-        }
+        })?;
+        Ok(Builder {
+            dim: Dimension {
+                context,
+                raw: RawDimension::Owned(c_dimension),
+            },
+        })
     }
 
     pub fn context(&self) -> &'ctx Context {
@@ -285,18 +236,14 @@ impl<'ctx> Builder<'ctx> {
     pub fn cell_val_num(self, num: u32) -> TileDBResult<Self> {
         let c_context = self.dim.context.capi();
         let c_num = num as std::ffi::c_uint;
-        let res = unsafe {
+        self.capi_return(unsafe {
             ffi::tiledb_dimension_set_cell_val_num(
                 c_context,
                 *self.dim.raw,
                 c_num,
             )
-        };
-        if res == ffi::TILEDB_OK {
-            Ok(self)
-        } else {
-            Err(self.dim.context.expect_last_error())
-        }
+        })?;
+        Ok(self)
     }
 
     pub fn filters(self, filters: FilterList) -> TileDBResult<Self> {
@@ -304,14 +251,10 @@ impl<'ctx> Builder<'ctx> {
         let c_dimension = self.dim.capi();
         let c_fl = filters.capi();
 
-        if unsafe {
+        self.capi_return(unsafe {
             ffi::tiledb_dimension_set_filter_list(c_context, c_dimension, c_fl)
-        } == ffi::TILEDB_OK
-        {
-            Ok(self)
-        } else {
-            Err(self.dim.context.expect_last_error())
-        }
+        })?;
+        Ok(self)
     }
 
     pub fn build(self) -> Dimension<'ctx> {
@@ -340,7 +283,7 @@ impl<'ctx> TryFrom<&Dimension<'ctx>> for DimensionData {
     type Error = crate::error::Error;
 
     fn try_from(dim: &Dimension<'ctx>) -> TileDBResult<Self> {
-        let datatype = dim.datatype();
+        let datatype = dim.datatype()?;
         let (domain, extent) = fn_typed!(datatype, DT, {
             let domain = dim.domain::<DT>()?;
             (
@@ -354,7 +297,7 @@ impl<'ctx> TryFrom<&Dimension<'ctx>> for DimensionData {
             domain,
             extent,
             cell_val_num: Some(dim.cell_val_num()?),
-            filters: FilterListData::try_from(&dim.filters())?,
+            filters: FilterListData::try_from(&dim.filters()?)?,
         })
     }
 }
@@ -479,7 +422,7 @@ mod tests {
             .unwrap()
             .build();
 
-            assert_eq!(Datatype::Int32, dim.datatype());
+            assert_eq!(Datatype::Int32, dim.datatype().unwrap());
 
             let domain_out = dim.domain::<i32>().unwrap();
             assert_eq!(domain_in[0], domain_out[0]);
@@ -551,7 +494,7 @@ mod tests {
             .unwrap()
             .into();
 
-            let fl = dimension.filters();
+            let fl = dimension.filters().unwrap();
             assert_eq!(0, fl.get_num_filters().unwrap());
         }
 
@@ -579,7 +522,7 @@ mod tests {
             .unwrap()
             .into();
 
-            let fl = dimension.filters();
+            let fl = dimension.filters().unwrap();
             assert_eq!(1, fl.get_num_filters().unwrap());
 
             let outlz4 = fl.get_filter(0).unwrap();

--- a/tiledb/api/src/array/domain.rs
+++ b/tiledb/api/src/array/domain.rs
@@ -8,7 +8,7 @@ use serde_json::json;
 use crate::array::{
     dimension::DimensionData, dimension::RawDimension, Dimension,
 };
-use crate::context::{CApiBound, Context, ContextBound};
+use crate::context::{CApiInterface, Context, ContextBound};
 use crate::{Factory, Result as TileDBResult};
 
 pub(crate) enum RawDomain {

--- a/tiledb/api/src/array/schema.rs
+++ b/tiledb/api/src/array/schema.rs
@@ -149,7 +149,7 @@ impl<'ctx> Schema<'ctx> {
             )
         })?;
 
-        Ok(ArrayType::try_from(c_atype)?)
+        ArrayType::try_from(c_atype)
     }
 
     pub fn capacity(&self) -> TileDBResult<u64> {
@@ -179,7 +179,7 @@ impl<'ctx> Schema<'ctx> {
             )
         })?;
 
-        Ok(Layout::try_from(c_cell_order)?)
+        Layout::try_from(c_cell_order)
     }
 
     pub fn tile_order(&self) -> TileDBResult<Layout> {
@@ -194,7 +194,7 @@ impl<'ctx> Schema<'ctx> {
             )
         })?;
 
-        Ok(Layout::try_from(c_tile_order)?)
+        Layout::try_from(c_tile_order)
     }
 
     pub fn allows_duplicates(&self) -> TileDBResult<bool> {

--- a/tiledb/api/src/array/schema.rs
+++ b/tiledb/api/src/array/schema.rs
@@ -693,11 +693,11 @@ mod tests {
         let domain = schema.domain().expect("Error reading domain");
 
         let rows = domain.dimension(0).expect("Error reading rows dimension");
-        assert_eq!(Datatype::Int32, rows.datatype());
+        assert_eq!(Datatype::Int32, rows.datatype().unwrap());
         // TODO: add method to check min/max
 
         let cols = domain.dimension(1).expect("Error reading cols dimension");
-        assert_eq!(Datatype::Int32, rows.datatype());
+        assert_eq!(Datatype::Int32, rows.datatype().unwrap());
         // TODO: add method to check min/max
 
         let rows_domain = rows.domain::<i32>().unwrap();

--- a/tiledb/api/src/array/schema.rs
+++ b/tiledb/api/src/array/schema.rs
@@ -9,7 +9,7 @@ use serde_json::json;
 use crate::array::attribute::{AttributeData, RawAttribute};
 use crate::array::domain::{DomainData, RawDomain};
 use crate::array::{Attribute, Domain, Layout};
-use crate::context::Context;
+use crate::context::{CApiBound, Context, ContextBound};
 use crate::filter_list::{FilterList, FilterListData, RawFilterList};
 use crate::{Factory, Result as TileDBResult};
 
@@ -77,6 +77,12 @@ pub struct Schema<'ctx> {
     raw: RawSchema,
 }
 
+impl<'ctx> ContextBound<'ctx> for Schema<'ctx> {
+    fn context(&self) -> &'ctx Context {
+        self.context
+    }
+}
+
 impl<'ctx> Schema<'ctx> {
     pub(crate) fn capi(&self) -> *mut ffi::tiledb_array_schema_t {
         *self.raw
@@ -90,18 +96,15 @@ impl<'ctx> Schema<'ctx> {
         let c_context: *mut ffi::tiledb_ctx_t = self.context.capi();
         let c_schema = *self.raw;
         let mut c_domain: *mut ffi::tiledb_domain_t = out_ptr!();
-        let c_ret = unsafe {
+        self.capi_return(unsafe {
             ffi::tiledb_array_schema_get_domain(
                 c_context,
                 c_schema,
                 &mut c_domain,
             )
-        };
-        if c_ret == ffi::TILEDB_OK {
-            Ok(Domain::new(self.context, RawDomain::Owned(c_domain)))
-        } else {
-            Err(self.context.expect_last_error())
-        }
+        })?;
+
+        Ok(Domain::new(self.context, RawDomain::Owned(c_domain)))
     }
 
     /// Retrieve the schema of an array from storage
@@ -110,125 +113,114 @@ impl<'ctx> Schema<'ctx> {
         let c_uri = cstring!(uri);
         let mut c_schema: *mut ffi::tiledb_array_schema_t = out_ptr!();
 
-        let c_ret = unsafe {
+        context.capi_return(unsafe {
             ffi::tiledb_array_schema_load(
                 c_context,
                 c_uri.as_ptr(),
                 &mut c_schema,
             )
-        };
-        if c_ret == ffi::TILEDB_OK {
-            Ok(Schema::new(context, RawSchema::Owned(c_schema)))
-        } else {
-            Err(context.expect_last_error())
-        }
+        })?;
+
+        Ok(Schema::new(context, RawSchema::Owned(c_schema)))
     }
 
-    pub fn version(&self) -> i64 {
-        let mut c_ret: std::os::raw::c_int = out_ptr!();
-        if unsafe {
+    pub fn version(&self) -> TileDBResult<i64> {
+        let mut c_version: std::os::raw::c_int = out_ptr!();
+        self.capi_return(unsafe {
             ffi::tiledb_array_schema_get_allows_dups(
                 self.context.capi(),
                 self.capi(),
-                &mut c_ret,
+                &mut c_version,
             )
-        } == ffi::TILEDB_OK
-        {
-            c_ret as i64
-        } else {
-            unreachable!("Rust API design should prevent sanity check failure")
-        }
+        })?;
+
+        Ok(c_version as i64)
     }
 
-    pub fn array_type(&self) -> ArrayType {
+    pub fn array_type(&self) -> TileDBResult<ArrayType> {
         let c_context = self.context.capi();
         let c_schema = *self.raw;
         let mut c_atype: ffi::tiledb_array_type_t = out_ptr!();
-        let c_ret = unsafe {
+        self.capi_return(unsafe {
             ffi::tiledb_array_schema_get_array_type(
                 c_context,
                 c_schema,
                 &mut c_atype,
             )
-        };
-        assert_eq!(ffi::TILEDB_OK, c_ret); // Rust API should prevent sanity check error
-        ArrayType::try_from(c_atype).expect("Invalid response from C API")
+        })?;
+
+        Ok(ArrayType::try_from(c_atype)?)
     }
 
-    pub fn capacity(&self) -> u64 {
+    pub fn capacity(&self) -> TileDBResult<u64> {
         let c_context = self.context.capi();
         let c_schema = *self.raw;
         let mut c_capacity: u64 = out_ptr!();
-        let c_ret = unsafe {
+        self.capi_return(unsafe {
             ffi::tiledb_array_schema_get_capacity(
                 c_context,
                 c_schema,
                 &mut c_capacity,
             )
-        };
-        assert_eq!(ffi::TILEDB_OK, c_ret); // Rust API should prevent sanity check error
-        c_capacity
+        })?;
+
+        Ok(c_capacity)
     }
 
-    pub fn cell_order(&self) -> Layout {
+    pub fn cell_order(&self) -> TileDBResult<Layout> {
         let c_context = self.context.capi();
         let c_schema = *self.raw;
         let mut c_cell_order: ffi::tiledb_layout_t = out_ptr!();
-        let c_ret = unsafe {
+        self.capi_return(unsafe {
             ffi::tiledb_array_schema_get_cell_order(
                 c_context,
                 c_schema,
                 &mut c_cell_order,
             )
-        };
-        assert_eq!(ffi::TILEDB_OK, c_ret); // Rust API should prevent sanity check error
-        Layout::try_from(c_cell_order).expect("Invalid response from C API")
+        })?;
+
+        Ok(Layout::try_from(c_cell_order)?)
     }
 
-    pub fn tile_order(&self) -> Layout {
+    pub fn tile_order(&self) -> TileDBResult<Layout> {
         let c_context = self.context.capi();
         let c_schema = *self.raw;
         let mut c_tile_order: ffi::tiledb_layout_t = out_ptr!();
-        let c_ret = unsafe {
+        self.capi_return(unsafe {
             ffi::tiledb_array_schema_get_tile_order(
                 c_context,
                 c_schema,
                 &mut c_tile_order,
             )
-        };
-        assert_eq!(ffi::TILEDB_OK, c_ret); // Rust API should prevent sanity check error
-        Layout::try_from(c_tile_order).expect("Invalid response from C API")
+        })?;
+
+        Ok(Layout::try_from(c_tile_order)?)
     }
 
-    pub fn allows_duplicates(&self) -> bool {
-        let mut c_ret: std::os::raw::c_int = out_ptr!();
-        if unsafe {
+    pub fn allows_duplicates(&self) -> TileDBResult<bool> {
+        let mut c_allows_duplicates: std::os::raw::c_int = out_ptr!();
+        self.capi_return(unsafe {
             ffi::tiledb_array_schema_get_allows_dups(
                 self.context.capi(),
                 self.capi(),
-                &mut c_ret,
+                &mut c_allows_duplicates,
             )
-        } == ffi::TILEDB_OK
-        {
-            c_ret != 0
-        } else {
-            unreachable!("Rust API design should prevent sanity check failure")
-        }
+        })?;
+        Ok(c_allows_duplicates != 0)
     }
 
-    pub fn nattributes(&self) -> usize {
+    pub fn nattributes(&self) -> TileDBResult<usize> {
         let c_context = self.context.capi();
         let c_schema = *self.raw;
         let mut c_nattrs: u32 = out_ptr!();
-        let c_ret = unsafe {
+        self.capi_return(unsafe {
             ffi::tiledb_array_schema_get_attribute_num(
                 c_context,
                 c_schema,
                 &mut c_nattrs,
             )
-        };
-        assert_eq!(ffi::TILEDB_OK, c_ret); // Rust API should prevent sanity check error
-        c_nattrs as usize
+        })?;
+        Ok(c_nattrs as usize)
     }
 
     pub fn attribute(&self, index: usize) -> TileDBResult<Attribute> {
@@ -236,19 +228,16 @@ impl<'ctx> Schema<'ctx> {
         let c_schema = *self.raw;
         let c_index = index as u32;
         let mut c_attr: *mut ffi::tiledb_attribute_t = out_ptr!();
-        let c_ret = unsafe {
+        self.capi_return(unsafe {
             ffi::tiledb_array_schema_get_attribute_from_index(
                 c_context,
                 c_schema,
                 c_index,
                 &mut c_attr,
             )
-        };
-        if c_ret == ffi::TILEDB_OK {
-            Ok(Attribute::new(self.context, RawAttribute::Owned(c_attr)))
-        } else {
-            Err(self.context.expect_last_error())
-        }
+        })?;
+
+        Ok(Attribute::new(self.context, RawAttribute::Owned(c_attr)))
     }
 
     fn filter_list(
@@ -259,16 +248,13 @@ impl<'ctx> Schema<'ctx> {
         let c_schema = *self.raw;
         let mut c_filters: *mut ffi::tiledb_filter_list_t = out_ptr!();
 
-        let c_ret =
-            unsafe { ffi_function(c_context, c_schema, &mut c_filters) };
-        if c_ret == ffi::TILEDB_OK {
-            Ok(FilterList {
-                context: self.context,
-                raw: RawFilterList::Owned(c_filters),
-            })
-        } else {
-            Err(self.context.expect_last_error())
-        }
+        self.capi_return(unsafe {
+            ffi_function(c_context, c_schema, &mut c_filters)
+        })?;
+        Ok(FilterList {
+            context: self.context,
+            raw: RawFilterList::Owned(c_filters),
+        })
     }
 
     pub fn coordinate_filters(&self) -> TileDBResult<FilterList> {
@@ -297,86 +283,22 @@ impl<'ctx> Debug for Schema<'ctx> {
 
 impl<'c1, 'c2> PartialEq<Schema<'c2>> for Schema<'c1> {
     fn eq(&self, other: &Schema<'c2>) -> bool {
-        let nattr_matches = self.nattributes() == other.nattributes();
-        if !nattr_matches {
-            return false;
+        eq_helper!(self.nattributes(), other.nattributes());
+        eq_helper!(self.version(), other.version());
+        eq_helper!(self.array_type(), other.array_type());
+        eq_helper!(self.capacity(), other.capacity());
+        eq_helper!(self.cell_order(), other.cell_order());
+        eq_helper!(self.tile_order(), other.tile_order());
+        eq_helper!(self.allows_duplicates(), other.allows_duplicates());
+        eq_helper!(self.coordinate_filters(), other.coordinate_filters());
+        eq_helper!(self.offsets_filters(), other.offsets_filters());
+        eq_helper!(self.nullity_filters(), other.nullity_filters());
+
+        for a in 0..self.nattributes().unwrap() {
+            eq_helper!(self.attribute(a), other.attribute(a));
         }
 
-        let version_matches = self.version() == other.version();
-        if !version_matches {
-            return false;
-        }
-
-        let array_type_matches = self.array_type() == other.array_type();
-        if !array_type_matches {
-            return false;
-        }
-
-        let capacity_matches = self.capacity() == other.capacity();
-        if !capacity_matches {
-            return false;
-        }
-
-        let cell_order_matches = self.cell_order() == other.cell_order();
-        if !cell_order_matches {
-            return false;
-        }
-
-        let tile_order_matches = self.tile_order() == other.tile_order();
-        if !tile_order_matches {
-            return false;
-        }
-
-        let duplicates_matches =
-            self.allows_duplicates() == other.allows_duplicates();
-        if !duplicates_matches {
-            return false;
-        }
-
-        let coords_filters_matches =
-            match (self.coordinate_filters(), other.coordinate_filters()) {
-                (Ok(mine), Ok(theirs)) => mine == theirs,
-                _ => false,
-            };
-        if !coords_filters_matches {
-            return false;
-        }
-
-        let offsets_filters_matches =
-            match (self.offsets_filters(), other.offsets_filters()) {
-                (Ok(mine), Ok(theirs)) => mine == theirs,
-                _ => false,
-            };
-        if !offsets_filters_matches {
-            return false;
-        }
-
-        let nullity_filters_matches =
-            match (self.nullity_filters(), other.nullity_filters()) {
-                (Ok(mine), Ok(theirs)) => mine == theirs,
-                _ => false,
-            };
-        if !nullity_filters_matches {
-            return false;
-        }
-
-        for a in 0..self.nattributes() {
-            let attr_matches = match (self.attribute(a), other.attribute(a)) {
-                (Ok(mine), Ok(theirs)) => mine == theirs,
-                _ => false,
-            };
-            if !attr_matches {
-                return false;
-            }
-        }
-
-        let domain_matches = match (self.domain(), other.domain()) {
-            (Ok(mine), Ok(theirs)) => mine == theirs,
-            _ => false,
-        };
-        if !domain_matches {
-            return false;
-        }
+        eq_helper!(self.domain(), other.domain());
 
         true
     }
@@ -392,6 +314,12 @@ pub struct Builder<'ctx> {
     schema: Schema<'ctx>,
 }
 
+impl<'ctx> ContextBound<'ctx> for Builder<'ctx> {
+    fn context(&self) -> &'ctx Context {
+        self.schema.context
+    }
+}
+
 impl<'ctx> Builder<'ctx> {
     pub fn new(
         context: &'ctx Context,
@@ -402,24 +330,18 @@ impl<'ctx> Builder<'ctx> {
         let c_array_type = array_type.capi_enum();
         let mut c_schema: *mut ffi::tiledb_array_schema_t =
             std::ptr::null_mut();
-        let c_alloc_ret = unsafe {
+        context.capi_return(unsafe {
             ffi::tiledb_array_schema_alloc(
                 c_context,
                 c_array_type,
                 &mut c_schema,
             )
-        };
-        if c_alloc_ret != ffi::TILEDB_OK {
-            return Err(context.expect_last_error());
-        }
+        })?;
 
         let c_domain = domain.capi();
-        let c_domain_ret = unsafe {
+        context.capi_return(unsafe {
             ffi::tiledb_array_schema_set_domain(c_context, c_schema, c_domain)
-        };
-        if c_domain_ret != ffi::TILEDB_OK {
-            return Err(context.expect_last_error());
-        }
+        })?;
 
         Ok(Builder {
             schema: Schema {
@@ -432,46 +354,34 @@ impl<'ctx> Builder<'ctx> {
     pub fn capacity(self, capacity: u64) -> TileDBResult<Self> {
         let c_context = self.schema.context.capi();
         let c_schema = *self.schema.raw;
-        let c_ret = unsafe {
+        self.context().capi_return(unsafe {
             ffi::tiledb_array_schema_set_capacity(c_context, c_schema, capacity)
-        };
-        if c_ret == ffi::TILEDB_OK {
-            Ok(self)
-        } else {
-            Err(self.schema.context.expect_last_error())
-        }
+        })?;
+        Ok(self)
     }
 
     pub fn cell_order(self, order: Layout) -> TileDBResult<Self> {
         let c_context = self.schema.context.capi();
         let c_schema = *self.schema.raw;
         let c_order = order.capi_enum();
-        let c_ret = unsafe {
+        self.capi_return(unsafe {
             ffi::tiledb_array_schema_set_cell_order(
                 c_context, c_schema, c_order,
             )
-        };
-        if c_ret == ffi::TILEDB_OK {
-            Ok(self)
-        } else {
-            Err(self.schema.context.expect_last_error())
-        }
+        })?;
+        Ok(self)
     }
 
     pub fn tile_order(self, order: Layout) -> TileDBResult<Self> {
         let c_context = self.schema.context.capi();
         let c_schema = *self.schema.raw;
         let c_order = order.capi_enum();
-        let c_ret = unsafe {
+        self.capi_return(unsafe {
             ffi::tiledb_array_schema_set_tile_order(
                 c_context, c_schema, c_order,
             )
-        };
-        if c_ret == ffi::TILEDB_OK {
-            Ok(self)
-        } else {
-            Err(self.schema.context.expect_last_error())
-        }
+        })?;
+        Ok(self)
     }
 
     pub fn allow_duplicates(self, allow: bool) -> TileDBResult<Self> {
@@ -515,14 +425,10 @@ impl<'ctx> Builder<'ctx> {
     {
         let filters = filters.borrow();
         let c_context = self.schema.context.capi();
-        let c_ret = unsafe {
+        self.capi_return(unsafe {
             ffi_function(c_context, *self.schema.raw, filters.capi())
-        };
-        if c_ret == ffi::TILEDB_OK {
-            Ok(self)
-        } else {
-            Err(self.schema.context.expect_last_error())
-        }
+        })?;
+        Ok(self)
     }
 
     pub fn coordinate_filters<FL>(self, filters: FL) -> TileDBResult<Self>
@@ -586,13 +492,13 @@ impl<'ctx> TryFrom<&Schema<'ctx>> for SchemaData {
 
     fn try_from(schema: &Schema<'ctx>) -> TileDBResult<Self> {
         Ok(SchemaData {
-            array_type: schema.array_type(),
+            array_type: schema.array_type()?,
             domain: DomainData::try_from(&schema.domain()?)?,
-            capacity: Some(schema.capacity()),
-            cell_order: Some(schema.cell_order()),
-            tile_order: Some(schema.tile_order()),
-            allow_duplicates: Some(schema.allows_duplicates()),
-            attributes: (0..schema.nattributes())
+            capacity: Some(schema.capacity()?),
+            cell_order: Some(schema.cell_order()?),
+            tile_order: Some(schema.tile_order()?),
+            allow_duplicates: Some(schema.allows_duplicates()?),
+            attributes: (0..schema.nattributes()?)
                 .map(|a| AttributeData::try_from(&schema.attribute(a)?))
                 .collect::<TileDBResult<Vec<AttributeData>>>()?,
             coordinate_filters: FilterListData::try_from(
@@ -680,7 +586,7 @@ mod tests {
             .unwrap();
 
         let s: Schema = b.into();
-        assert_eq!(0, s.version());
+        assert_eq!(0, s.version().unwrap());
     }
 
     #[test]
@@ -692,7 +598,7 @@ mod tests {
                 Builder::new(&c, ArrayType::Dense, sample_domain(&c))
                     .unwrap()
                     .build();
-            let t = s.array_type();
+            let t = s.array_type().unwrap();
             assert_eq!(ArrayType::Dense, t);
         }
 
@@ -701,7 +607,7 @@ mod tests {
                 Builder::new(&c, ArrayType::Sparse, sample_domain(&c))
                     .unwrap()
                     .build();
-            let t = s.array_type();
+            let t = s.array_type().unwrap();
             assert_eq!(ArrayType::Sparse, t);
         }
 
@@ -720,7 +626,7 @@ mod tests {
                     .capacity(cap_in)
                     .unwrap()
                     .build();
-            let cap_out = s.capacity();
+            let cap_out = s.capacity().unwrap();
             assert_eq!(cap_in, cap_out);
         }
         Ok(())
@@ -739,7 +645,7 @@ mod tests {
                     .unwrap();
 
             let s: Schema = b.into();
-            assert!(!s.allows_duplicates());
+            assert!(!s.allows_duplicates().unwrap());
         }
         // dense, duplicates (should error)
         {
@@ -757,7 +663,7 @@ mod tests {
                     .unwrap();
 
             let s: Schema = b.into();
-            assert!(!s.allows_duplicates());
+            assert!(!s.allows_duplicates().unwrap());
         }
         // sparse, duplicates
         {
@@ -768,7 +674,7 @@ mod tests {
                     .unwrap();
 
             let s: Schema = b.into();
-            assert!(s.allows_duplicates());
+            assert!(s.allows_duplicates().unwrap());
         }
     }
 
@@ -821,8 +727,8 @@ mod tests {
                     .cell_order(Layout::RowMajor)
                     .unwrap()
                     .build();
-            let tile = s.tile_order();
-            let cell = s.cell_order();
+            let tile = s.tile_order().unwrap();
+            let cell = s.cell_order().unwrap();
             assert_eq!(Layout::RowMajor, tile);
             assert_eq!(Layout::RowMajor, cell);
         }
@@ -835,8 +741,8 @@ mod tests {
                     .cell_order(Layout::ColumnMajor)
                     .unwrap()
                     .build();
-            let tile = s.tile_order();
-            let cell = s.cell_order();
+            let tile = s.tile_order().unwrap();
+            let cell = s.cell_order().unwrap();
             assert_eq!(Layout::ColumnMajor, tile);
             assert_eq!(Layout::ColumnMajor, cell);
         }
@@ -865,7 +771,7 @@ mod tests {
                     .cell_order(Layout::Hilbert)
                     .unwrap()
                     .build();
-            let cell = s.cell_order();
+            let cell = s.cell_order().unwrap();
             assert_eq!(Layout::Hilbert, cell);
         }
 
@@ -879,7 +785,7 @@ mod tests {
         {
             let s: Schema =
                 Builder::new(&c, ArrayType::Dense, sample_domain(&c))?.build();
-            assert_eq!(0, s.nattributes());
+            assert_eq!(0, s.nattributes()?);
         }
         {
             let s: Schema = {
@@ -889,7 +795,7 @@ mod tests {
                     .add_attribute(a1)?
                     .build()
             };
-            assert_eq!(1, s.nattributes());
+            assert_eq!(1, s.nattributes()?);
 
             let a1 = s.attribute(0)?;
             assert_eq!(Datatype::Int32, a1.datatype()?);
@@ -909,7 +815,7 @@ mod tests {
                     .add_attribute(a2)?
                     .build()
             };
-            assert_eq!(2, s.nattributes());
+            assert_eq!(2, s.nattributes()?);
 
             let a1 = s.attribute(0)?;
             assert_eq!(Datatype::Int32, a1.datatype()?);
@@ -1055,8 +961,8 @@ mod tests {
 
         // capacity change
         {
-            let cmp = start_schema(base.array_type())
-                .capacity((base.capacity() + 1) * 2)
+            let cmp = start_schema(base.array_type().unwrap())
+                .capacity((base.capacity().unwrap() + 1) * 2)
                 .unwrap()
                 .build();
             assert_ne!(base, cmp);
@@ -1064,8 +970,8 @@ mod tests {
 
         // cell order change
         {
-            let cmp = start_schema(base.array_type())
-                .cell_order(if base.cell_order() == Layout::RowMajor {
+            let cmp = start_schema(base.array_type().unwrap())
+                .cell_order(if base.cell_order().unwrap() == Layout::RowMajor {
                     Layout::ColumnMajor
                 } else {
                     Layout::RowMajor
@@ -1077,8 +983,8 @@ mod tests {
 
         // tile order change
         {
-            let cmp = start_schema(base.array_type())
-                .tile_order(if base.tile_order() == Layout::RowMajor {
+            let cmp = start_schema(base.array_type().unwrap())
+                .tile_order(if base.tile_order().unwrap() == Layout::RowMajor {
                     Layout::ColumnMajor
                 } else {
                     Layout::RowMajor
@@ -1090,8 +996,8 @@ mod tests {
 
         // allow duplicates change
         {
-            let cmp = start_schema(base.array_type())
-                .allow_duplicates(!base.allows_duplicates())
+            let cmp = start_schema(base.array_type().unwrap())
+                .allow_duplicates(!base.allows_duplicates().unwrap())
                 .unwrap()
                 .build();
             assert_ne!(base, cmp);
@@ -1099,7 +1005,7 @@ mod tests {
 
         // coords filters
         {
-            let cmp = start_schema(base.array_type())
+            let cmp = start_schema(base.array_type().unwrap())
                 .coordinate_filters(
                     &FilterListBuilder::new(&c).unwrap().build(),
                 )
@@ -1110,7 +1016,7 @@ mod tests {
 
         // offsets filters
         {
-            let cmp = start_schema(base.array_type())
+            let cmp = start_schema(base.array_type().unwrap())
                 .offsets_filters(&FilterListBuilder::new(&c).unwrap().build())
                 .unwrap()
                 .build();
@@ -1119,7 +1025,7 @@ mod tests {
 
         // nullity filters
         {
-            let cmp = start_schema(base.array_type())
+            let cmp = start_schema(base.array_type().unwrap())
                 .nullity_filters(&FilterListBuilder::new(&c).unwrap().build())
                 .unwrap()
                 .build();
@@ -1128,21 +1034,22 @@ mod tests {
 
         // change attribute
         {
-            let cmp = Builder::new(&c, base.array_type(), sample_domain(&c))
-                .unwrap()
-                .add_attribute(
-                    AttributeBuilder::new(&c, "a1", Datatype::Float32)
-                        .unwrap()
-                        .build(),
-                )
-                .unwrap()
-                .build();
+            let cmp =
+                Builder::new(&c, base.array_type().unwrap(), sample_domain(&c))
+                    .unwrap()
+                    .add_attribute(
+                        AttributeBuilder::new(&c, "a1", Datatype::Float32)
+                            .unwrap()
+                            .build(),
+                    )
+                    .unwrap()
+                    .build();
             assert_ne!(base, cmp);
         }
 
         // add attribute
         {
-            let cmp = start_schema(base.array_type())
+            let cmp = start_schema(base.array_type().unwrap())
                 .add_attribute(
                     AttributeBuilder::new(&c, "a2", Datatype::Int64)
                         .unwrap()
@@ -1169,7 +1076,7 @@ mod tests {
                 )
                 .unwrap()
                 .build();
-            let cmp = Builder::new(&c, base.array_type(), domain)
+            let cmp = Builder::new(&c, base.array_type().unwrap(), domain)
                 .unwrap()
                 .add_attribute(
                     AttributeBuilder::new(&c, "a1", Datatype::Int32)

--- a/tiledb/api/src/array/schema.rs
+++ b/tiledb/api/src/array/schema.rs
@@ -9,7 +9,7 @@ use serde_json::json;
 use crate::array::attribute::{AttributeData, RawAttribute};
 use crate::array::domain::{DomainData, RawDomain};
 use crate::array::{Attribute, Domain, Layout};
-use crate::context::{CApiBound, Context, ContextBound};
+use crate::context::{CApiInterface, Context, ContextBound};
 use crate::filter_list::{FilterList, FilterListData, RawFilterList};
 use crate::{Factory, Result as TileDBResult};
 

--- a/tiledb/api/src/array/schema.rs
+++ b/tiledb/api/src/array/schema.rs
@@ -386,33 +386,25 @@ impl<'ctx> Builder<'ctx> {
 
     pub fn allow_duplicates(self, allow: bool) -> TileDBResult<Self> {
         let c_allow = if allow { 1 } else { 0 };
-        if unsafe {
+        self.capi_return(unsafe {
             ffi::tiledb_array_schema_set_allows_dups(
                 self.schema.context.capi(),
                 *self.schema.raw,
                 c_allow,
             )
-        } == ffi::TILEDB_OK
-        {
-            Ok(self)
-        } else {
-            Err(self.schema.context.expect_last_error())
-        }
+        })?;
+        Ok(self)
     }
 
     pub fn add_attribute(self, attr: Attribute) -> TileDBResult<Self> {
-        if unsafe {
+        self.capi_return(unsafe {
             ffi::tiledb_array_schema_add_attribute(
                 self.schema.context.capi(),
                 *self.schema.raw,
                 attr.capi(),
             )
-        } == ffi::TILEDB_OK
-        {
-            Ok(self)
-        } else {
-            Err(self.schema.context.expect_last_error())
-        }
+        })?;
+        Ok(self)
     }
 
     fn filter_list<FL>(

--- a/tiledb/api/src/context.rs
+++ b/tiledb/api/src/context.rs
@@ -31,6 +31,23 @@ impl Drop for RawContext {
     }
 }
 
+pub trait ContextBound<'ctx> {
+    fn context(&self) -> &'ctx Context;
+}
+
+pub(crate) trait CApiBound {
+    fn capi_return(&self, c_ret: i32) -> TileDBResult<()>;
+}
+
+impl<'ctx, T> CApiBound for T
+where
+    T: ContextBound<'ctx>,
+{
+    fn capi_return(&self, c_ret: i32) -> TileDBResult<()> {
+        self.context().capi_return(c_ret)
+    }
+}
+
 pub struct Context {
     raw: RawContext,
 }

--- a/tiledb/api/src/context.rs
+++ b/tiledb/api/src/context.rs
@@ -35,11 +35,11 @@ pub trait ContextBound<'ctx> {
     fn context(&self) -> &'ctx Context;
 }
 
-pub(crate) trait CApiBound {
+pub(crate) trait CApiInterface {
     fn capi_return(&self, c_ret: i32) -> TileDBResult<()>;
 }
 
-impl<'ctx, T> CApiBound for T
+impl<'ctx, T> CApiInterface for T
 where
     T: ContextBound<'ctx>,
 {

--- a/tiledb/api/src/context.rs
+++ b/tiledb/api/src/context.rs
@@ -160,6 +160,14 @@ impl Context {
             Err(self.expect_last_error())
         }
     }
+
+    pub(crate) fn capi_return(&self, c_ret: i32) -> TileDBResult<()> {
+        if c_ret == ffi::TILEDB_OK {
+            Ok(())
+        } else {
+            Err(self.expect_last_error())
+        }
+    }
 }
 
 #[cfg(test)]

--- a/tiledb/api/src/context.rs
+++ b/tiledb/api/src/context.rs
@@ -178,6 +178,7 @@ impl Context {
         }
     }
 
+    /// Safely translate a return value from the C API into a TileDBResult
     pub(crate) fn capi_return(&self, c_ret: i32) -> TileDBResult<()> {
         if c_ret == ffi::TILEDB_OK {
             Ok(())

--- a/tiledb/api/src/lib.rs
+++ b/tiledb/api/src/lib.rs
@@ -17,6 +17,17 @@ macro_rules! cstring {
     };
 }
 
+macro_rules! eq_helper {
+    ($mine:expr, $theirs:expr) => {{
+        if !match ($mine, $theirs) {
+            (Ok(mine), Ok(theirs)) => mine == theirs,
+            _ => false,
+        } {
+            return false;
+        }
+    }};
+}
+
 macro_rules! out_ptr {
     () => {
         unsafe { std::mem::MaybeUninit::zeroed().assume_init() }
@@ -51,7 +62,7 @@ pub fn version() -> (i32, i32, i32) {
 }
 
 pub use array::Array;
-pub use context::Context;
+pub use context::{Context, ContextBound};
 pub use datatype::Datatype;
 pub use query::{Builder as QueryBuilder, Query, QueryType};
 pub type Result<T> = std::result::Result<T, error::Error>;

--- a/tiledb/api/src/query/subarray.rs
+++ b/tiledb/api/src/query/subarray.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use crate::array::DimensionKey;
-use crate::context::Context;
+use crate::context::{CApiInterface, Context, ContextBound};
 use crate::convert::CAPIConverter;
 use crate::query::Builder as QueryBuilder;
 use crate::Result as TileDBResult;
@@ -30,9 +30,22 @@ pub struct Subarray<'ctx> {
     context: &'ctx Context,
     raw: RawSubarray,
 }
+
+impl<'ctx> ContextBound<'ctx> for Subarray<'ctx> {
+    fn context(&self) -> &'ctx Context {
+        self.context
+    }
+}
+
 pub struct Builder<'ctx> {
     query: QueryBuilder<'ctx>,
     subarray: Subarray<'ctx>,
+}
+
+impl<'ctx> ContextBound<'ctx> for Builder<'ctx> {
+    fn context(&self) -> &'ctx Context {
+        self.subarray.context()
+    }
 }
 
 impl<'ctx> Builder<'ctx> {
@@ -42,20 +55,17 @@ impl<'ctx> Builder<'ctx> {
         let c_array = query.query.array.capi();
         let mut c_subarray: *mut ffi::tiledb_subarray_t = out_ptr!();
 
-        let c_ret = unsafe {
+        context.capi_return(unsafe {
             ffi::tiledb_subarray_alloc(c_context, c_array, &mut c_subarray)
-        };
-        if c_ret == ffi::TILEDB_OK {
-            Ok(Builder {
-                query,
-                subarray: Subarray {
-                    context,
-                    raw: RawSubarray::Owned(c_subarray),
-                },
-            })
-        } else {
-            Err(context.expect_last_error())
-        }
+        })?;
+
+        Ok(Builder {
+            query,
+            subarray: Subarray {
+                context,
+                raw: RawSubarray::Owned(c_subarray),
+            },
+        })
     }
 
     pub fn dimension_range_typed<Conv: CAPIConverter, K: Into<DimensionKey>>(
@@ -69,10 +79,10 @@ impl<'ctx> Builder<'ctx> {
         let c_start = &range[0] as *const Conv as *const std::ffi::c_void;
         let c_end = &range[1] as *const Conv as *const std::ffi::c_void;
 
-        let c_ret = match key.into() {
+        match key.into() {
             DimensionKey::Index(idx) => {
                 let c_idx = idx.try_into().unwrap();
-                unsafe {
+                self.capi_return(unsafe {
                     ffi::tiledb_subarray_add_range(
                         c_context,
                         c_subarray,
@@ -81,11 +91,11 @@ impl<'ctx> Builder<'ctx> {
                         c_end,
                         std::ptr::null(),
                     )
-                }
+                })
             }
             DimensionKey::Name(name) => {
                 let c_name = cstring!(name);
-                unsafe {
+                self.capi_return(unsafe {
                     ffi::tiledb_subarray_add_range_by_name(
                         c_context,
                         c_subarray,
@@ -94,14 +104,10 @@ impl<'ctx> Builder<'ctx> {
                         c_end,
                         std::ptr::null(),
                     )
-                }
+                })
             }
-        };
-        if c_ret == ffi::TILEDB_OK {
-            self.build()
-        } else {
-            Err(self.subarray.context.expect_last_error())
-        }
+        }?;
+        self.build()
     }
 
     fn build(mut self) -> TileDBResult<QueryBuilder<'ctx>> {
@@ -109,14 +115,10 @@ impl<'ctx> Builder<'ctx> {
         let c_query = *self.query.query.raw;
         let c_subarray = *self.subarray.raw;
 
-        let c_ret = unsafe {
+        self.capi_return(unsafe {
             ffi::tiledb_query_set_subarray_t(c_context, c_query, c_subarray)
-        };
-        if c_ret == ffi::TILEDB_OK {
-            self.query.query.subarrays.push(self.subarray);
-            Ok(self.query)
-        } else {
-            Err(self.subarray.context.expect_last_error())
-        }
+        })?;
+        self.query.query.subarrays.push(self.subarray);
+        Ok(self.query)
     }
 }

--- a/tiledb/arrow/src/dimension.rs
+++ b/tiledb/arrow/src/dimension.rs
@@ -22,7 +22,7 @@ pub struct DimensionMetadata {
 
 impl DimensionMetadata {
     pub fn new(dim: &tiledb::array::Dimension) -> TileDBResult<Self> {
-        fn_typed!(dim.datatype(), DT, {
+        fn_typed!(dim.datatype()?, DT, {
             let domain = dim.domain::<DT>()?;
             let extent = dim.extent::<DT>()?;
 
@@ -30,7 +30,7 @@ impl DimensionMetadata {
                 cell_val_num: dim.cell_val_num()?,
                 domain: [json!(domain[0]), json!(domain[1])],
                 extent: json!(extent),
-                filters: FilterMetadata::new(&dim.filters())?,
+                filters: FilterMetadata::new(&dim.filters()?)?,
             })
         })
     }
@@ -42,7 +42,7 @@ impl DimensionMetadata {
 pub fn arrow_field(
     dim: &tiledb::array::Dimension,
 ) -> TileDBResult<Option<arrow_schema::Field>> {
-    if let Some(arrow_dt) = arrow_type_physical(&dim.datatype()) {
+    if let Some(arrow_dt) = arrow_type_physical(&dim.datatype()?) {
         let name = dim.name()?;
         let metadata = serde_json::ser::to_string(&DimensionMetadata::new(
             dim,

--- a/tiledb/arrow/src/schema.rs
+++ b/tiledb/arrow/src/schema.rs
@@ -31,12 +31,12 @@ pub struct SchemaMetadata {
 impl SchemaMetadata {
     pub fn new(schema: &Schema) -> TileDBResult<Self> {
         Ok(SchemaMetadata {
-            array_type: schema.array_type(),
-            version: schema.version(),
-            capacity: schema.capacity(),
-            allows_duplicates: schema.allows_duplicates(),
-            cell_order: schema.cell_order(),
-            tile_order: schema.tile_order(),
+            array_type: schema.array_type()?,
+            version: schema.version()?,
+            capacity: schema.capacity()?,
+            allows_duplicates: schema.allows_duplicates()?,
+            cell_order: schema.cell_order()?,
+            tile_order: schema.tile_order()?,
             coordinate_filters: FilterMetadata::new(
                 &schema.coordinate_filters()?,
             )?,
@@ -51,7 +51,7 @@ pub fn arrow_schema<'ctx>(
     tiledb: &'ctx Schema<'ctx>,
 ) -> TileDBResult<Option<ArrowSchema>> {
     let mut builder =
-        arrow_schema::SchemaBuilder::with_capacity(tiledb.nattributes());
+        arrow_schema::SchemaBuilder::with_capacity(tiledb.nattributes()?);
 
     for d in 0..tiledb.domain()?.ndim()? {
         let dim = tiledb.domain()?.dimension(d)?;
@@ -62,7 +62,7 @@ pub fn arrow_schema<'ctx>(
         }
     }
 
-    for a in 0..tiledb.nattributes() {
+    for a in 0..tiledb.nattributes()? {
         let attr = tiledb.attribute(a)?;
         if let Some(field) = crate::attribute::arrow_field(&attr)? {
             builder.push(field)

--- a/tiledb/arrow/src/schema.rs
+++ b/tiledb/arrow/src/schema.rs
@@ -42,7 +42,7 @@ impl SchemaMetadata {
             )?,
             offsets_filters: FilterMetadata::new(&schema.offsets_filters()?)?,
             nullity_filters: FilterMetadata::new(&schema.nullity_filters()?)?,
-            ndim: schema.domain()?.ndim(),
+            ndim: schema.domain()?.ndim()?,
         })
     }
 }
@@ -53,7 +53,7 @@ pub fn arrow_schema<'ctx>(
     let mut builder =
         arrow_schema::SchemaBuilder::with_capacity(tiledb.nattributes());
 
-    for d in 0..tiledb.domain()?.ndim() {
+    for d in 0..tiledb.domain()?.ndim()? {
         let dim = tiledb.domain()?.dimension(d)?;
         if let Some(field) = crate::dimension::arrow_field(&dim)? {
             builder.push(field)


### PR DESCRIPTION
This pull request does a few things which hopefully should improve stability of our API.

1) in a few cases the code wrote in the assumption that libtiledb would return `TILEDB_OK`.  We discussed and agreed not to do this, so this request fixes those.

2) we add the `Context::capi_return` function and move all C API return value checking in that function. There are more return codes than just `TILEDB_OK` and `TILEDB_ERR`, and this makes it substantially easier for us to accommodate those into possibly different kinds of Rust API errors.

3) we add the ContextBound trait which is just a cute way to give everything `fn context(&self) -> &'ctx Context`.  This is helpful for propagating the `capi_return` function described above, and also might be handy for users of the API.

Resolves sc#44161