### PR TITLE
Add API Coverage CI Job

### DIFF
--- a/.github/workflows/nigthtly-ci.yml
+++ b/.github/workflows/nigthtly-ci.yml
@@ -1,10 +1,9 @@
+name: Nightlies
 on:
   schedule:
     # runs every day at 1:45 UTC
     - cron: "45 01 * * *"
   workflow_dispatch:
-
-name: Nightlies
 
 jobs:
   update_build_and_test:

--- a/.github/workflows/pr-api-coverage.yml
+++ b/.github/workflows/pr-api-coverage.yml
@@ -1,0 +1,20 @@
+name: PR API Coverage
+on:
+  workflow_call:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tiledb-rs
+        uses: actions/checkout@v3
+      - name: Install Rust Stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: Setup Rustc Cache
+        uses: Swatinem/rust-cache@v2
+      - name: Install TileDB
+        uses: ./.github/actions/install-tiledb
+      - name: Build API Coverage Tool
+        run: cd tools/api-coverage && cargo build
+      - name: Calculate Coverage
+        run: ./target/debug/api-coverage 2>&1 >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pr-build-and-test.yml
+++ b/.github/workflows/pr-build-and-test.yml
@@ -1,20 +1,10 @@
+name: PR Build and Test
 on:
   workflow_call:
-  workflow_dispatch:
 
-  push:
-    branches:
-      - main
-      - refs/tags/*
-  pull_request:
-    branches:
-      - '*'  # must quote since "*" is a YAML reserved character; we want a string
-
-concurrency:
-  group: ${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
-name: PR Checks
+env:
+  # Print stack traces on test failure
+  RUST_BACKTRACE: full
 
 jobs:
   build_and_test:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,22 @@
+name: "Pull Request CI"
+on:
+  push:
+    branches:
+      - dev
+      - release-*
+      - refs/tags/*
+
+  pull_request:
+    branches:
+      - '*'  # Quotes required because * is reserved by YAML
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    uses: ./.github/workflows/pr-build-and-test.yml
+
+  check-api-coverage:
+    uses: ./.github/workflows/pr-api-coverage.yml

--- a/tiledb/api/src/string.rs
+++ b/tiledb/api/src/string.rs
@@ -30,20 +30,21 @@ pub struct TDBString {
 
 impl TDBString {
     pub fn to_string(&self) -> TileDBResult<String> {
-        let mut c_str = std::ptr::null::<std::ffi::c_uchar>();
+        let mut c_str: *const i8 = out_ptr!();
         let mut c_len: usize = 0;
 
         let res = unsafe {
             ffi::tiledb_string_view(
                 *self.raw,
-                &mut c_str as *mut *const u8,
+                &mut c_str as *mut *const i8,
                 &mut c_len,
             )
         };
 
         if res == ffi::TILEDB_OK {
-            let raw_slice: &[u8] =
-                unsafe { std::slice::from_raw_parts(c_str, c_len) };
+            let raw_slice: &[u8] = unsafe {
+                std::slice::from_raw_parts(c_str as *const u8, c_len)
+            };
             let c_str = std::str::from_utf8(raw_slice).map_err(|e| {
                 Error::LibTileDB(format!(
                     "TileDB returned a string that is not UTF-8: {}",

--- a/tiledb/api/src/vfs.rs
+++ b/tiledb/api/src/vfs.rs
@@ -1,10 +1,42 @@
 use std::ops::Deref;
 
-pub use ffi::VFSMode;
+use serde::{Deserialize, Serialize};
 
 use crate::config::{Config, RawConfig};
 use crate::context::{CApiInterface, Context, ContextBound};
 use crate::Result as TileDBResult;
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum VFSMode {
+    Read,
+    Write,
+    Append,
+}
+
+impl VFSMode {
+    pub(crate) fn capi_enum(&self) -> ffi::tiledb_vfs_mode_t {
+        match *self {
+            VFSMode::Read => ffi::tiledb_vfs_mode_t_TILEDB_VFS_READ,
+            VFSMode::Write => ffi::tiledb_vfs_mode_t_TILEDB_VFS_WRITE,
+            VFSMode::Append => ffi::tiledb_vfs_mode_t_TILEDB_VFS_APPEND,
+        }
+    }
+}
+
+impl TryFrom<ffi::tiledb_vfs_mode_t> for VFSMode {
+    type Error = crate::error::Error;
+    fn try_from(value: ffi::tiledb_vfs_mode_t) -> TileDBResult<Self> {
+        match value {
+            ffi::tiledb_vfs_mode_t_TILEDB_VFS_READ => Ok(VFSMode::Read),
+            ffi::tiledb_vfs_mode_t_TILEDB_VFS_WRITE => Ok(VFSMode::Write),
+            ffi::tiledb_vfs_mode_t_TILEDB_VFS_APPEND => Ok(VFSMode::Append),
+            _ => Err(Self::Error::LibTileDB(format!(
+                "Invalid VFS mode: {}",
+                value
+            ))),
+        }
+    }
+}
 
 pub enum VFSLsStatus {
     Continue,
@@ -292,7 +324,13 @@ impl<'ctx> VFS<'ctx> {
         let c_vfs = *self.raw;
         let c_uri = cstring!(uri);
         self.capi_return(unsafe {
-            ffi::tiledb_vfs_open(c_ctx, c_vfs, c_uri.as_ptr(), mode, &mut c_fh)
+            ffi::tiledb_vfs_open(
+                c_ctx,
+                c_vfs,
+                c_uri.as_ptr(),
+                mode.capi_enum(),
+                &mut c_fh,
+            )
         })?;
 
         Ok(VFSHandle {

--- a/tiledb/sys/ignored.rs
+++ b/tiledb/sys/ignored.rs
@@ -6,7 +6,7 @@
 
 // We use the tiledb_version function instead.
 pub const TILEDB_VERSION_MAJOR: u32 = 2;
-pub const TILEDB_VERSION_MINOR: u32 = 22;
+pub const TILEDB_VERSION_MINOR: u32 = 21;
 pub const TILEDB_VERSION_PATCH: u32 = 0;
 
 // This is a list of functions that we are currently planning on not wrapping.

--- a/tiledb/sys/remapped.rs
+++ b/tiledb/sys/remapped.rs
@@ -13,7 +13,13 @@
 //  pub fn old_tiledb_version(major: *mut i32, minor: *mut i32, rev: *mut i32);
 //  pub fn new_tiledb_version(major: *mut u32, minor: *mut u32, rev: *mut u32);
 
-// If/when we need to remap constants, those go outside the extern "C" block.
+// Remapped constants
+
+// For whatever reason, bindgen generate TILEDB_OK as u32, and the other
+// error values as i32. This fixes TILEDB_OK to be i32 so we can compare
+// status codes correctly.
+pub const old_TILEDB_OK: u32 = 0;
+pub const new_TILEDB_OK: i32 = 0;
 
 extern "C" {
 

--- a/tiledb/sys/src/attribute.rs
+++ b/tiledb/sys/src/attribute.rs
@@ -20,7 +20,7 @@ extern "C" {
     pub fn tiledb_attribute_get_type(
         ctx: *mut tiledb_ctx_t,
         attr: *const tiledb_attribute_t,
-        type_: *mut u32,
+        type_: *mut tiledb_datatype_t,
     ) -> i32;
 
     pub fn tiledb_attribute_set_nullable(

--- a/tiledb/sys/src/capi_enum.rs
+++ b/tiledb/sys/src/capi_enum.rs
@@ -157,6 +157,11 @@ pub const tiledb_query_type_t_TILEDB_UPDATE: tiledb_query_type_t = 3;
 pub const tiledb_query_type_t_TILEDB_MODIFY_EXCLUSIVE: tiledb_query_type_t = 4;
 pub type tiledb_query_type_t = ::std::os::raw::c_uint;
 
+pub const tiledb_vfs_mode_t_TILEDB_VFS_READ: tiledb_vfs_mode_t = 0;
+pub const tiledb_vfs_mode_t_TILEDB_VFS_WRITE: tiledb_vfs_mode_t = 1;
+pub const tiledb_vfs_mode_t_TILEDB_VFS_APPEND: tiledb_vfs_mode_t = 2;
+pub type tiledb_vfs_mode_t = ::std::os::raw::c_uint;
+
 pub const tiledb_walk_order_t_TILEDB_PREORDER: tiledb_walk_order_t = 0;
 pub const tiledb_walk_order_t_TILEDB_POSTORDER: tiledb_walk_order_t = 1;
 pub type tiledb_walk_order_t = ::std::os::raw::c_uint;

--- a/tiledb/sys/src/context.rs
+++ b/tiledb/sys/src/context.rs
@@ -1,3 +1,4 @@
+use crate::capi_enum::tiledb_filesystem_t;
 use crate::types::{
     capi_return_t, tiledb_config_t, tiledb_ctx_t, tiledb_error_t,
 };
@@ -27,7 +28,7 @@ extern "C" {
 
     pub fn tiledb_ctx_is_supported_fs(
         ctx: *mut tiledb_ctx_t,
-        fs: u32,
+        fs: tiledb_filesystem_t,
         is_supported: *mut i32,
     ) -> capi_return_t;
 

--- a/tiledb/sys/src/datatype.rs
+++ b/tiledb/sys/src/datatype.rs
@@ -1,15 +1,16 @@
+use crate::capi_enum::tiledb_datatype_t;
 use crate::types::capi_return_t;
 
 extern "C" {
     pub fn tiledb_datatype_to_str(
-        datatype: u32,
+        datatype: tiledb_datatype_t,
         str_: *mut *const ::std::os::raw::c_char,
     ) -> capi_return_t;
 
     pub fn tiledb_datatype_from_str(
         str_: *const ::std::os::raw::c_char,
-        datatype: *mut u32,
+        datatype: *mut tiledb_datatype_t,
     ) -> capi_return_t;
 
-    pub fn tiledb_datatype_size(type_: u32) -> u64;
+    pub fn tiledb_datatype_size(type_: tiledb_datatype_t) -> u64;
 }

--- a/tiledb/sys/src/filesystem.rs
+++ b/tiledb/sys/src/filesystem.rs
@@ -1,13 +1,14 @@
+use crate::capi_enum::tiledb_filesystem_t;
 use crate::types::capi_return_t;
 
 extern "C" {
     pub fn tiledb_filesystem_to_str(
-        filesystem: u32,
+        filesystem: tiledb_filesystem_t,
         str_: *mut *const ::std::os::raw::c_char,
     ) -> capi_return_t;
 
     pub fn tiledb_filesystem_from_str(
         str_: *const ::std::os::raw::c_char,
-        filesystem: *mut u32,
+        filesystem: *mut tiledb_filesystem_t,
     ) -> capi_return_t;
 }

--- a/tiledb/sys/src/filter.rs
+++ b/tiledb/sys/src/filter.rs
@@ -1,11 +1,10 @@
-use crate::types::capi_return_t;
-use crate::types::tiledb_ctx_t;
-use crate::types::tiledb_filter_t;
+use crate::capi_enum::{tiledb_filter_option_t, tiledb_filter_type_t};
+use crate::types::{capi_return_t, tiledb_ctx_t, tiledb_filter_t};
 
 extern "C" {
     pub fn tiledb_filter_alloc(
         ctx: *mut tiledb_ctx_t,
-        type_: u32,
+        type_: tiledb_filter_type_t,
         filter: *mut *mut tiledb_filter_t,
     ) -> capi_return_t;
 
@@ -14,20 +13,20 @@ extern "C" {
     pub fn tiledb_filter_get_type(
         ctx: *mut tiledb_ctx_t,
         filter: *mut tiledb_filter_t,
-        type_: *mut u32,
+        type_: *mut tiledb_filter_type_t,
     ) -> capi_return_t;
 
     pub fn tiledb_filter_set_option(
         ctx: *mut tiledb_ctx_t,
         filter: *mut tiledb_filter_t,
-        option: u32,
+        option: tiledb_filter_option_t,
         value: *const ::std::os::raw::c_void,
     ) -> capi_return_t;
 
     pub fn tiledb_filter_get_option(
         ctx: *mut tiledb_ctx_t,
         filter: *mut tiledb_filter_t,
-        option: u32,
+        option: tiledb_filter_option_t,
         value: *mut ::std::os::raw::c_void,
     ) -> capi_return_t;
 }

--- a/tiledb/sys/src/filter_type.rs
+++ b/tiledb/sys/src/filter_type.rs
@@ -1,13 +1,14 @@
+use crate::capi_enum::tiledb_filter_type_t;
 use crate::types::capi_return_t;
 
 extern "C" {
     pub fn tiledb_filter_type_to_str(
-        filter_type: u32,
+        filter_type: tiledb_filter_type_t,
         str_: *mut *const ::std::os::raw::c_char,
     ) -> capi_return_t;
 
     pub fn tiledb_filter_type_from_str(
         str_: *const ::std::os::raw::c_char,
-        filter_type: *mut u32,
+        filter_type: *mut tiledb_filter_type_t,
     ) -> capi_return_t;
 }

--- a/tiledb/sys/src/stats.rs
+++ b/tiledb/sys/src/stats.rs
@@ -2,6 +2,6 @@ extern "C" {
     pub fn tiledb_stats_enable() -> i32;
     pub fn tiledb_stats_disable() -> i32;
     pub fn tiledb_stats_reset() -> i32;
-    pub fn tiledb_stats_dump_str(out: *mut *mut ::std::ffi::c_char) -> i32;
-    pub fn tiledb_stats_free_str(out: *mut *mut ::std::ffi::c_char) -> i32;
+    pub fn tiledb_stats_dump_str(out: *mut *mut ::std::os::raw::c_char) -> i32;
+    pub fn tiledb_stats_free_str(out: *mut *mut ::std::os::raw::c_char) -> i32;
 }

--- a/tiledb/sys/src/string.rs
+++ b/tiledb/sys/src/string.rs
@@ -3,7 +3,7 @@ use crate::types::{capi_return_t, tiledb_string_t};
 extern "C" {
     pub fn tiledb_string_view(
         s: *mut tiledb_string_t,
-        data: *mut *const ::std::os::raw::c_uchar,
+        data: *mut *const ::std::os::raw::c_char,
         length: *mut usize,
     ) -> capi_return_t;
 

--- a/tiledb/sys/src/vfs.rs
+++ b/tiledb/sys/src/vfs.rs
@@ -1,3 +1,4 @@
+use crate::capi_enum::tiledb_vfs_mode_t;
 use crate::types::{
     capi_return_t, tiledb_config_t, tiledb_ctx_t, tiledb_vfs_fh_t, tiledb_vfs_t,
 };
@@ -26,16 +27,6 @@ pub type LSRecursiveCallback = ::std::option::Option<
 >;
 
 extern "C" {
-    pub fn tiledb_vfs_mode_to_str(
-        vfs_mode: VFSMode,
-        str_: *mut *const ::std::os::raw::c_char,
-    ) -> capi_return_t;
-
-    pub fn tiledb_vfs_mode_from_str(
-        str_: *const ::std::os::raw::c_char,
-        vfs_mode: *mut VFSMode,
-    ) -> capi_return_t;
-
     pub fn tiledb_vfs_alloc(
         ctx: *mut tiledb_ctx_t,
         config: *mut tiledb_config_t,
@@ -182,7 +173,7 @@ extern "C" {
         ctx: *mut tiledb_ctx_t,
         vfs: *mut tiledb_vfs_t,
         uri: *const ::std::os::raw::c_char,
-        mode: VFSMode,
+        mode: tiledb_vfs_mode_t,
         fh: *mut *mut tiledb_vfs_fh_t,
     ) -> capi_return_t;
 


### PR DESCRIPTION
This fixes all of our existing API discrepancies and requires that no more are introduced (i.e., CI will fail if whatever declarations in `tiledb/sys` don't exactly match what bindgen generates unless they are remapped).

I've also fixed up the output so we can use it as a build status on GitHub.
