### PR TITLE
Add test that our arbitrary schemata can actually create an array, and update strategies to make it so

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,6 +742,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf16337405ca084e9c78985114633b6827711d22b9e6ef6c6c0d665eb3f0b6e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,7 +950,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -975,7 +986,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.53",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1028,7 +1050,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1038,6 +1060,7 @@ dependencies = [
  "anyhow",
  "num-traits",
  "proptest",
+ "proptest-derive",
  "serde",
  "serde_json",
  "tempdir",
@@ -1131,7 +1154,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.53",
  "wasm-bindgen-shared",
 ]
 
@@ -1153,7 +1176,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.53",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1278,5 +1301,5 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.53",
 ]

--- a/tiledb/api/Cargo.toml
+++ b/tiledb/api/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 num-traits = { version = "0.2", optional = true }
 proptest = { version = "1.0.0", optional = true }
+proptest-derive = { version = "0.4.0", optional = true }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = "1.0.58"
@@ -21,4 +22,4 @@ tempdir = "0.3.7"
 
 [features]
 default = []
-proptest-strategies = ["dep:num-traits", "dep:proptest"]
+proptest-strategies = ["dep:num-traits", "dep:proptest", "dep:proptest-derive"]

--- a/tiledb/api/src/array/attribute/strategy.rs
+++ b/tiledb/api/src/array/attribute/strategy.rs
@@ -51,14 +51,12 @@ fn prop_filters(
     };
 
     let pipeline_requirements = FilterRequirements {
-        context: match requirements.context.as_ref() {
-            None => None,
-            Some(StrategyContext::Schema(array_type, domain)) => {
-                Some(FilterContext::Domain(*array_type, domain.clone()))
-            }
-        },
+        context: requirements.context.as_ref().map(
+            |StrategyContext::Schema(array_type, domain)| {
+                FilterContext::Domain(*array_type, domain.clone())
+            },
+        ),
         input_datatype: Some(datatype),
-        ..Default::default()
     };
 
     prop_filter_pipeline(Rc::new(pipeline_requirements))

--- a/tiledb/api/src/array/attribute/strategy.rs
+++ b/tiledb/api/src/array/attribute/strategy.rs
@@ -4,6 +4,7 @@ use serde_json::json;
 use crate::array::{attribute::FillData, AttributeData};
 use crate::datatype::strategy::*;
 use crate::filter::list::FilterListData;
+use crate::filter::strategy::*;
 use crate::{fn_typed, Datatype};
 
 pub fn prop_attribute_name() -> impl Strategy<Value = String> {
@@ -28,7 +29,10 @@ fn prop_fill<T: Arbitrary>() -> impl Strategy<Value = T> {
 }
 
 fn prop_filters(datatype: Datatype) -> impl Strategy<Value = FilterListData> {
-    crate::filter::strategy::prop_filter_pipeline_for_datatype(datatype)
+    prop_filter_pipeline(crate::filter::strategy::Requirements {
+        input_datatype: Some(datatype),
+        ..Default::default()
+    })
 }
 
 pub fn prop_attribute_for_datatype(

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -175,6 +175,9 @@ impl Drop for Array<'_> {
     }
 }
 
+#[cfg(feature = "proptest-strategies")]
+pub mod strategy;
+
 #[cfg(test)]
 pub mod tests {
     use std::io;

--- a/tiledb/api/src/array/schema/mod.rs
+++ b/tiledb/api/src/array/schema/mod.rs
@@ -14,6 +14,7 @@ use crate::filter::list::{FilterList, FilterListData, RawFilterList};
 use crate::{Factory, Result as TileDBResult};
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "proptest-strategies", derive(proptest_derive::Arbitrary))]
 pub enum ArrayType {
     Dense,
     Sparse,

--- a/tiledb/api/src/array/schema/strategy.rs
+++ b/tiledb/api/src/array/schema/strategy.rs
@@ -125,7 +125,7 @@ fn prop_schema_for_domain(
                     {
                         let dimgen = crate::array::dimension::strategy::prop_dimension_name();
                         for dim in domain.dimension.iter_mut() {
-                            if !names.insert(dim.name.clone()) {
+                            while !names.insert(dim.name.clone()) {
                                 dim.name = dimgen
                                     .new_tree(&mut runner)
                                     .unwrap()
@@ -136,7 +136,7 @@ fn prop_schema_for_domain(
                     {
                         let attgen = crate::array::attribute::strategy::prop_attribute_name();
                         for attr in attributes.iter_mut() {
-                            if !names.insert(attr.name.clone()) {
+                            while !names.insert(attr.name.clone()) {
                                 attr.name = attgen
                                     .new_tree(&mut runner)
                                     .unwrap()

--- a/tiledb/api/src/array/schema/strategy.rs
+++ b/tiledb/api/src/array/schema/strategy.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use proptest::prelude::*;
 
 use crate::array::attribute::strategy::*;
@@ -53,7 +55,13 @@ pub fn prop_coordinate_filters(
         }
     }
 
-    prop_filter_pipeline().prop_filter(
+    let req = Requirements {
+        context: Some(FilterContext::SchemaCoordinates(Rc::new(
+            domain.clone(),
+        ))),
+        ..Default::default()
+    };
+    prop_filter_pipeline(req).prop_filter(
         "Floating-point dimension cannot have DOUBLE DELTA compression",
         move |fl| {
             !(has_unfiltered_float_dimension
@@ -89,8 +97,8 @@ pub fn prop_schema_for_domain(
         allow_duplicates,
         proptest::collection::vec(prop_attribute(), MIN_ATTRS..=MAX_ATTRS),
         prop_coordinate_filters(&domain),
-        prop_filter_pipeline(),
-        prop_filter_pipeline(),
+        prop_filter_pipeline(Default::default()),
+        prop_filter_pipeline(Default::default()),
     )
         .prop_map(
             move |(

--- a/tiledb/api/src/array/schema/strategy.rs
+++ b/tiledb/api/src/array/schema/strategy.rs
@@ -173,7 +173,6 @@ pub fn prop_schema(
     array_type.prop_flat_map(|array_type| {
         prop_domain(Rc::new(DomainRequirements {
             array_type: Some(array_type),
-            ..Default::default()
         }))
         .prop_flat_map(move |domain| {
             prop_schema_for_domain(array_type, Rc::new(domain))

--- a/tiledb/api/src/array/strategy.rs
+++ b/tiledb/api/src/array/strategy.rs
@@ -20,7 +20,7 @@ mod tests {
                 let tempdir = TempDir::new("test_array_create").expect("Error creating temp dir");
                 let uri = String::from("file:///") + tempdir.path().join("array").to_str().unwrap();
 
-                Array::create(&ctx, &uri, schema)
+                Array::create(&ctx, uri, schema)
             };
             array_create.expect("Error creating array from arbitrary schema");
         });

--- a/tiledb/api/src/array/strategy.rs
+++ b/tiledb/api/src/array/strategy.rs
@@ -1,0 +1,28 @@
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use tempdir::TempDir;
+
+    use crate::array::*;
+    use crate::context::Context;
+    use crate::Factory;
+
+    #[test]
+    fn test_array_create() {
+        let ctx = Context::new().expect("Error creating context");
+
+        proptest!(|(maybe_schema in crate::array::schema::strategy::prop_schema(Default::default()))| {
+            let schema = maybe_schema.create(&ctx)
+                .expect("Error constructing arbitrary schema");
+            assert_eq!(schema, schema);
+
+            let array_create = {
+                let tempdir = TempDir::new("test_array_create").expect("Error creating temp dir");
+                let uri = String::from("file:///") + tempdir.path().join("array").to_str().unwrap();
+
+                Array::create(&ctx, &uri, schema)
+            };
+            array_create.expect("Error creating array from arbitrary schema");
+        });
+    }
+}

--- a/tiledb/api/src/filter/strategy.rs
+++ b/tiledb/api/src/filter/strategy.rs
@@ -1,12 +1,42 @@
 use std::collections::VecDeque;
+use std::rc::Rc;
 
 use proptest::prelude::*;
 use proptest::strategy::Just;
 
+use crate::array::DomainData;
 use crate::datatype::strategy::*;
 use crate::filter::list::FilterListData;
 use crate::filter::*;
 use crate::Datatype;
+
+#[derive(Clone)]
+pub enum FilterContext {
+    Domain(Rc<DomainData>),
+    SchemaCoordinates(Rc<DomainData>),
+}
+
+impl FilterContext {
+    pub fn domain(&self) -> Rc<DomainData> {
+        match self {
+            FilterContext::Domain(domain) => domain.clone(),
+            FilterContext::SchemaCoordinates(domain) => domain.clone(),
+        }
+    }
+}
+
+/// Defines requirements for what a generated filter must be able to accept
+#[derive(Clone, Default)]
+pub struct Requirements {
+    pub context: Option<FilterContext>,
+    pub input_datatype: Option<Datatype>,
+}
+
+impl Requirements {
+    pub fn domain(&self) -> Option<Rc<DomainData>> {
+        Some(self.context.as_ref()?.domain())
+    }
+}
 
 fn prop_bitwidthreduction() -> impl Strategy<Value = FilterData> {
     const MIN_WINDOW: u32 = 8;
@@ -25,23 +55,57 @@ fn prop_compression_reinterpret_datatype() -> impl Strategy<Value = Datatype> {
     prop_datatype_implemented()
 }
 
-fn prop_compression() -> impl Strategy<Value = FilterData> {
+fn prop_compression(
+    requirements: Requirements,
+) -> impl Strategy<Value = FilterData> {
     const MIN_COMPRESSION_LEVEL: i32 = 1;
     const MAX_COMPRESSION_LEVEL: i32 = 9;
-    (
-        prop_oneof![
-            Just(CompressionType::Bzip2),
-            Just(CompressionType::Delta),
-            Just(CompressionType::Dictionary),
-            Just(CompressionType::DoubleDelta),
-            Just(CompressionType::Gzip),
-            Just(CompressionType::Lz4),
-            Just(CompressionType::Rle),
-            Just(CompressionType::Zstd),
-        ],
-        MIN_COMPRESSION_LEVEL..=MAX_COMPRESSION_LEVEL,
-        prop_compression_reinterpret_datatype(),
-    )
+
+    prop_compression_reinterpret_datatype()
+        .prop_flat_map(move |reinterpret_datatype| {
+            let compression_types = vec![
+                CompressionType::Bzip2,
+                CompressionType::Dictionary,
+                CompressionType::Gzip,
+                CompressionType::Lz4,
+                CompressionType::Rle,
+                CompressionType::Zstd,
+            ];
+
+            let with_double_delta = || -> Vec<CompressionType> {
+                let mut with_double_delta = compression_types.clone();
+                with_double_delta.push(CompressionType::Delta);
+                with_double_delta.push(CompressionType::DoubleDelta);
+                with_double_delta
+            };
+
+            let kind = proptest::strategy::Union::new(
+                match (requirements.input_datatype, reinterpret_datatype) {
+                    (None, _) => with_double_delta(),
+                    (Some(input_datatype), Datatype::Any) => {
+                        if input_datatype.is_real_type() {
+                            compression_types.clone()
+                        } else {
+                            with_double_delta()
+                        }
+                    }
+                    (Some(_), reinterpret_datatype) => {
+                        if reinterpret_datatype.is_real_type() {
+                            compression_types.clone()
+                        } else {
+                            with_double_delta()
+                        }
+                    }
+                }
+                .into_iter()
+                .map(Just),
+            );
+            (
+                kind,
+                MIN_COMPRESSION_LEVEL..=MAX_COMPRESSION_LEVEL,
+                Just(reinterpret_datatype),
+            )
+        })
         .prop_map(|(kind, level, reinterpret_datatype)| {
             FilterData::Compression(CompressionData {
                 kind,
@@ -97,44 +161,85 @@ fn prop_webp() -> impl Strategy<Value = FilterData> {
         })
 }
 
-pub fn prop_filter() -> impl Strategy<Value = FilterData> {
-    prop_oneof![
-        Just(FilterData::BitShuffle),
-        Just(FilterData::ByteShuffle),
-        prop_bitwidthreduction(),
-        Just(FilterData::Checksum(ChecksumType::Md5)),
-        Just(FilterData::Checksum(ChecksumType::Sha256)),
-        prop_compression(),
-        prop_positivedelta(),
-        prop_scalefloat(),
-        prop_webp(),
-        Just(FilterData::Xor)
-    ]
-}
-
-pub fn prop_filter_for_datatype(
-    input_datatype: Datatype,
+pub fn prop_filter(
+    requirements: Requirements,
 ) -> impl Strategy<Value = FilterData> {
-    prop_filter()
-        .prop_filter("Filter does not accept input type", move |filter| {
-            filter.transform_datatype(&input_datatype).is_some()
-        })
+    let mut filter_strategies = vec![
+        Just(FilterData::BitShuffle).boxed(),
+        Just(FilterData::ByteShuffle).boxed(),
+        Just(FilterData::Checksum(ChecksumType::Md5)).boxed(),
+        Just(FilterData::Checksum(ChecksumType::Sha256)).boxed(),
+    ];
+
+    let ok_bit_reduction = match requirements.input_datatype {
+        None => true,
+        Some(dt) => {
+            dt.is_integral_type()
+                || dt.is_datetime_type()
+                || dt.is_time_type()
+                || dt.is_byte_type()
+        }
+    };
+    if ok_bit_reduction {
+        filter_strategies.push(prop_bitwidthreduction().boxed());
+        filter_strategies.push(prop_positivedelta().boxed());
+    }
+
+    filter_strategies.push(prop_compression(requirements.clone()).boxed());
+
+    let ok_scale_float = match requirements.input_datatype {
+        None => true,
+        Some(dt) => [std::mem::size_of::<f32>(), std::mem::size_of::<f64>()]
+            .contains(&(dt.size() as usize)),
+    };
+    if ok_scale_float {
+        filter_strategies.push(prop_scalefloat().boxed());
+    }
+
+    let ok_webp = match (requirements.input_datatype, requirements.domain()) {
+        (Some(Datatype::UInt8), Some(domain)) => domain.dimension.len() == 2,
+        (None, None) => true,
+        _ => false,
+    };
+    if ok_webp {
+        filter_strategies.push(prop_webp().boxed());
+    }
+
+    let ok_xor = match requirements.input_datatype {
+        Some(input_datatype) => {
+            [1, 2, 4, 8].contains(&(input_datatype.size() as usize))
+        }
+        None => true,
+    };
+    if ok_xor {
+        filter_strategies.push(Just(FilterData::Xor).boxed());
+    }
+
+    proptest::strategy::Union::new(filter_strategies)
 }
 
 fn prop_filter_pipeline_impl(
-    start: Datatype,
+    requirements: Requirements,
     nfilters: usize,
 ) -> impl Strategy<Value = VecDeque<FilterData>> {
     if nfilters == 0 {
         Just(VecDeque::new()).boxed()
     } else {
-        prop_filter_for_datatype(start)
+        prop_filter(requirements.clone())
             .prop_flat_map(move |filter| {
                 // This unwrap is guaranteed to succeed because the filter was
                 // already checked before being returned from
                 // prop_filter_for_datatype.
-                let next = filter.transform_datatype(&start).unwrap();
-                prop_filter_pipeline_impl(next, nfilters - 1)
+                let next = filter
+                    .transform_datatype(&requirements.input_datatype.expect(
+                        "Input datatype required to construct pipeline",
+                    ))
+                    .unwrap();
+                let next_requirements = Requirements {
+                    input_datatype: Some(next),
+                    ..requirements.clone()
+                };
+                prop_filter_pipeline_impl(next_requirements, nfilters - 1)
                     .boxed()
                     .prop_map(move |mut filter_vec| {
                         filter_vec.push_front(filter.clone());
@@ -145,37 +250,36 @@ fn prop_filter_pipeline_impl(
     }
 }
 
-pub fn prop_filter_pipeline_for_datatype(
-    datatype: Datatype,
+pub fn prop_filter_pipeline(
+    requirements: Requirements,
 ) -> impl Strategy<Value = FilterListData> {
     const MIN_FILTERS: usize = 0;
     const MAX_FILTERS: usize = 4;
 
-    (MIN_FILTERS..=MAX_FILTERS).prop_flat_map(move |nfilters| {
-        prop_filter_pipeline_impl(datatype, nfilters).prop_map(
-            move |filter_deque| {
-                let mut current_dt = datatype;
-                for filter in filter_deque.iter() {
-                    current_dt = if let Some(next_dt) =
-                        filter.transform_datatype(&current_dt)
-                    {
-                        next_dt
-                    } else {
-                        unreachable!(
-                            "Error in filter pipeline construction: {:?} \
-                        does not accept input type {} in pipeline {:?}",
-                            filter, current_dt, filter_deque
-                        )
-                    }
-                }
-                filter_deque.into_iter().collect::<FilterListData>()
-            },
-        )
-    })
-}
+    fn with_datatype(
+        requirements: Requirements,
+    ) -> impl Strategy<Value = FilterListData> {
+        (MIN_FILTERS..=MAX_FILTERS).prop_flat_map(move |nfilters| {
+            prop_filter_pipeline_impl(requirements.clone(), nfilters).prop_map(
+                move |filter_deque| {
+                    filter_deque.into_iter().collect::<FilterListData>()
+                },
+            )
+        })
+    }
 
-pub fn prop_filter_pipeline() -> impl Strategy<Value = FilterListData> {
-    prop_datatype().prop_flat_map(prop_filter_pipeline_for_datatype)
+    if requirements.input_datatype.is_some() {
+        with_datatype(requirements).boxed()
+    } else {
+        prop_datatype_implemented()
+            .prop_flat_map(move |input_datatype| {
+                with_datatype(Requirements {
+                    input_datatype: Some(input_datatype),
+                    ..requirements.clone()
+                })
+            })
+            .boxed()
+    }
 }
 
 #[cfg(test)]
@@ -188,7 +292,7 @@ mod tests {
     fn filter_arbitrary() {
         let ctx = Context::new().expect("Error creating context");
 
-        proptest!(|(filt in prop_filter_pipeline())| {
+        proptest!(|(filt in prop_filter_pipeline(Default::default()))| {
             filt.create(&ctx).expect("Error constructing arbitrary filter");
         });
     }
@@ -200,7 +304,10 @@ mod tests {
         let ctx = Context::new().expect("Error creating context");
 
         proptest!(|((dt, filt) in prop_datatype().prop_flat_map(
-                |dt| (Just(dt), prop_filter_for_datatype(dt))))| {
+                |dt| (Just(dt), prop_filter(Requirements {
+                    input_datatype: Some(dt),
+                    ..Default::default()
+                }))))| {
             let filt = filt.create(&ctx)
                 .expect("Error constructing arbitrary filter");
 
@@ -215,7 +322,7 @@ mod tests {
     fn filter_list_arbitrary() {
         let ctx = Context::new().expect("Error creating context");
 
-        proptest!(|(fl in prop_filter_pipeline())| {
+        proptest!(|(fl in prop_filter_pipeline(Default::default()))| {
             fl.create(&ctx).expect("Error constructing arbitrary filter list");
         });
     }
@@ -227,7 +334,10 @@ mod tests {
         let ctx = Context::new().expect("Error creating context");
 
         proptest!(|((dt, fl) in prop_datatype_implemented().prop_flat_map(
-                |dt| (Just(dt), prop_filter_pipeline_for_datatype(dt))))| {
+                |dt| (Just(dt), prop_filter_pipeline(Requirements {
+                    input_datatype: Some(dt),
+                    ..Default::default()
+                }))))| {
             let fl = fl.create(&ctx)
                 .expect("Error constructing arbitrary filter");
 
@@ -264,7 +374,7 @@ mod tests {
     fn filter_eq_reflexivity() {
         let ctx = Context::new().expect("Error creating context");
 
-        proptest!(|(attr in prop_filter_pipeline())| {
+        proptest!(|(attr in prop_filter_pipeline(Default::default()))| {
             let attr = attr.create(&ctx)
                 .expect("Error constructing arbitrary filter");
             assert_eq!(attr, attr);

--- a/tiledb/api/src/filter/strategy.rs
+++ b/tiledb/api/src/filter/strategy.rs
@@ -159,11 +159,11 @@ fn prop_webp(
     if let Some(StrategyContext::Domain(array_type, ref domain)) =
         requirements.context.as_ref()
     {
-        if *array_type == ArrayType::Sparse || domain.dimension.len() != 2 {
-            return None;
-        } else if !domain.dimension[0].datatype.is_integral_type() {
-            return None;
-        } else if domain.dimension[0].datatype != domain.dimension[1].datatype {
+        if *array_type == ArrayType::Sparse
+            || domain.dimension.len() != 2
+            || !domain.dimension[0].datatype.is_integral_type()
+            || domain.dimension[0].datatype != domain.dimension[1].datatype
+        {
             return None;
         }
 
@@ -198,9 +198,7 @@ fn prop_webp(
 
         Some(
             (
-                proptest::strategy::Union::new(
-                    formats.into_iter().map(|m| Just(m)),
-                ),
+                proptest::strategy::Union::new(formats.into_iter().map(Just)),
                 prop_oneof![Just(false), Just(true)],
                 0f32..=100f32,
             )

--- a/tiledb/arrow/src/attribute.rs
+++ b/tiledb/arrow/src/attribute.rs
@@ -165,7 +165,7 @@ pub mod tests {
         let c: TileDBContext = TileDBContext::new()?;
 
         /* tiledb => arrow => tiledb */
-        proptest!(|(tdb_in in tiledb::array::attribute::strategy::prop_attribute())| {
+        proptest!(|(tdb_in in tiledb::array::attribute::strategy::prop_attribute(Default::default()))| {
             let tdb_in = tdb_in.create(&c)
                 .expect("Error constructing arbitrary tiledb attribute");
             if let Some(arrow_field) = arrow_field(&tdb_in)

--- a/tiledb/arrow/src/filter.rs
+++ b/tiledb/arrow/src/filter.rs
@@ -51,7 +51,7 @@ mod tests {
     fn test_serialize_invertibility() {
         let c: TileDBContext = TileDBContext::new().unwrap();
 
-        proptest!(|(filters_in in tiledb::filter::strategy::prop_filter_pipeline())| {
+        proptest!(|(filters_in in tiledb::filter::strategy::prop_filter_pipeline(Default::default()))| {
             let filters_in = filters_in.create(&c)
                 .expect("Error constructing arbitrary filter list");
             let metadata = FilterMetadata::new(&filters_in)

--- a/tiledb/arrow/src/schema.rs
+++ b/tiledb/arrow/src/schema.rs
@@ -160,7 +160,7 @@ mod tests {
         let c: TileDBContext = TileDBContext::new()?;
 
         /* tiledb => arrow => tiledb */
-        proptest!(|(tdb_in in tiledb::array::schema::strategy::prop_schema())| {
+        proptest!(|(tdb_in in tiledb::array::schema::strategy::prop_schema(Default::default()))| {
             let tdb_in = tdb_in.create(&c)
                 .expect("Error constructing arbitrary tiledb attribute");
             if let Some(arrow_schema) = arrow_schema(&tdb_in)


### PR DESCRIPTION
Even though you can create a schema, that doesn't mean it can turn into an array!  This pull request found that out and then modifies our schema generation strategies so that our test does what we would like.

A lot of the complexity is driven by the constraints on the webp filter, and also by the proptest library guidance to avoid `proptest_filter`.  Fortunately our strategy already generates a Domain before it generates the attribute filters, so we can pass the Domain down to the filter pipeline generator and use it to determine what we're able to do.

The other main challenge is the dimension/attribute name uniqueness. Solving this with `proptest_filter` does not work at all because shrinking does not work on our types yet.  I started out trying to solve this by generating a set of names at the beginning and threading them through the dimension and attribute strategies, but this proved to be surprisingly complicated, so in the end we just make a pass at the end to de-duplicate the names.  It's not really the "correct" solution but it means we can Do The Thing, which seems like a fine compromise to make.