### PR TITLE
Implement proptest shrinking for filter pipeline

### DIFF
--- a/tiledb/api/src/array/attribute/strategy.rs
+++ b/tiledb/api/src/array/attribute/strategy.rs
@@ -6,7 +6,6 @@ use serde_json::json;
 use crate::array::{attribute::FillData, ArrayType, AttributeData, DomainData};
 use crate::datatype::strategy::*;
 use crate::filter::list::FilterListData;
-use crate::filter::strategy::*;
 use crate::{fn_typed, Datatype};
 
 #[derive(Clone)]
@@ -59,7 +58,7 @@ fn prop_filters(
         input_datatype: Some(datatype),
     };
 
-    prop_filter_pipeline(Rc::new(pipeline_requirements))
+    any_with::<FilterListData>(Rc::new(pipeline_requirements))
 }
 
 /// Returns a strategy for generating an arbitrary Attribute of the given datatype

--- a/tiledb/api/src/array/dimension/strategy.rs
+++ b/tiledb/api/src/array/dimension/strategy.rs
@@ -96,7 +96,7 @@ pub fn prop_dimension_for_datatype(
                 domain: [json!(values.0[0]), json!(values.0[1])],
                 extent: json!(values.1),
                 cell_val_num: None,
-                filters: vec![],
+                filters: Default::default(),
             })
             .boxed()
     })

--- a/tiledb/api/src/array/schema/strategy.rs
+++ b/tiledb/api/src/array/schema/strategy.rs
@@ -12,7 +12,7 @@ use crate::array::domain::strategy::{Requirements as DomainRequirements, *};
 use crate::array::{ArrayType, DomainData, Layout, SchemaData};
 use crate::filter::list::FilterListData;
 use crate::filter::strategy::{
-    Requirements as FilterRequirements, StrategyContext as FilterContext, *,
+    Requirements as FilterRequirements, StrategyContext as FilterContext,
 };
 
 #[derive(Clone, Default)]
@@ -59,7 +59,7 @@ pub fn prop_coordinate_filters(
         ))),
         ..Default::default()
     };
-    prop_filter_pipeline(Rc::new(req))
+    any_with::<FilterListData>(Rc::new(req))
 }
 
 fn prop_schema_for_domain(
@@ -94,8 +94,8 @@ fn prop_schema_for_domain(
             MIN_ATTRS..=MAX_ATTRS,
         ),
         prop_coordinate_filters(&domain),
-        prop_filter_pipeline(Default::default()),
-        prop_filter_pipeline(Default::default()),
+        any::<FilterListData>(),
+        any::<FilterListData>()
     )
         .prop_map(
             move |(

--- a/tiledb/api/src/filter/list.rs
+++ b/tiledb/api/src/filter/list.rs
@@ -2,6 +2,8 @@ use std::borrow::Borrow;
 use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::ops::Deref;
 
+use serde::{Deserialize, Serialize};
+
 use crate::context::{CApiInterface, Context, ContextBound};
 use crate::filter::{Filter, FilterData, RawFilter};
 use crate::Result as TileDBResult;
@@ -191,7 +193,25 @@ impl<'ctx> Builder<'ctx> {
     }
 }
 
-pub type FilterListData = Vec<FilterData>;
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct FilterListData(Vec<FilterData>);
+
+impl Deref for FilterListData {
+    type Target = Vec<FilterData>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl FromIterator<FilterData> for FilterListData {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = FilterData>,
+    {
+        FilterListData(iter.into_iter().collect::<Vec<FilterData>>())
+    }
+}
 
 impl<'ctx> TryFrom<&FilterList<'ctx>> for FilterListData {
     type Error = crate::error::Error;

--- a/tiledb/api/src/filter/strategy.rs
+++ b/tiledb/api/src/filter/strategy.rs
@@ -303,7 +303,7 @@ fn prop_filter_pipeline_impl(
     }
 }
 
-pub fn prop_filter_pipeline(
+fn prop_filter_pipeline(
     requirements: Rc<Requirements>,
 ) -> impl Strategy<Value = FilterListData> {
     const MIN_FILTERS: usize = 0;

--- a/tiledb/api/src/filter/strategy.rs
+++ b/tiledb/api/src/filter/strategy.rs
@@ -2,7 +2,8 @@ use std::collections::VecDeque;
 use std::rc::Rc;
 
 use proptest::prelude::*;
-use proptest::strategy::Just;
+use proptest::strategy::{Just, NewTree, Strategy, ValueTree};
+use proptest::test_runner::TestRunner;
 
 use crate::array::{ArrayType, DomainData};
 use crate::datatype::strategy::*;
@@ -10,14 +11,14 @@ use crate::filter::list::FilterListData;
 use crate::filter::*;
 use crate::Datatype;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum StrategyContext {
     Domain(ArrayType, Rc<DomainData>),
     SchemaCoordinates(Rc<DomainData>),
 }
 
 /// Defines requirements for what a generated filter must be able to accept
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Requirements {
     pub input_datatype: Option<Datatype>,
     pub context: Option<StrategyContext>,
@@ -333,10 +334,96 @@ pub fn prop_filter_pipeline(
     }
 }
 
+/// Value tree to search through the complexity space of some filter pipeline.
+/// A filter pipeline has a bit more structure than just a list of filters,
+/// because the output of each filter feeds into the next one.
+/// The input type is fixed, but the final output can be any data type.
+///
+/// The complexity search space is more restricted than a generic vector strategy.
+/// 1) the filters themselves are basically scalars, so we don't need to shrink them
+/// 2) we must preserve the soundness of the pipeline with contiguous elements,
+///    so our only option is to delete from (or restore) the back of the pipeline
+#[derive(Debug)]
+pub struct FilterPipelineValueTree {
+    initial_pipeline: FilterListData,
+    sublen: usize,
+}
+
+impl FilterPipelineValueTree {
+    pub fn new(init: FilterListData) -> Self {
+        let sublen = init.len();
+        FilterPipelineValueTree {
+            initial_pipeline: init,
+            sublen,
+        }
+    }
+}
+
+impl ValueTree for FilterPipelineValueTree {
+    type Value = FilterListData;
+
+    fn current(&self) -> Self::Value {
+        self.initial_pipeline
+            .iter()
+            .take(self.sublen)
+            .cloned()
+            .collect::<FilterListData>()
+    }
+
+    fn simplify(&mut self) -> bool {
+        if self.sublen > 0 {
+            self.sublen -= 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn complicate(&mut self) -> bool {
+        if self.sublen < self.initial_pipeline.len() {
+            self.sublen += 1;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct FilterPipelineStrategy {
+    requirements: Rc<Requirements>,
+}
+
+impl Strategy for FilterPipelineStrategy {
+    type Tree = FilterPipelineValueTree;
+    type Value = FilterListData;
+
+    fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
+        let initial_pipeline =
+            prop_filter_pipeline(Rc::clone(&self.requirements))
+                .new_tree(runner)?
+                .current();
+
+        Ok(FilterPipelineValueTree::new(initial_pipeline))
+    }
+}
+
+impl Arbitrary for FilterListData {
+    type Parameters = Rc<Requirements>;
+    type Strategy = FilterPipelineStrategy;
+
+    fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+        FilterPipelineStrategy {
+            requirements: Rc::clone(&args),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{Context, Factory};
+    use proptest::strategy::{Strategy, ValueTree};
 
     #[test]
     /// Test that the arbitrary filter construction always succeeds
@@ -430,5 +517,26 @@ mod tests {
                 .expect("Error constructing arbitrary filter");
             assert_eq!(attr, attr);
         });
+    }
+
+    /// Ensure that filter pipelines can shrink
+    #[test]
+    fn pipeline_shrinking() {
+        let strat = any::<FilterListData>();
+
+        let mut runner =
+            proptest::test_runner::TestRunner::new(Default::default());
+
+        let mut value = loop {
+            let value = strat.new_tree(&mut runner).unwrap();
+            if value.current().len() > 2 {
+                break value;
+            }
+        };
+
+        let init = value.current();
+        while value.simplify() {
+            assert!(value.current().len() < init.len());
+        }
     }
 }

--- a/tiledb/arrow/src/filter.rs
+++ b/tiledb/arrow/src/filter.rs
@@ -51,7 +51,7 @@ mod tests {
     fn test_serialize_invertibility() {
         let c: TileDBContext = TileDBContext::new().unwrap();
 
-        proptest!(|(filters_in in tiledb::filter::strategy::prop_filter_pipeline(Default::default()))| {
+        proptest!(|(filters_in in any::<tiledb::filter::list::FilterListData>())| {
             let filters_in = filters_in.create(&c)
                 .expect("Error constructing arbitrary filter list");
             let metadata = FilterMetadata::new(&filters_in)


### PR DESCRIPTION
The strategy which generates filter pipelines is rather complex because it has to ensure that the output from each filter chains to the input from the next filter.  The strategy has to first choose an input datatype and a number of filters, and then it basically folds over those to produce the pipeline.

The end result sure looks a lot like a vector, and we'd probably like it to shrink like one when tests fail.  But the folding strategy basically does not work at all with this, and some light testing makes it very unclear if the simplification step ever actually does reduce the number of filters in the pipeline.

So here we implement `Arbitrary` for `FilterListData`, using the same code to produce the initial pipeline, and then we shrink the pipeline by trimming off the end (which we can do since the final data type of the pipeline does not matter).