### PR TITLE
Improve field lookup from schema API

### DIFF
--- a/tiledb/api/src/array/attribute/arrow.rs
+++ b/tiledb/api/src/array/attribute/arrow.rs
@@ -4,7 +4,7 @@ use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use crate::array::{Attribute, AttributeBuilder};
+use crate::array::{Attribute, AttributeBuilder, CellValNum};
 use crate::datatype::arrow::*;
 use crate::error::Error;
 use crate::filter::arrow::FilterMetadata;
@@ -21,7 +21,7 @@ pub struct FillValueMetadata {
 /// Encapsulates details of a TileDB attribute for storage in Arrow field metadata
 #[derive(Deserialize, Serialize)]
 pub struct AttributeMetadata {
-    pub cell_val_num: u32,
+    pub cell_val_num: CellValNum,
     pub fill_value: FillValueMetadata,
     pub filters: FilterMetadata,
 }

--- a/tiledb/api/src/array/attribute/mod.rs
+++ b/tiledb/api/src/array/attribute/mod.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use util::option::OptionSubset;
 
+use crate::array::CellValNum;
 use crate::context::{CApiInterface, Context, ContextBound};
 use crate::convert::{BitsEq, CAPIConverter};
 use crate::error::{DatatypeErrorKind, Error};
@@ -102,11 +103,7 @@ impl<'ctx> Attribute<'ctx> {
         })
     }
 
-    pub fn is_var_sized(&self) -> TileDBResult<bool> {
-        self.cell_val_num().map(|num| num == u32::MAX)
-    }
-
-    pub fn cell_val_num(&self) -> TileDBResult<u32> {
+    pub fn cell_val_num(&self) -> TileDBResult<CellValNum> {
         let c_context = self.context.capi();
         let mut c_num: std::ffi::c_uint = 0;
         self.capi_return(unsafe {
@@ -114,7 +111,11 @@ impl<'ctx> Attribute<'ctx> {
                 c_context, *self.raw, &mut c_num,
             )
         })?;
-        Ok(c_num as u32)
+        CellValNum::try_from(c_num)
+    }
+
+    pub fn is_var_sized(&self) -> TileDBResult<bool> {
+        Ok(self.cell_val_num()? == CellValNum::Var)
     }
 
     pub fn cell_size(&self) -> TileDBResult<u64> {
@@ -309,9 +310,9 @@ impl<'ctx> Builder<'ctx> {
         self.attr.datatype()
     }
 
-    pub fn cell_val_num(self, num: u32) -> TileDBResult<Self> {
+    pub fn cell_val_num(self, num: CellValNum) -> TileDBResult<Self> {
         let c_context = self.attr.context.capi();
-        let c_num = num as std::ffi::c_uint;
+        let c_num = num.capi() as std::ffi::c_uint;
         self.capi_return(unsafe {
             ffi::tiledb_attribute_set_cell_val_num(
                 c_context,
@@ -323,7 +324,7 @@ impl<'ctx> Builder<'ctx> {
     }
 
     pub fn var_sized(self) -> TileDBResult<Self> {
-        self.cell_val_num(u32::MAX)
+        self.cell_val_num(CellValNum::Var)
     }
 
     pub fn is_nullable(&self) -> bool {
@@ -448,7 +449,7 @@ pub struct AttributeData {
     pub name: String,
     pub datatype: Datatype,
     pub nullability: Option<bool>,
-    pub cell_val_num: Option<u32>,
+    pub cell_val_num: Option<CellValNum>,
     pub fill: Option<FillData>,
     pub filters: FilterListData,
 }
@@ -630,7 +631,7 @@ mod test {
                 .build();
 
             let num = attr.cell_val_num().expect("Error getting cell val num.");
-            assert_eq!(num, 1);
+            assert_eq!(num, Default::default());
             let size = attr
                 .cell_size()
                 .expect("Error getting attribute cell size.");
@@ -639,11 +640,11 @@ mod test {
         {
             let attr = Builder::new(&ctx, "foo", Datatype::UInt16)
                 .expect("Error creating attribute instance.")
-                .cell_val_num(3)
+                .cell_val_num(CellValNum::try_from(3).unwrap())
                 .expect("Error setting cell val num.")
                 .build();
             let num = attr.cell_val_num().expect("Error getting cell val num.");
-            assert_eq!(num, 3);
+            assert_eq!(u32::from(num), 3);
             let size = attr
                 .cell_size()
                 .expect("Error getting attribute cell size.");
@@ -652,7 +653,7 @@ mod test {
         {
             let attr = Builder::new(&ctx, "foo", Datatype::UInt16)
                 .expect("Error creating attribute instance.")
-                .cell_val_num(u32::MAX)
+                .cell_val_num(CellValNum::Var)
                 .expect("Error setting cell val size.")
                 .build();
             let is_var = attr
@@ -663,11 +664,11 @@ mod test {
         {
             let attr = Builder::new(&ctx, "foo", Datatype::UInt16)
                 .expect("Error creating attribute instance.")
-                .cell_val_num(42)
+                .cell_val_num(CellValNum::try_from(42).unwrap())
                 .expect("Error setting cell val num.")
                 .build();
             let num = attr.cell_val_num().expect("Error getting cell val num.");
-            assert_eq!(num, 42);
+            assert_eq!(num, CellValNum::try_from(42).unwrap());
             let size = attr.cell_size().expect("Error getting cell val size.");
             assert_eq!(size, 84);
         }
@@ -678,7 +679,7 @@ mod test {
                 .expect("Error setting var sized.")
                 .build();
             let num = attr.cell_val_num().expect("Error getting cell val num.");
-            assert_eq!(num, u32::MAX);
+            assert_eq!(num, CellValNum::Var);
             let size = attr.cell_size().expect("Error getting cell val size.");
             assert_eq!(size, u64::MAX);
         }
@@ -837,7 +838,11 @@ mod test {
         // change cellval
         {
             let other = start_attr(default_name, default_dt, default_nullable)
-                .cell_val_num((base.cell_val_num().unwrap() + 1) * 2)
+                .cell_val_num(
+                    ((u32::from(base.cell_val_num().unwrap()) + 1) * 2)
+                        .try_into()
+                        .unwrap(),
+                )
                 .expect("Error setting cell val num")
                 .build();
             assert_ne!(base, other);

--- a/tiledb/api/src/array/attribute/strategy.rs
+++ b/tiledb/api/src/array/attribute/strategy.rs
@@ -3,7 +3,9 @@ use std::rc::Rc;
 use proptest::prelude::*;
 use serde_json::json;
 
-use crate::array::{attribute::FillData, ArrayType, AttributeData, DomainData};
+use crate::array::{
+    attribute::FillData, ArrayType, AttributeData, CellValNum, DomainData,
+};
 use crate::datatype::strategy::*;
 use crate::filter::list::FilterListData;
 use crate::{fn_typed, Datatype};
@@ -31,7 +33,7 @@ pub fn prop_attribute_name() -> impl Strategy<Value = String> {
         )
 }
 
-fn prop_cell_val_num() -> impl Strategy<Value = Option<u32>> {
+fn prop_cell_val_num() -> impl Strategy<Value = Option<CellValNum>> {
     Just(None)
 }
 

--- a/tiledb/api/src/array/dimension/arrow.rs
+++ b/tiledb/api/src/array/dimension/arrow.rs
@@ -4,7 +4,7 @@ use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use crate::array::{Dimension, DimensionBuilder};
+use crate::array::{CellValNum, Dimension, DimensionBuilder};
 use crate::context::Context as TileDBContext;
 use crate::datatype::arrow::{arrow_type_physical, tiledb_type_physical};
 use crate::filter::arrow::FilterMetadata;
@@ -15,7 +15,7 @@ use crate::{error::Error as TileDBError, fn_typed, Result as TileDBResult};
 /// field
 #[derive(Deserialize, Serialize)]
 pub struct DimensionMetadata {
-    pub cell_val_num: u32,
+    pub cell_val_num: CellValNum,
     pub domain: [serde_json::value::Value; 2],
     pub extent: serde_json::value::Value,
     pub filters: FilterMetadata,

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -22,7 +22,9 @@ pub use domain::{Builder as DomainBuilder, DimensionKey, Domain, DomainData};
 pub use enumeration::{
     Builder as EnumerationBuilder, Enumeration, EnumerationData,
 };
-pub use schema::{ArrayType, Builder as SchemaBuilder, Schema, SchemaData};
+pub use schema::{
+    ArrayType, Builder as SchemaBuilder, CellValNum, Schema, SchemaData,
+};
 
 pub enum Mode {
     Read,

--- a/tiledb/utils/src/option.rs
+++ b/tiledb/utils/src/option.rs
@@ -1,3 +1,5 @@
+use std::num::*;
+
 /// Trait for comparing types which can express optional data.
 /// The `option_subset` method should return true if it finds that all required data
 /// of two objects are equal, and the non-required data are either equal or not set
@@ -148,9 +150,25 @@ mod serde_json {
     }
 }
 
-option_subset_partialeq!(u8, u16, u32, u64, usize);
-option_subset_partialeq!(i8, i16, i32, i64, isize);
+option_subset_partialeq!(u8, u16, u32, u64, u128, usize);
+option_subset_partialeq!(i8, i16, i32, i64, i128, isize);
 option_subset_partialeq!(bool, f32, f64, String);
+option_subset_partialeq!(
+    NonZeroI8,
+    NonZeroI16,
+    NonZeroI32,
+    NonZeroI64,
+    NonZeroI128,
+    NonZeroIsize
+);
+option_subset_partialeq!(
+    NonZeroU8,
+    NonZeroU16,
+    NonZeroU32,
+    NonZeroU64,
+    NonZeroU128,
+    NonZeroUsize
+);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
First we use the `DimensionKey` (soon to be re-named, from the fragment info PR) to enable looking up an attribute by name.  Then we also add `crate::array::schema::Field` to encapsulate commonalities to Dimension and Attribute, for use cases where it does not matter whether a schema field is a dimension or attribute.