### PR TITLE
Fix subarray builder to correctly use C API

### DIFF
--- a/tiledb/api/examples/quickstart_dense.rs
+++ b/tiledb/api/examples/quickstart_dense.rs
@@ -125,10 +125,11 @@ fn read_array() -> TileDBResult<()> {
                 QUICKSTART_ATTRIBUTE_NAME,
                 results.as_mut_slice(),
             )?
-            .subarray()?
+            .start_subarray()?
             .dimension_range_typed::<i32, _>("rows", &[1, 2])?
             .dimension_range_typed::<i32, _>("columns", &[2, 4])?
-            .build()?;
+            .finish_subarray()?
+            .build();
 
     query.submit()?;
 

--- a/tiledb/api/examples/quickstart_dense.rs
+++ b/tiledb/api/examples/quickstart_dense.rs
@@ -125,11 +125,10 @@ fn read_array() -> TileDBResult<()> {
                 QUICKSTART_ATTRIBUTE_NAME,
                 results.as_mut_slice(),
             )?
-            .add_subarray()?
+            .subarray()?
             .dimension_range_typed::<i32, _>("rows", &[1, 2])?
-            .add_subarray()?
             .dimension_range_typed::<i32, _>("columns", &[2, 4])?
-            .build();
+            .build()?;
 
     query.submit()?;
 

--- a/tiledb/api/examples/using_tiledb_stats.rs
+++ b/tiledb/api/examples/using_tiledb_stats.rs
@@ -136,10 +136,11 @@ pub fn read_array(json: bool) -> TileDBResult<()> {
         tiledb::QueryBuilder::new(&tdb, array, tiledb::QueryType::Read)?
             .layout(tiledb::query::QueryLayout::RowMajor)?
             .dimension_buffer_typed(ATTRIBUTE_NAME, results.as_mut_slice())?
-            .subarray()?
+            .start_subarray()?
             .dimension_range_typed::<i32, _>(0, &[1, 3000])?
             .dimension_range_typed::<i32, _>(1, &[1, 12000])?
-            .build()?;
+            .finish_subarray()?
+            .build();
 
     tiledb::stats::enable()?;
     query.submit()?;

--- a/tiledb/api/examples/using_tiledb_stats.rs
+++ b/tiledb/api/examples/using_tiledb_stats.rs
@@ -136,11 +136,10 @@ pub fn read_array(json: bool) -> TileDBResult<()> {
         tiledb::QueryBuilder::new(&tdb, array, tiledb::QueryType::Read)?
             .layout(tiledb::query::QueryLayout::RowMajor)?
             .dimension_buffer_typed(ATTRIBUTE_NAME, results.as_mut_slice())?
-            .add_subarray()?
+            .subarray()?
             .dimension_range_typed::<i32, _>(0, &[1, 3000])?
-            .add_subarray()?
             .dimension_range_typed::<i32, _>(1, &[1, 12000])?
-            .build();
+            .build()?;
 
     tiledb::stats::enable()?;
     query.submit()?;

--- a/tiledb/api/src/query/mod.rs
+++ b/tiledb/api/src/query/mod.rs
@@ -37,7 +37,6 @@ pub struct Query<'ctx> {
     #[context]
     context: &'ctx Context,
     array: Array<'ctx>,
-    subarrays: Vec<Subarray<'ctx>>,
     // This is a bit gross but the buffer sizes must out-live the query.
     // That's very C-like, Rust wants to use slices or something, so we do this
     // in order to pin the size to a fixed address
@@ -87,7 +86,6 @@ impl<'ctx> Builder<'ctx> {
             query: Query {
                 context,
                 array,
-                subarrays: vec![],
                 result_buffers: HashMap::new(),
                 raw: RawQuery::Owned(c_query),
             },
@@ -104,7 +102,7 @@ impl<'ctx> Builder<'ctx> {
         Ok(self)
     }
 
-    pub fn add_subarray(self) -> TileDBResult<SubarrayBuilder<'ctx>> {
+    pub fn subarray(self) -> TileDBResult<SubarrayBuilder<'ctx>> {
         SubarrayBuilder::for_query(self)
     }
 

--- a/tiledb/api/src/query/mod.rs
+++ b/tiledb/api/src/query/mod.rs
@@ -102,7 +102,7 @@ impl<'ctx> Builder<'ctx> {
         Ok(self)
     }
 
-    pub fn subarray(self) -> TileDBResult<SubarrayBuilder<'ctx>> {
+    pub fn start_subarray(self) -> TileDBResult<SubarrayBuilder<'ctx>> {
         SubarrayBuilder::for_query(self)
     }
 

--- a/tiledb/api/src/query/subarray.rs
+++ b/tiledb/api/src/query/subarray.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use crate::array::DimensionKey;
 use crate::context::{CApiInterface, Context, ContextBound};
 use crate::convert::CAPIConverter;
-use crate::query::{Builder as QueryBuilder, Query};
+use crate::query::Builder as QueryBuilder;
 use crate::Result as TileDBResult;
 
 pub(crate) enum RawSubarray {
@@ -103,7 +103,7 @@ impl<'ctx> Builder<'ctx> {
     }
 
     /// Apply the subarray to the query, returning the query builder.
-    pub fn to_query(self) -> TileDBResult<QueryBuilder<'ctx>> {
+    pub fn finish_subarray(self) -> TileDBResult<QueryBuilder<'ctx>> {
         let c_context = self.subarray.context.capi();
         let c_query = *self.query.query.raw;
         let c_subarray = *self.subarray.raw;
@@ -112,10 +112,5 @@ impl<'ctx> Builder<'ctx> {
             ffi::tiledb_query_set_subarray_t(c_context, c_query, c_subarray)
         })?;
         Ok(self.query)
-    }
-
-    /// Apply the subarray to the query and finish constructing the query.
-    pub fn build(self) -> TileDBResult<Query<'ctx>> {
-        Ok(self.to_query()?.build())
     }
 }


### PR DESCRIPTION
The previous builder was based on my misunderstanding of how to use the subarray API.  The pattern enforced by the builder prevented more than one dimension range from being used, because `SubarrayBuilder::dimension_range_typed` returned back the query builder.  Now it returns back the Subarray builder so that a more complex subarray can be constructed before changing back to the Query building state.

`cargo run --example quickstart_dense` before and after these changes shows that we now produce a correct result.