### PR TITLE
Process the output of `cargo expand` for API calls

### DIFF
--- a/.github/workflows/pr-api-coverage.yml
+++ b/.github/workflows/pr-api-coverage.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
 
 jobs:
-  coverage:
+  api_coverage:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tiledb-rs
@@ -12,6 +12,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Setup Rustc Cache
         uses: Swatinem/rust-cache@v2
+      - name: Install Cargo Expand
+        run: cargo install cargo-expand
       - name: Install TileDB
         uses: ./.github/actions/install-tiledb
       - name: Build API Coverage Tool

--- a/tools/api-coverage/src/main.rs
+++ b/tools/api-coverage/src/main.rs
@@ -17,8 +17,8 @@ use sys::SysDefs;
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    /// Path to the API crate
-    #[arg(short, long, default_value_t = String::from("tiledb/api/src"))]
+    /// The name of the API crate
+    #[arg(short, long, default_value_t = String::from("tiledb"))]
     api: String,
 
     /// Path to the bindgen generated APIs


### PR DESCRIPTION
Before this change we weren't catching any of the calls that happened inside macros which means we were missing a few things that were only called from within `fn_typed!`.