### PR TITLE
Support for reading and writing validity vectors

### DIFF
--- a/tiledb/api/examples/reading_incomplete.rs
+++ b/tiledb/api/examples/reading_incomplete.rs
@@ -164,20 +164,24 @@ fn read_array_step() -> TileDBResult<()> {
     let rows_output = RefCell::new(QueryBuffersMut {
         data: BufferMut::Owned(vec![0i32; init_capacity].into_boxed_slice()),
         cell_offsets: None,
+        validity: None,
     });
     let cols_output = RefCell::new(QueryBuffersMut {
         data: BufferMut::Owned(vec![0i32; init_capacity].into_boxed_slice()),
         cell_offsets: None,
+        validity: None,
     });
     let int32_output = RefCell::new(QueryBuffersMut {
         data: BufferMut::Owned(vec![0i32; init_capacity].into_boxed_slice()),
         cell_offsets: None,
+        validity: None,
     });
     let char_output = RefCell::new(QueryBuffersMut {
         data: BufferMut::Owned(vec![0u8; init_capacity].into_boxed_slice()),
         cell_offsets: Some(BufferMut::Owned(
             vec![0u64; init_capacity].into_boxed_slice(),
         )),
+        validity: None,
     });
 
     let mut qq = query_builder_start(&tdb)?
@@ -289,20 +293,24 @@ fn read_array_callback() -> TileDBResult<()> {
     let rows_output = RefCell::new(QueryBuffersMut {
         data: BufferMut::Owned(vec![0i32; init_capacity].into_boxed_slice()),
         cell_offsets: None,
+        validity: None,
     });
     let cols_output = RefCell::new(QueryBuffersMut {
         data: BufferMut::Owned(vec![0i32; init_capacity].into_boxed_slice()),
         cell_offsets: None,
+        validity: None,
     });
     let int32_output = RefCell::new(QueryBuffersMut {
         data: BufferMut::Owned(vec![0i32; init_capacity].into_boxed_slice()),
         cell_offsets: None,
+        validity: None,
     });
     let char_output = RefCell::new(QueryBuffersMut {
         data: BufferMut::Owned(vec![0u8; init_capacity].into_boxed_slice()),
         cell_offsets: Some(BufferMut::Owned(
             vec![0u64; init_capacity].into_boxed_slice(),
         )),
+        validity: None,
     });
     let mut qq = query_builder_start(&tdb)?
         .register_callback4::<FnMutAdapter<(i32, i32, i32, String), _>>(

--- a/tiledb/api/src/query/buffer.rs
+++ b/tiledb/api/src/query/buffer.rs
@@ -37,6 +37,7 @@ impl<'data, T> Deref for Buffer<'data, T> {
 pub struct QueryBuffers<'data, T = u8> {
     pub data: Buffer<'data, T>,
     pub cell_offsets: Option<Buffer<'data, u64>>,
+    pub validity: Option<Buffer<'data, u8>>,
 }
 
 impl<'data, T> QueryBuffers<'data, T> {
@@ -48,6 +49,9 @@ impl<'data, T> QueryBuffers<'data, T> {
             data: Buffer::Borrowed(self.data.as_ref()),
             cell_offsets: Option::map(self.cell_offsets.as_ref(), |c| {
                 Buffer::Borrowed(c.as_ref())
+            }),
+            validity: Option::map(self.validity.as_ref(), |v| {
+                Buffer::Borrowed(v.as_ref())
             }),
         }
     }
@@ -111,6 +115,7 @@ impl<'data, T> DerefMut for BufferMut<'data, T> {
 pub struct QueryBuffersMut<'data, T = u8> {
     pub data: BufferMut<'data, T>,
     pub cell_offsets: Option<BufferMut<'data, u64>>,
+    pub validity: Option<BufferMut<'data, u8>>,
 }
 
 impl<'data, T> QueryBuffersMut<'data, T> {
@@ -123,6 +128,9 @@ impl<'data, T> QueryBuffersMut<'data, T> {
             data: Buffer::Borrowed(self.data.as_ref()),
             cell_offsets: Option::map(self.cell_offsets.as_ref(), |c| {
                 Buffer::Borrowed(c.as_ref())
+            }),
+            validity: Option::map(self.validity.as_ref(), |v| {
+                Buffer::Borrowed(v.as_ref())
             }),
         }
     }

--- a/tiledb/api/src/query/read/managed.rs
+++ b/tiledb/api/src/query/read/managed.rs
@@ -18,6 +18,7 @@ where
         let tmp = QueryBuffersMut {
             data: BufferMut::Empty,
             cell_offsets: None,
+            validity: None,
         };
         let old_scratch = ScratchSpace::<C>::try_from(
             self.scratch.replace(tmp),

--- a/tiledb/api/src/query/read/mod.rs
+++ b/tiledb/api/src/query/read/mod.rs
@@ -297,6 +297,7 @@ pub trait ReadQueryBuilder<'ctx>: Sized + QueryBuilder<'ctx> {
         let scratch = QueryBuffersMut {
             data: BufferMut::Owned(scratch.0),
             cell_offsets: scratch.1.map(BufferMut::Owned),
+            validity: scratch.2.map(BufferMut::Owned),
         };
 
         let scratch = Box::pin(RefCell::new(scratch));
@@ -367,6 +368,7 @@ pub trait ReadQueryBuilder<'ctx>: Sized + QueryBuilder<'ctx> {
         let scratch = QueryBuffersMut {
             data: BufferMut::Owned(scratch.0),
             cell_offsets: scratch.1.map(BufferMut::Owned),
+            validity: scratch.2.map(BufferMut::Owned),
         };
 
         let scratch = Box::pin(RefCell::new(scratch));

--- a/tiledb/api/src/query/read/typed.rs
+++ b/tiledb/api/src/query/read/typed.rs
@@ -86,7 +86,18 @@ mod impls {
         type Constructor = Self;
     }
 
+    impl<C> ReadResult for (Vec<C>, Vec<u8>)
+    where
+        C: CAPISameRepr,
+    {
+        type Constructor = Self;
+    }
+
     impl ReadResult for Vec<String> {
+        type Constructor = Self;
+    }
+
+    impl ReadResult for (Vec<String>, Vec<u8>) {
         type Constructor = Self;
     }
 }


### PR DESCRIPTION
This exposes the validity vectors from TileDB which are used to indicate nullness.