### PR TITLE
Replace dev with main in CI

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -2,7 +2,7 @@ name: "Pull Request CI"
 on:
   push:
     branches:
-      - dev
+      - main
       - release-*
       - refs/tags/*
 


### PR DESCRIPTION
I just noticed I copy pasta'ed the wrong default branch name when updating CI the other day.