### PR TITLE
Fix domain shrinking proptest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "float_next_after"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,6 +1045,8 @@ version = "0.1.0"
 name = "tiledb-utils"
 version = "0.1.0"
 dependencies = [
+ "float_next_after",
+ "num-traits",
  "serde_json",
  "tiledb-proc-macro",
 ]

--- a/tiledb/utils/Cargo.toml
+++ b/tiledb/utils/Cargo.toml
@@ -5,6 +5,8 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
+float_next_after = "1.0.0"
+num-traits = { version = "0.2" }
 serde_json = { workspace = true, optional = true }
 tiledb-proc-macro = { workspace = true }
 

--- a/tiledb/utils/src/numbers.rs
+++ b/tiledb/utils/src/numbers.rs
@@ -1,8 +1,10 @@
+use float_next_after::NextAfter;
+
 pub trait AnyNumCmp {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering;
 }
 
-macro_rules! derive_primitive_anynumcmp {
+macro_rules! derive_primitive_any_num_cmp {
     ($($T:ty),+) => {
         $(
             impl AnyNumCmp for $T {
@@ -14,7 +16,7 @@ macro_rules! derive_primitive_anynumcmp {
     };
 }
 
-macro_rules! derive_float_anynumcmp {
+macro_rules! derive_float_any_num_cmp {
     ($($T:ty),+) => {
         $(
             impl AnyNumCmp for $T {
@@ -26,6 +28,91 @@ macro_rules! derive_float_anynumcmp {
     };
 }
 
-derive_primitive_anynumcmp!(u8, u16, u32, u64, usize);
-derive_primitive_anynumcmp!(i8, i16, i32, i64, isize);
-derive_float_anynumcmp!(f32, f64);
+derive_primitive_any_num_cmp!(u8, u16, u32, u64, usize);
+derive_primitive_any_num_cmp!(i8, i16, i32, i64, isize);
+derive_float_any_num_cmp!(f32, f64);
+
+pub enum NextDirection {
+    Up,
+    Down,
+}
+
+pub trait NextNumericValue {
+    fn next_numeric_value(&self, direction: NextDirection) -> Self;
+}
+
+macro_rules! derive_primitive_next_numeric_value {
+    ($($T:ty),+) => {
+        $(
+            impl NextNumericValue for $T {
+                fn next_numeric_value(&self, direction: NextDirection) -> Self {
+                    let clamp = if matches!(direction, NextDirection::Up) {
+                        <$T>::MAX
+                    } else {
+                        <$T>::MIN
+                    };
+
+                    if *self == clamp {
+                        clamp
+                    } else if matches!(direction, NextDirection::Up) {
+                        self + <$T as num_traits::One>::one()
+                    } else {
+                        self - <$T as num_traits::One>::one()
+                    }
+                }
+            }
+        )+
+    };
+}
+
+macro_rules! derive_float_next_numeric_value {
+    ($($T:ty),+) => {
+        $(
+            impl NextNumericValue for $T {
+                fn next_numeric_value(&self, direction: NextDirection) -> Self {
+                    if matches!(direction, NextDirection::Up) {
+                        self.next_after(<$T>::INFINITY)
+                    } else {
+                        self.next_after(<$T>::NEG_INFINITY)
+                    }
+                }
+            }
+        )+
+    };
+}
+
+derive_primitive_next_numeric_value!(u8, u16, u32, u64, usize);
+derive_primitive_next_numeric_value!(i8, i16, i32, i64, isize);
+derive_float_next_numeric_value!(f32, f64);
+
+pub trait SmallestPositiveValue {
+    fn smallest_positive_value() -> Self;
+}
+
+macro_rules! derive_primitive_smallest_positive_value {
+    ($($T:ty),+) => {
+        $(
+            impl SmallestPositiveValue for $T {
+                fn smallest_positive_value() -> Self {
+                    <$T as num_traits::One>::one()
+                }
+            }
+        )+
+    };
+}
+
+macro_rules! derive_float_smallest_positive_value {
+    ($($T:ty),+) => {
+        $(
+            impl SmallestPositiveValue for $T {
+                fn smallest_positive_value() -> Self {
+                    <$T>::MIN_POSITIVE
+                }
+            }
+        )+
+    };
+}
+
+derive_primitive_smallest_positive_value!(u8, u16, u32, u64, usize);
+derive_primitive_smallest_positive_value!(i8, i16, i32, i64, isize);
+derive_float_smallest_positive_value!(f32, f64);


### PR DESCRIPTION
There were two underlying but related bugs in the dimension range and extent generation. The first bug found and fixed was when we had floating point values with sufficiently large exponents that caused this relationship: `x + y == x`. I.e., "a vary large value + 1 == the same value". This is due to floating point resolution at resolution being larger than 1 when the exponent is large enough. For this bug, the end result was that our extent bounds ended up being `[1.0, 0.0)` which is an empty range that causes proptest to panic internally.

A second version of this same bug also existed for integral values when we had the case of `x + 1 = y`. In this case, due to the open rhs of a range, we ended up with `[1.0, 1.0)` which is also empty.

Once those were fixed, the next issue was based on the same underlying issue in that `x + y == x` can be true for floating point values when `y` is sufficiently smaller than `one`. For this case I had to implement the SmallestPositiveValue trait which is `1` for integral types as would be expected, but is `{f32,f64}::MIN_POSITIVE` which is a tiny value of approximately `1e-127`.

Also, as a side note, since this test is testing the actual proptest shrinking strategy, the TestRunner test cases value is ignored. The easiest way to trigger the issue was to just wrap the test in a `for _ in range 0..1000 { ... }` loop.

Fixes #55