### PR TITLE
Fix slow property tests

### DIFF
--- a/tiledb/api/src/query/buffer.rs
+++ b/tiledb/api/src/query/buffer.rs
@@ -127,3 +127,21 @@ impl<'data, T> QueryBuffersMut<'data, T> {
         }
     }
 }
+
+#[cfg(any(test, feature = "proptest-strategies"))]
+pub mod strategy {
+    use proptest::collection::vec;
+    use proptest::prelude::*;
+
+    pub fn prop_string_vec(
+        range: proptest::collection::SizeRange,
+    ) -> impl Strategy<Value = Vec<String>> {
+        vec(vec(1u8..127, 0..64), range)
+            .prop_map(move |mut v| {
+                v.iter_mut()
+                    .map(|s| String::from_utf8(s.clone()).unwrap())
+                    .collect::<Vec<_>>()
+            })
+            .boxed()
+    }
+}

--- a/tiledb/api/src/query/read/callback.rs
+++ b/tiledb/api/src/query/read/callback.rs
@@ -653,7 +653,13 @@ mod tests {
 
     proptest! {
         #[test]
-        fn read_result_strings(record_capacity in MIN_RECORDS..=MAX_RECORDS, byte_capacity in MIN_BYTE_CAPACITY..=MAX_BYTE_CAPACITY, stringsrc in vec(any::<String>(), MIN_RECORDS..=MAX_RECORDS))
+        fn read_result_strings(
+            record_capacity in MIN_RECORDS..=MAX_RECORDS,
+            byte_capacity in MIN_BYTE_CAPACITY..=MAX_BYTE_CAPACITY,
+            stringsrc in crate::query::buffer::strategy::prop_string_vec(
+                (MIN_RECORDS..=MAX_RECORDS).into()
+            )
+        )
         {
             do_read_result_strings(record_capacity, byte_capacity, stringsrc)
         }

--- a/tiledb/api/src/query/write/input.rs
+++ b/tiledb/api/src/query/write/input.rs
@@ -109,7 +109,11 @@ mod tests {
         }
 
         #[test]
-        fn input_provider_strings(stringvec in vec(any::<String>(), MIN_RECORDS..=MAX_RECORDS)) {
+        fn input_provider_strings(
+            stringvec in crate::query::buffer::strategy::prop_string_vec(
+                (MIN_RECORDS..=MAX_RECORDS).into()
+            )
+        ) {
             let input = stringvec.as_tiledb_input();
             let (bytes, offsets) = (input.data.as_ref(), input.cell_offsets);
             assert!(offsets.is_some());


### PR DESCRIPTION
There were two tests that were each taking over twenty seconds to complete. After some investigation with Ryan the other day, we narrowed it own to constantly reparsing the pattern passed to `string_regex`. The idea then was to put all of our `string_regex` patterns behind a lazy_static. However, it turns out that its none of our strategies causing the issue.

The issue is `vec(any::<String>(), 0..1024)`. That will constantly re-parse the default `string_regex` pattern of `\\PC*`. To avoid that slowness I've created a new strategy that generates `Vec<Vec<u8>>` and then prop_maps the inner vector into a String. This works because I'm only generating `u8` values in the range [1, 127) which is guaranteed to be 7-bit clean and infallibly convertible to UTF-8.

This knocks both of the twenty second tests to about three seconds.