### PR TITLE
Enable #[derive(ContextBound)]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,6 +1028,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.53",
+ "tiledb",
 ]
 
 [[package]]

--- a/tiledb/api/src/array/attribute/mod.rs
+++ b/tiledb/api/src/array/attribute/mod.rs
@@ -272,7 +272,7 @@ impl<'c1, 'c2> PartialEq<Attribute<'c2>> for Attribute<'c1> {
 
 #[derive(ContextBound)]
 pub struct Builder<'ctx> {
-    #[ContextBound]
+    #[base(ContextBound)]
     attr: Attribute<'ctx>,
 }
 

--- a/tiledb/api/src/array/attribute/mod.rs
+++ b/tiledb/api/src/array/attribute/mod.rs
@@ -37,15 +37,11 @@ impl Drop for RawAttribute {
     }
 }
 
+#[derive(ContextBound)]
 pub struct Attribute<'ctx> {
+    #[context]
     context: &'ctx Context,
     raw: RawAttribute,
-}
-
-impl<'ctx> ContextBound<'ctx> for Attribute<'ctx> {
-    fn context(&self) -> &'ctx Context {
-        self.context
-    }
 }
 
 impl<'ctx> Attribute<'ctx> {
@@ -274,14 +270,10 @@ impl<'c1, 'c2> PartialEq<Attribute<'c2>> for Attribute<'c1> {
     }
 }
 
+#[derive(ContextBound)]
 pub struct Builder<'ctx> {
+    #[ContextBound]
     attr: Attribute<'ctx>,
-}
-
-impl<'ctx> ContextBound<'ctx> for Builder<'ctx> {
-    fn context(&self) -> &'ctx Context {
-        self.attr.context
-    }
 }
 
 impl<'ctx> Builder<'ctx> {

--- a/tiledb/api/src/array/dimension/mod.rs
+++ b/tiledb/api/src/array/dimension/mod.rs
@@ -173,7 +173,7 @@ impl<'c1, 'c2> PartialEq<Dimension<'c2>> for Dimension<'c1> {
 
 #[derive(ContextBound)]
 pub struct Builder<'ctx> {
-    #[ContextBound]
+    #[base(ContextBound)]
     dim: Dimension<'ctx>,
 }
 

--- a/tiledb/api/src/array/dimension/mod.rs
+++ b/tiledb/api/src/array/dimension/mod.rs
@@ -32,15 +32,11 @@ impl Drop for RawDimension {
     }
 }
 
+#[derive(ContextBound)]
 pub struct Dimension<'ctx> {
+    #[context]
     pub(crate) context: &'ctx Context,
     pub(crate) raw: RawDimension,
-}
-
-impl<'ctx> ContextBound<'ctx> for Dimension<'ctx> {
-    fn context(&self) -> &'ctx Context {
-        self.context
-    }
 }
 
 impl<'ctx> Dimension<'ctx> {
@@ -175,14 +171,10 @@ impl<'c1, 'c2> PartialEq<Dimension<'c2>> for Dimension<'c1> {
     }
 }
 
+#[derive(ContextBound)]
 pub struct Builder<'ctx> {
+    #[ContextBound]
     dim: Dimension<'ctx>,
-}
-
-impl<'ctx> ContextBound<'ctx> for Builder<'ctx> {
-    fn context(&self) -> &'ctx Context {
-        self.dim.context
-    }
 }
 
 impl<'ctx> Builder<'ctx> {

--- a/tiledb/api/src/array/domain/mod.rs
+++ b/tiledb/api/src/array/domain/mod.rs
@@ -63,15 +63,11 @@ macro_rules! impl_dimension_key_for_str {
 }
 impl_dimension_key_for_str!(&str, String);
 
+#[derive(ContextBound)]
 pub struct Domain<'ctx> {
+    #[context]
     context: &'ctx Context,
     raw: RawDomain,
-}
-
-impl<'ctx> ContextBound<'ctx> for Domain<'ctx> {
-    fn context(&self) -> &'ctx Context {
-        self.context
-    }
 }
 
 impl<'ctx> Domain<'ctx> {
@@ -200,14 +196,10 @@ impl<'c1, 'c2> PartialEq<Domain<'c2>> for Domain<'c1> {
     }
 }
 
+#[derive(ContextBound)]
 pub struct Builder<'ctx> {
+    #[ContextBound]
     domain: Domain<'ctx>,
-}
-
-impl<'ctx> ContextBound<'ctx> for Builder<'ctx> {
-    fn context(&self) -> &'ctx Context {
-        self.domain.context
-    }
 }
 
 impl<'ctx> Builder<'ctx> {

--- a/tiledb/api/src/array/domain/mod.rs
+++ b/tiledb/api/src/array/domain/mod.rs
@@ -198,7 +198,7 @@ impl<'c1, 'c2> PartialEq<Domain<'c2>> for Domain<'c1> {
 
 #[derive(ContextBound)]
 pub struct Builder<'ctx> {
-    #[ContextBound]
+    #[base(ContextBound)]
     domain: Domain<'ctx>,
 }
 

--- a/tiledb/api/src/array/enumeration/mod.rs
+++ b/tiledb/api/src/array/enumeration/mod.rs
@@ -32,15 +32,11 @@ impl Drop for RawEnumeration {
     }
 }
 
+#[derive(ContextBound)]
 pub struct Enumeration<'ctx> {
+    #[context]
     context: &'ctx Context,
     raw: RawEnumeration,
-}
-
-impl<'ctx> ContextBound<'ctx> for Enumeration<'ctx> {
-    fn context(&self) -> &'ctx Context {
-        self.context
-    }
 }
 
 impl<'ctx> Enumeration<'ctx> {
@@ -244,7 +240,9 @@ impl<'c1, 'c2> PartialEq<Enumeration<'c2>> for Enumeration<'c1> {
     }
 }
 
+#[derive(ContextBound)]
 pub struct Builder<'ctx, 'data, 'offsets> {
+    #[context]
     context: &'ctx Context,
     name: String,
     dtype: Datatype,
@@ -252,14 +250,6 @@ pub struct Builder<'ctx, 'data, 'offsets> {
     ordered: bool,
     data: &'data [u8],
     offsets: Option<&'offsets [u64]>,
-}
-
-impl<'ctx, 'data, 'offsets> ContextBound<'ctx>
-    for Builder<'ctx, 'data, 'offsets>
-{
-    fn context(&self) -> &'ctx Context {
-        self.context
-    }
 }
 
 pub trait EnumerationBuilderData {}

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -137,15 +137,11 @@ impl Drop for RawArray {
     }
 }
 
+#[derive(ContextBound)]
 pub struct Array<'ctx> {
+    #[context]
     context: &'ctx Context,
     raw: RawArray,
-}
-
-impl<'ctx> ContextBound<'ctx> for Array<'ctx> {
-    fn context(&self) -> &'ctx Context {
-        self.context
-    }
 }
 
 impl<'ctx> Array<'ctx> {

--- a/tiledb/api/src/array/schema/mod.rs
+++ b/tiledb/api/src/array/schema/mod.rs
@@ -75,15 +75,11 @@ type FnFilterListGet = unsafe extern "C" fn(
     *mut *mut ffi::tiledb_filter_list_t,
 ) -> i32;
 
+#[derive(ContextBound)]
 pub struct Schema<'ctx> {
+    #[context]
     context: &'ctx Context,
     raw: RawSchema,
-}
-
-impl<'ctx> ContextBound<'ctx> for Schema<'ctx> {
-    fn context(&self) -> &'ctx Context {
-        self.context
-    }
 }
 
 impl<'ctx> Schema<'ctx> {
@@ -313,14 +309,10 @@ type FnFilterListSet = unsafe extern "C" fn(
     *mut ffi::tiledb_filter_list_t,
 ) -> i32;
 
+#[derive(ContextBound)]
 pub struct Builder<'ctx> {
+    #[ContextBound]
     schema: Schema<'ctx>,
-}
-
-impl<'ctx> ContextBound<'ctx> for Builder<'ctx> {
-    fn context(&self) -> &'ctx Context {
-        self.schema.context
-    }
 }
 
 impl<'ctx> Builder<'ctx> {

--- a/tiledb/api/src/array/schema/mod.rs
+++ b/tiledb/api/src/array/schema/mod.rs
@@ -311,7 +311,7 @@ type FnFilterListSet = unsafe extern "C" fn(
 
 #[derive(ContextBound)]
 pub struct Builder<'ctx> {
-    #[ContextBound]
+    #[base(ContextBound)]
     schema: Schema<'ctx>,
 }
 

--- a/tiledb/api/src/filter/list.rs
+++ b/tiledb/api/src/filter/list.rs
@@ -29,15 +29,11 @@ impl Drop for RawFilterList {
     }
 }
 
+#[derive(ContextBound)]
 pub struct FilterList<'ctx> {
+    #[context]
     pub(crate) context: &'ctx Context,
     pub(crate) raw: RawFilterList,
-}
-
-impl<'ctx> ContextBound<'ctx> for FilterList<'ctx> {
-    fn context(&self) -> &'ctx Context {
-        self.context
-    }
 }
 
 impl<'ctx> FilterList<'ctx> {
@@ -135,14 +131,10 @@ impl<'c1, 'c2> PartialEq<FilterList<'c2>> for FilterList<'c1> {
     }
 }
 
+#[derive(ContextBound)]
 pub struct Builder<'ctx> {
+    #[base(ContextBound)]
     filter_list: FilterList<'ctx>,
-}
-
-impl<'ctx> ContextBound<'ctx> for Builder<'ctx> {
-    fn context(&self) -> &'ctx Context {
-        self.filter_list.context()
-    }
 }
 
 impl<'ctx> Builder<'ctx> {

--- a/tiledb/api/src/filter/mod.rs
+++ b/tiledb/api/src/filter/mod.rs
@@ -314,15 +314,11 @@ impl Drop for RawFilter {
     }
 }
 
+#[derive(ContextBound)]
 pub struct Filter<'ctx> {
+    #[context]
     context: &'ctx Context,
     pub(crate) raw: RawFilter,
-}
-
-impl<'ctx> ContextBound<'ctx> for Filter<'ctx> {
-    fn context(&self) -> &'ctx Context {
-        self.context
-    }
 }
 
 impl<'ctx> Filter<'ctx> {

--- a/tiledb/api/src/query/mod.rs
+++ b/tiledb/api/src/query/mod.rs
@@ -32,7 +32,9 @@ impl Drop for RawQuery {
     }
 }
 
+#[derive(ContextBound)]
 pub struct Query<'ctx> {
+    #[context]
     context: &'ctx Context,
     array: Array<'ctx>,
     subarrays: Vec<Subarray<'ctx>>,
@@ -41,12 +43,6 @@ pub struct Query<'ctx> {
     // in order to pin the size to a fixed address
     result_buffers: HashMap<String, Box<u64>>,
     raw: RawQuery,
-}
-
-impl<'ctx> ContextBound<'ctx> for Query<'ctx> {
-    fn context(&self) -> &'ctx Context {
-        self.context
-    }
 }
 
 impl<'ctx> Query<'ctx> {
@@ -63,14 +59,10 @@ impl<'ctx> Query<'ctx> {
     }
 }
 
+#[derive(ContextBound)]
 pub struct Builder<'ctx> {
+    #[base(ContextBound)]
     query: Query<'ctx>,
-}
-
-impl<'ctx> ContextBound<'ctx> for Builder<'ctx> {
-    fn context(&self) -> &'ctx Context {
-        self.query.context()
-    }
 }
 
 impl<'ctx> Builder<'ctx> {

--- a/tiledb/api/src/query/subarray.rs
+++ b/tiledb/api/src/query/subarray.rs
@@ -26,26 +26,18 @@ impl Drop for RawSubarray {
     }
 }
 
+#[derive(ContextBound)]
 pub struct Subarray<'ctx> {
+    #[context]
     context: &'ctx Context,
     raw: RawSubarray,
 }
 
-impl<'ctx> ContextBound<'ctx> for Subarray<'ctx> {
-    fn context(&self) -> &'ctx Context {
-        self.context
-    }
-}
-
+#[derive(ContextBound)]
 pub struct Builder<'ctx> {
     query: QueryBuilder<'ctx>,
+    #[base(ContextBound)]
     subarray: Subarray<'ctx>,
-}
-
-impl<'ctx> ContextBound<'ctx> for Builder<'ctx> {
-    fn context(&self) -> &'ctx Context {
-        self.subarray.context()
-    }
 }
 
 impl<'ctx> Builder<'ctx> {

--- a/tiledb/api/src/vfs.rs
+++ b/tiledb/api/src/vfs.rs
@@ -32,15 +32,11 @@ impl Drop for RawVFS {
     }
 }
 
+#[derive(ContextBound)]
 pub struct VFS<'ctx> {
+    #[context]
     context: &'ctx Context,
     raw: RawVFS,
-}
-
-impl<'ctx> ContextBound<'ctx> for VFS<'ctx> {
-    fn context(&self) -> &'ctx Context {
-        self.context
-    }
 }
 
 pub(crate) enum RawVFSHandle {
@@ -63,15 +59,11 @@ impl Drop for RawVFSHandle {
     }
 }
 
+#[derive(ContextBound)]
 pub struct VFSHandle<'ctx> {
+    #[context]
     context: &'ctx Context,
     raw: RawVFSHandle,
-}
-
-impl<'ctx> ContextBound<'ctx> for VFSHandle<'ctx> {
-    fn context(&self) -> &'ctx Context {
-        self.context
-    }
 }
 
 impl<'ctx> VFS<'ctx> {

--- a/tiledb/proc-macro/Cargo.toml
+++ b/tiledb/proc-macro/Cargo.toml
@@ -11,5 +11,8 @@ proc-macro2 = "1"
 quote = "1"
 syn = "2"
 
+[dev-dependencies]
+tiledb = { workspace = true }
+
 [lib]
 proc-macro = true

--- a/tiledb/proc-macro/src/context.rs
+++ b/tiledb/proc-macro/src/context.rs
@@ -1,0 +1,82 @@
+use proc_macro::TokenStream;
+use proc_macro2::{Ident, Span};
+use syn::spanned::Spanned;
+
+pub fn expand(input: &syn::DeriveInput) -> TokenStream {
+    let name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) =
+        input.generics.split_for_impl();
+    let body = context_bound_body(input);
+
+    let expanded = quote! {
+        impl #impl_generics ContextBound <'ctx> for #name #ty_generics #where_clause {
+            fn context(&self) -> &'ctx Context {
+                #body
+            }
+        }
+    };
+    expanded.into()
+}
+
+fn context_bound_body(input: &syn::DeriveInput) -> proc_macro2::TokenStream {
+    match input.data {
+        syn::Data::Struct(ref structdata) => match structdata.fields {
+            syn::Fields::Named(ref fields) => {
+                match context_bound_body_fields_named(fields) {
+                    Some(tt) => tt,
+                    None => quote_spanned! {
+                        fields.span() => compile_error!("expected field with #[context] or #[base(ContextBound)] attribute")
+                    },
+                }
+            }
+            syn::Fields::Unnamed(_) => {
+                unimplemented!("syn::Fields::Unnamed")
+            }
+            syn::Fields::Unit => unimplemented!("syn::Fields::Unit"),
+        },
+        syn::Data::Enum(_) => unimplemented!("syn::Data::Enum"),
+        syn::Data::Union(_) => unimplemented!("syn::Data::Union"),
+    }
+}
+
+fn context_bound_body_fields_named(
+    fields: &syn::FieldsNamed,
+) -> Option<proc_macro2::TokenStream> {
+    for f in fields.named.iter() {
+        for a in f.attrs.iter() {
+            if let syn::AttrStyle::Outer = a.style {
+                match a.meta {
+                    syn::Meta::Path(ref p) => {
+                        let mpath = p
+                            .segments
+                            .iter()
+                            .map(|p| p.ident.to_string())
+                            .collect::<Vec<String>>();
+                        if mpath == vec!["context"] {
+                            let fname = Ident::new(
+                                &f.ident.as_ref().unwrap().to_string(),
+                                Span::call_site(),
+                            );
+                            return Some(quote! {
+                                self.#fname
+                            });
+                        } else if mpath == vec!["ContextBound"] {
+                            let fname = Ident::new(
+                                &f.ident.as_ref().unwrap().to_string(),
+                                Span::call_site(),
+                            );
+                            return Some(quote! {
+                                self.#fname.context()
+                            });
+                        }
+                    }
+                    syn::Meta::List(_) => {
+                        unimplemented!()
+                    }
+                    syn::Meta::NameValue(_) => unimplemented!(),
+                }
+            }
+        }
+    }
+    None
+}

--- a/tiledb/proc-macro/src/context.rs
+++ b/tiledb/proc-macro/src/context.rs
@@ -122,7 +122,7 @@ fn context_bound_impl_fields_named_base(
         for generic in input.generics.params.iter() {
             match generic {
                 GenericParam::Lifetime(ref l) => {
-                    if l.lifetime.ident.to_string() == "ctx" {
+                    if l.lifetime.ident == "ctx" {
                         has_ctx_bound = true;
                         break;
                     }
@@ -182,5 +182,5 @@ fn context_bound_impl_fields_named_base(
         }
     };
 
-    expanded.into()
+    expanded
 }

--- a/tiledb/proc-macro/src/lib.rs
+++ b/tiledb/proc-macro/src/lib.rs
@@ -11,7 +11,7 @@ use syn::DeriveInput;
 mod context;
 mod option_subset;
 
-#[proc_macro_derive(ContextBound, attributes(context, ContextBound))]
+#[proc_macro_derive(ContextBound, attributes(context, base))]
 pub fn derive_context_bound(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     context::expand(&input)

--- a/tiledb/proc-macro/src/lib.rs
+++ b/tiledb/proc-macro/src/lib.rs
@@ -8,7 +8,14 @@ extern crate syn;
 use proc_macro::TokenStream;
 use syn::DeriveInput;
 
+mod context;
 mod option_subset;
+
+#[proc_macro_derive(ContextBound, attributes(context, ContextBound))]
+pub fn derive_context_bound(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    context::expand(&input)
+}
 
 #[proc_macro_derive(OptionSubset)]
 pub fn derive_option_subset(input: TokenStream) -> TokenStream {

--- a/tiledb/proc-macro/tests/context.rs
+++ b/tiledb/proc-macro/tests/context.rs
@@ -1,0 +1,254 @@
+extern crate tiledb;
+#[macro_use]
+extern crate tiledb_proc_macro;
+
+use std::cell::RefCell;
+
+use tiledb::{Context, ContextBound};
+
+#[derive(ContextBound)]
+struct SimpleThing<'ctx> {
+    #[context]
+    context: &'ctx Context,
+}
+
+#[test]
+fn simple() {
+    let context = Context::new().unwrap();
+    let simple = SimpleThing { context: &context };
+
+    assert_eq!(
+        &context as *const Context,
+        simple.context() as *const Context
+    );
+}
+
+#[derive(Clone)]
+struct DeriveBase<'ctx> {
+    found: RefCell<bool>,
+    context: &'ctx Context,
+}
+
+impl<'ctx> DeriveBase<'ctx> {
+    fn new(context: &'ctx Context) -> Self {
+        DeriveBase {
+            found: RefCell::new(false),
+            context,
+        }
+    }
+}
+
+impl<'ctx> ContextBound<'ctx> for DeriveBase<'ctx> {
+    fn context(&self) -> &'ctx Context {
+        *self.found.borrow_mut() = true;
+        self.context
+    }
+}
+
+#[derive(ContextBound)]
+struct DirectBase<'ctx> {
+    #[base(ContextBound)]
+    base: DeriveBase<'ctx>,
+}
+
+#[test]
+fn direct_base() {
+    let context = Context::new().unwrap();
+
+    let s = DirectBase {
+        base: DeriveBase::new(&context),
+    };
+
+    assert_eq!(&context as *const Context, s.context() as *const Context);
+    assert!(*s.base.found.borrow());
+}
+
+#[derive(ContextBound)]
+struct IndirectBase<'ctx> {
+    #[base(ContextBound)]
+    base: DirectBase<'ctx>,
+}
+
+#[test]
+fn indirect_base() {
+    let context = Context::new().unwrap();
+
+    let s = IndirectBase {
+        base: DirectBase {
+            base: DeriveBase::new(&context),
+        },
+    };
+
+    assert_eq!(&context as *const Context, s.context() as *const Context);
+    assert!(*s.base.base.found.borrow());
+}
+
+#[derive(ContextBound)]
+struct GenericDirectBase<'ctx, T> {
+    _marker: std::marker::PhantomData<T>,
+    #[base(ContextBound)]
+    base: DeriveBase<'ctx>,
+}
+
+#[test]
+fn generic_direct_base() {
+    let context = Context::new().unwrap();
+
+    let s = GenericDirectBase {
+        _marker: std::marker::PhantomData::<u64>,
+        base: DeriveBase::new(&context),
+    };
+
+    assert_eq!(&context as *const Context, s.context() as *const Context);
+    assert!(*s.base.found.borrow());
+}
+
+#[derive(ContextBound)]
+struct GenericIndirectBase<'ctx, T> {
+    #[base(ContextBound)]
+    base: GenericDirectBase<'ctx, T>,
+}
+
+#[test]
+fn generic_indirect_base() {
+    let context = Context::new().unwrap();
+
+    let s = GenericIndirectBase {
+        base: GenericDirectBase {
+            _marker: std::marker::PhantomData::<u64>,
+            base: DeriveBase::new(&context),
+        },
+    };
+
+    assert_eq!(&context as *const Context, s.context() as *const Context);
+    assert!(*s.base.base.found.borrow());
+}
+
+#[derive(ContextBound)]
+struct GenericDirectBaseBounded<'ctx, T>
+where
+    T: Default,
+{
+    _marker: std::marker::PhantomData<T>,
+    #[base(ContextBound)]
+    base: DeriveBase<'ctx>,
+}
+
+#[test]
+fn generic_direct_base_bounded() {
+    let context = Context::new().unwrap();
+
+    let s = GenericDirectBaseBounded {
+        _marker: std::marker::PhantomData::<u64>,
+        base: DeriveBase::new(&context),
+    };
+
+    assert_eq!(&context as *const Context, s.context() as *const Context);
+    assert!(*s.base.found.borrow());
+}
+
+#[derive(ContextBound)]
+struct GenericIndirectBaseBounded<'ctx, T>
+where
+    T: Default,
+{
+    #[base(ContextBound)]
+    base: GenericDirectBaseBounded<'ctx, T>,
+}
+
+#[test]
+fn generic_indirect_base_bounded() {
+    let context = Context::new().unwrap();
+
+    let s = GenericIndirectBaseBounded {
+        base: GenericDirectBaseBounded {
+            _marker: std::marker::PhantomData::<u64>,
+            base: DeriveBase::new(&context),
+        },
+    };
+
+    assert_eq!(&context as *const Context, s.context() as *const Context);
+    assert!(*s.base.base.found.borrow());
+}
+
+#[derive(ContextBound)]
+struct UnboundedCtxBaseNotCtx<'ctx, T> {
+    _marker: std::marker::PhantomData<&'ctx u64>,
+    #[base(ContextBound)]
+    base: T,
+}
+
+#[test]
+fn unbounded_ctx_base_not_ctx() {
+    let context = Context::new().unwrap();
+
+    let s = UnboundedCtxBaseNotCtx {
+        _marker: std::marker::PhantomData,
+        base: DeriveBase::new(&context),
+    };
+
+    assert_eq!(&context as *const Context, s.context() as *const Context);
+    assert!(*s.base.found.borrow());
+}
+
+#[derive(ContextBound)]
+struct ContextBoundBase<'ctx, T>
+where
+    T: ContextBound<'ctx>,
+{
+    _marker: std::marker::PhantomData<&'ctx u64>,
+    #[base(ContextBound)]
+    base: T,
+}
+
+#[test]
+fn context_bound_base() {
+    let context = Context::new().unwrap();
+
+    let s = ContextBoundBase {
+        _marker: std::marker::PhantomData,
+        base: DeriveBase::new(&context),
+    };
+
+    assert_eq!(&context as *const Context, s.context() as *const Context);
+    assert!(*s.base.found.borrow());
+}
+
+#[derive(ContextBound)]
+struct UnboundedBase<T> {
+    #[base(ContextBound)]
+    base: T,
+}
+
+#[test]
+fn unbounded_base() {
+    let context = Context::new().unwrap();
+
+    let s = UnboundedBase {
+        base: DeriveBase::new(&context),
+    };
+
+    assert_eq!(&context as *const Context, s.context() as *const Context);
+    assert!(*s.base.found.borrow());
+}
+
+#[derive(ContextBound)]
+struct UnrelatedBoundedBase<T>
+where
+    T: Clone,
+{
+    #[base(ContextBound)]
+    base: T,
+}
+
+#[test]
+fn unrelated_bounded_base() {
+    let context = Context::new().unwrap();
+
+    let s = UnrelatedBoundedBase {
+        base: DeriveBase::new(&context),
+    };
+
+    assert_eq!(&context as *const Context, s.context() as *const Context);
+    assert!(*s.base.found.borrow());
+}


### PR DESCRIPTION
This pull request enables writing `#[derive(ContextBound)]`.  The implementation looks for a field with an attribute either `#[context]`, which is the context field to return directly, or a field with attribute `#[base(ContextBound)]` which indicates that the impl should be deferred to the base field.

There are a few `unimplemented!()`s, but what *is* implemented is enough to replace all the manual impls in our current code, as well as satisfy the proc macro unit test which simulates how we will want to use this in the near future for the query API adapters.