### PR TITLE
Extend API to enable proptests which write arbitrary array data, and get started writing the proptests

### DIFF
--- a/tiledb/api/examples/fragment_info.rs
+++ b/tiledb/api/examples/fragment_info.rs
@@ -150,7 +150,7 @@ fn write_array() -> TileDBResult<()> {
 
     let data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 
-    let query = tiledb::query::WriteBuilder::new(&tdb, array)?
+    let query = tiledb::query::WriteBuilder::new(array)?
         .layout(tiledb::query::QueryLayout::RowMajor)?
         .data_typed(FRAGMENT_INFO_ATTRIBUTE_NAME, &data)?
         .build();

--- a/tiledb/api/examples/quickstart_dense.rs
+++ b/tiledb/api/examples/quickstart_dense.rs
@@ -88,7 +88,7 @@ fn write_array() -> TileDBResult<()> {
 
     let data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 
-    let query = tiledb::query::WriteBuilder::new(&tdb, array)?
+    let query = tiledb::query::WriteBuilder::new(array)?
         .layout(tiledb::query::QueryLayout::RowMajor)?
         .data_typed(QUICKSTART_ATTRIBUTE_NAME, &data)?
         .build();
@@ -113,7 +113,7 @@ fn read_array() -> TileDBResult<()> {
         tiledb::array::Mode::Read,
     )?;
 
-    let mut query = tiledb::query::ReadBuilder::new(&tdb, array)?
+    let mut query = tiledb::query::ReadBuilder::new(array)?
         .layout(tiledb::query::QueryLayout::RowMajor)?
         .register_constructor_managed::<_, Vec<i32>, _, _, _>(
             QUICKSTART_ATTRIBUTE_NAME,

--- a/tiledb/api/examples/reading_incomplete.rs
+++ b/tiledb/api/examples/reading_incomplete.rs
@@ -109,7 +109,7 @@ fn write_array() -> TileDBResult<()> {
     let int32_data = vec![1, 2, 3];
     let char_data = vec!["a", "bb", "ccc"];
 
-    let query = tiledb::query::WriteBuilder::new(&tdb, array)?
+    let query = tiledb::query::WriteBuilder::new(array)?
         .layout(tiledb::query::QueryLayout::Global)?
         .data_typed("rows", &coords_rows)?
         .data_typed("columns", &coords_cols)?
@@ -129,7 +129,7 @@ fn query_builder_start(tdb: &tiledb::Context) -> TileDBResult<ReadBuilder> {
     let array =
         tiledb::Array::open(tdb, ARRAY_NAME, tiledb::array::Mode::Read)?;
 
-    tiledb::query::ReadBuilder::new(tdb, array)?
+    tiledb::query::ReadBuilder::new(array)?
         .layout(tiledb::query::QueryLayout::RowMajor)?
         .start_subarray()?
         .dimension_range_typed::<i32, _>(0, &[1, 4])?

--- a/tiledb/api/examples/reading_incomplete.rs
+++ b/tiledb/api/examples/reading_incomplete.rs
@@ -6,8 +6,10 @@ use itertools::izip;
 use tiledb::array::{CellOrder, TileOrder};
 use tiledb::query::buffer::{BufferMut, QueryBuffers, QueryBuffersMut};
 use tiledb::query::read::output::{NonVarSized, VarDataIterator, VarSized};
-use tiledb::query::read::{FnMutAdapter, ReadStepOutput};
-use tiledb::query::{QueryBuilder, ReadBuilder, ReadQuery, ReadQueryBuilder};
+use tiledb::query::read::{FnMutAdapter, ReadStepOutput, ScratchStrategy};
+use tiledb::query::{
+    Query, QueryBuilder, ReadBuilder, ReadQuery, ReadQueryBuilder,
+};
 use tiledb::Datatype;
 use tiledb::Result as TileDBResult;
 
@@ -314,10 +316,16 @@ fn read_array_callback() -> TileDBResult<()> {
     });
     let mut qq = query_builder_start(&tdb)?
         .register_callback4::<FnMutAdapter<(i32, i32, i32, String), _>>(
-            ("rows", &rows_output),
-            ("columns", &cols_output),
-            (INT32_ATTRIBUTE_NAME, &int32_output),
-            (CHAR_ATTRIBUTE_NAME, &char_output),
+            ("rows", ScratchStrategy::RawBuffers(&rows_output)),
+            ("columns", ScratchStrategy::RawBuffers(&cols_output)),
+            (
+                INT32_ATTRIBUTE_NAME,
+                ScratchStrategy::RawBuffers(&int32_output),
+            ),
+            (
+                CHAR_ATTRIBUTE_NAME,
+                ScratchStrategy::RawBuffers(&char_output),
+            ),
             FnMutAdapter::new(callback),
         )?
         .build();

--- a/tiledb/api/examples/using_tiledb_stats.rs
+++ b/tiledb/api/examples/using_tiledb_stats.rs
@@ -102,7 +102,7 @@ pub fn write_array() -> TileDBResult<()> {
         tiledb::Array::open(&tdb, ARRAY_NAME, tiledb::array::Mode::Write)?;
     let data: Vec<i32> = Vec::from_iter(0..12000 * 12000);
 
-    let query = tiledb::query::WriteBuilder::new(&tdb, array)?
+    let query = tiledb::query::WriteBuilder::new(array)?
         .layout(tiledb::query::QueryLayout::RowMajor)?
         .data_typed(ATTRIBUTE_NAME, &data)?
         .build();
@@ -130,7 +130,7 @@ pub fn read_array(json: bool) -> TileDBResult<()> {
     let array =
         tiledb::Array::open(&tdb, ARRAY_NAME, tiledb::array::Mode::Read)?;
 
-    let mut query = tiledb::query::ReadBuilder::new(&tdb, array)?
+    let mut query = tiledb::query::ReadBuilder::new(array)?
         .layout(tiledb::query::QueryLayout::RowMajor)?
         .register_constructor_managed::<_, Vec<i32>, _, _, _>(
             ATTRIBUTE_NAME,

--- a/tiledb/api/src/array/attribute/mod.rs
+++ b/tiledb/api/src/array/attribute/mod.rs
@@ -115,7 +115,7 @@ impl<'ctx> Attribute<'ctx> {
     }
 
     pub fn is_var_sized(&self) -> TileDBResult<bool> {
-        Ok(self.cell_val_num()? == CellValNum::Var)
+        Ok(self.cell_val_num()?.is_var_sized())
     }
 
     pub fn cell_size(&self) -> TileDBResult<u64> {
@@ -639,7 +639,7 @@ mod test {
                 .build();
 
             let num = attr.cell_val_num().expect("Error getting cell val num.");
-            assert_eq!(num, Default::default());
+            assert_eq!(num, <CellValNum as Default>::default());
             let size = attr
                 .cell_size()
                 .expect("Error getting attribute cell size.");

--- a/tiledb/api/src/array/dimension/mod.rs
+++ b/tiledb/api/src/array/dimension/mod.rs
@@ -87,7 +87,7 @@ impl<'ctx> Dimension<'ctx> {
     }
 
     pub fn is_var_sized(&self) -> TileDBResult<bool> {
-        Ok(self.cell_val_num()? == CellValNum::Var)
+        Ok(self.cell_val_num()?.is_var_sized())
     }
 
     pub fn domain<Conv: CAPIConverter>(&self) -> TileDBResult<[Conv; 2]> {

--- a/tiledb/api/src/array/fragment_info.rs
+++ b/tiledb/api/src/array/fragment_info.rs
@@ -967,9 +967,8 @@ pub mod tests {
     fn write_dense_array(ctx: &Context, array_uri: &str) -> TileDBResult<()> {
         let data = vec![1u64, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         let array = Array::open(ctx, array_uri, Mode::Write)?;
-        let query = WriteBuilder::new(ctx, array)?
-            .data_typed("attr", &data)?
-            .build();
+        let query =
+            WriteBuilder::new(array)?.data_typed("attr", &data)?.build();
         query.submit()?;
         Ok(())
     }
@@ -1014,7 +1013,7 @@ pub mod tests {
         let id_data = vec![1u32, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         let attr_data = vec![1u64, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         let array = Array::open(ctx, array_uri, Mode::Write)?;
-        let query = WriteBuilder::new(ctx, array)?
+        let query = WriteBuilder::new(array)?
             .data_typed("id", &id_data)?
             .data_typed("attr", &attr_data)?
             .build();

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -7,6 +7,7 @@ use std::ops::Deref;
 use serde::{Deserialize, Serialize};
 use util::option::OptionSubset;
 
+use crate::array::schema::RawSchema;
 use crate::context::{CApiInterface, Context, ContextBound};
 use crate::Result as TileDBResult;
 
@@ -205,6 +206,22 @@ impl<'ctx> Array<'ctx> {
             context,
             raw: RawArray::Owned(array_raw),
         })
+    }
+
+    pub fn schema(&self) -> TileDBResult<Schema> {
+        let c_context = self.context.capi();
+        let c_array = *self.raw;
+        let mut c_schema: *mut ffi::tiledb_array_schema_t = out_ptr!();
+
+        self.capi_return(unsafe {
+            ffi::tiledb_array_get_schema(
+                c_context,
+                c_array,
+                &mut c_schema as *mut *mut ffi::tiledb_array_schema_t,
+            )
+        })?;
+
+        Ok(Schema::new(self.context, RawSchema::Owned(c_schema)))
     }
 }
 

--- a/tiledb/api/src/array/schema/mod.rs
+++ b/tiledb/api/src/array/schema/mod.rs
@@ -158,6 +158,13 @@ impl<'ctx> Field<'ctx> {
         }
     }
 
+    pub fn nullability(&self) -> TileDBResult<bool> {
+        Ok(match self {
+            Field::Dimension(_) => false,
+            Field::Attribute(ref a) => a.is_nullable(),
+        })
+    }
+
     pub fn cell_val_num(&self) -> TileDBResult<CellValNum> {
         match self {
             Field::Dimension(ref d) => d.cell_val_num(),
@@ -170,6 +177,7 @@ impl<'ctx> Field<'ctx> {
 pub struct FieldData {
     pub name: String,
     pub datatype: Datatype,
+    pub nullability: Option<bool>,
     pub cell_val_num: Option<CellValNum>,
 }
 
@@ -185,6 +193,7 @@ impl From<&AttributeData> for FieldData {
             name: attr.name.clone(),
             cell_val_num: attr.cell_val_num,
             datatype: attr.datatype,
+            nullability: attr.nullability,
         }
     }
 }
@@ -195,6 +204,7 @@ impl From<&DimensionData> for FieldData {
             name: dim.name.clone(),
             cell_val_num: dim.cell_val_num,
             datatype: dim.datatype,
+            nullability: Some(false),
         }
     }
 }
@@ -207,6 +217,7 @@ impl<'ctx> TryFrom<&Field<'ctx>> for FieldData {
             name: field.name()?,
             cell_val_num: Some(field.cell_val_num()?),
             datatype: field.datatype()?,
+            nullability: Some(field.nullability()?),
         })
     }
 }

--- a/tiledb/api/src/array/schema/mod.rs
+++ b/tiledb/api/src/array/schema/mod.rs
@@ -69,11 +69,24 @@ impl CellValNum {
             CellValNum::Var => u32::MAX,
         }
     }
+
+    pub fn is_var_sized(&self) -> bool {
+        matches!(self, CellValNum::Var)
+    }
 }
 
 impl Default for CellValNum {
     fn default() -> Self {
         CellValNum::Fixed(NonZeroU32::new(1).unwrap())
+    }
+}
+
+impl PartialEq<u32> for CellValNum {
+    fn eq(&self, other: &u32) -> bool {
+        match self {
+            CellValNum::Fixed(val) => val.get() == *other,
+            CellValNum::Var => *other == std::u32::MAX,
+        }
     }
 }
 

--- a/tiledb/api/src/array/schema/mod.rs
+++ b/tiledb/api/src/array/schema/mod.rs
@@ -213,6 +213,11 @@ impl FieldData {
             } else {
                 None
             },
+            validity_capacity: if self.nullability.unwrap_or(true) {
+                Some(NonZeroUsize::new(1024 * 128).unwrap())
+            } else {
+                None
+            },
         }
     }
 }

--- a/tiledb/api/src/query/buffer.rs
+++ b/tiledb/api/src/query/buffer.rs
@@ -185,8 +185,56 @@ typed_query_buffers!(UInt8: u8, UInt16: u16, UInt32: u32, UInt64: u64);
 typed_query_buffers!(Int8: i8, Int16: i16, Int32: i32, Int64: i64);
 typed_query_buffers!(Float32: f32, Float64: f64);
 
+#[macro_export]
+macro_rules! typed_query_buffers_go {
+    ($expr:expr, $DT:ident, $inner:pat, $then:expr) => {
+        match $expr {
+            TypedQueryBuffers::UInt8($inner) => {
+                type $DT = u8;
+                $then
+            }
+            TypedQueryBuffers::UInt16($inner) => {
+                type $DT = u16;
+                $then
+            }
+            TypedQueryBuffers::UInt32($inner) => {
+                type $DT = u32;
+                $then
+            }
+            TypedQueryBuffers::UInt64($inner) => {
+                type $DT = u64;
+                $then
+            }
+            TypedQueryBuffers::Int8($inner) => {
+                type $DT = i8;
+                $then
+            }
+            TypedQueryBuffers::Int16($inner) => {
+                type $DT = i16;
+                $then
+            }
+            TypedQueryBuffers::Int32($inner) => {
+                type $DT = i32;
+                $then
+            }
+            TypedQueryBuffers::Int64($inner) => {
+                type $DT = i64;
+                $then
+            }
+            TypedQueryBuffers::Float32($inner) => {
+                type $DT = f32;
+                $then
+            }
+            TypedQueryBuffers::Float64($inner) => {
+                type $DT = f64;
+                $then
+            }
+        }
+    };
+}
+
 macro_rules! ref_typed_query_buffers_go {
-    ($expr:expr, $DT:ident, $inner:ident, $then:expr) => {
+    ($expr:expr, $DT:ident, $inner:pat, $then:expr) => {
         match $expr {
             RefTypedQueryBuffersMut::UInt8($inner) => {
                 type $DT = u8;

--- a/tiledb/api/src/query/buffer.rs
+++ b/tiledb/api/src/query/buffer.rs
@@ -34,14 +34,14 @@ impl<'data, T> Deref for Buffer<'data, T> {
     }
 }
 
-pub struct QueryBuffers<'data, T = u8> {
-    pub data: Buffer<'data, T>,
+pub struct QueryBuffers<'data, C> {
+    pub data: Buffer<'data, C>,
     pub cell_offsets: Option<Buffer<'data, u64>>,
     pub validity: Option<Buffer<'data, u8>>,
 }
 
-impl<'data, T> QueryBuffers<'data, T> {
-    pub fn borrow<'this>(&'this self) -> QueryBuffers<'data, T>
+impl<'data, C> QueryBuffers<'data, C> {
+    pub fn borrow<'this>(&'this self) -> QueryBuffers<'data, C>
     where
         'this: 'data,
     {
@@ -57,10 +57,10 @@ impl<'data, T> QueryBuffers<'data, T> {
     }
 }
 
-pub enum BufferMut<'data, T = u8> {
+pub enum BufferMut<'data, C> {
     Empty,
-    Borrowed(&'data mut [T]),
-    Owned(Box<[T]>),
+    Borrowed(&'data mut [C]),
+    Owned(Box<[C]>),
 }
 
 impl<'data, T> BufferMut<'data, T> {

--- a/tiledb/api/src/query/buffer.rs
+++ b/tiledb/api/src/query/buffer.rs
@@ -1,3 +1,4 @@
+use std::cell::Ref;
 use std::ops::{Deref, DerefMut};
 
 pub enum Buffer<'data, T = u8> {
@@ -133,6 +134,109 @@ impl<'data, T> QueryBuffersMut<'data, T> {
                 Buffer::Borrowed(v.as_ref())
             }),
         }
+    }
+}
+
+pub enum TypedQueryBuffers<'data> {
+    UInt8(QueryBuffers<'data, u8>),
+    UInt16(QueryBuffers<'data, u16>),
+    UInt32(QueryBuffers<'data, u32>),
+    UInt64(QueryBuffers<'data, u64>),
+    Int8(QueryBuffers<'data, i8>),
+    Int16(QueryBuffers<'data, i16>),
+    Int32(QueryBuffers<'data, i32>),
+    Int64(QueryBuffers<'data, i64>),
+    Float32(QueryBuffers<'data, f32>),
+    Float64(QueryBuffers<'data, f64>),
+}
+
+pub enum RefTypedQueryBuffersMut<'cell, 'data> {
+    UInt8(Ref<'cell, QueryBuffersMut<'data, u8>>),
+    UInt16(Ref<'cell, QueryBuffersMut<'data, u16>>),
+    UInt32(Ref<'cell, QueryBuffersMut<'data, u32>>),
+    UInt64(Ref<'cell, QueryBuffersMut<'data, u64>>),
+    Int8(Ref<'cell, QueryBuffersMut<'data, i8>>),
+    Int16(Ref<'cell, QueryBuffersMut<'data, i16>>),
+    Int32(Ref<'cell, QueryBuffersMut<'data, i32>>),
+    Int64(Ref<'cell, QueryBuffersMut<'data, i64>>),
+    Float32(Ref<'cell, QueryBuffersMut<'data, f32>>),
+    Float64(Ref<'cell, QueryBuffersMut<'data, f64>>),
+}
+
+macro_rules! typed_query_buffers {
+    ($($V:ident : $U:ty),+) => {
+        $(
+            impl<'data> From<QueryBuffers<'data, $U>> for TypedQueryBuffers<'data> {
+                fn from(value: QueryBuffers<'data, $U>) -> Self {
+                    TypedQueryBuffers::$V(value)
+                }
+            }
+
+            impl<'cell, 'data> From<Ref<'cell, QueryBuffersMut<'data, $U>>> for RefTypedQueryBuffersMut<'cell, 'data> {
+                fn from(value: Ref<'cell, QueryBuffersMut<'data, $U>>) -> Self {
+                    RefTypedQueryBuffersMut::$V(value)
+                }
+            }
+        )+
+    }
+}
+
+typed_query_buffers!(UInt8: u8, UInt16: u16, UInt32: u32, UInt64: u64);
+typed_query_buffers!(Int8: i8, Int16: i16, Int32: i32, Int64: i64);
+typed_query_buffers!(Float32: f32, Float64: f64);
+
+macro_rules! ref_typed_query_buffers_go {
+    ($expr:expr, $DT:ident, $inner:ident, $then:expr) => {
+        match $expr {
+            RefTypedQueryBuffersMut::UInt8($inner) => {
+                type $DT = u8;
+                $then
+            }
+            RefTypedQueryBuffersMut::UInt16($inner) => {
+                type $DT = u16;
+                $then
+            }
+            RefTypedQueryBuffersMut::UInt32($inner) => {
+                type $DT = u32;
+                $then
+            }
+            RefTypedQueryBuffersMut::UInt64($inner) => {
+                type $DT = u64;
+                $then
+            }
+            RefTypedQueryBuffersMut::Int8($inner) => {
+                type $DT = i8;
+                $then
+            }
+            RefTypedQueryBuffersMut::Int16($inner) => {
+                type $DT = i16;
+                $then
+            }
+            RefTypedQueryBuffersMut::Int32($inner) => {
+                type $DT = i32;
+                $then
+            }
+            RefTypedQueryBuffersMut::Int64($inner) => {
+                type $DT = i64;
+                $then
+            }
+            RefTypedQueryBuffersMut::Float32($inner) => {
+                type $DT = f32;
+                $then
+            }
+            RefTypedQueryBuffersMut::Float64($inner) => {
+                type $DT = f64;
+                $then
+            }
+        }
+    };
+}
+
+impl<'cell, 'data> RefTypedQueryBuffersMut<'cell, 'data> {
+    pub fn as_shared(&'cell self) -> TypedQueryBuffers<'cell> {
+        ref_typed_query_buffers_go!(self, _DT, qb, {
+            TypedQueryBuffers::from(qb.as_shared())
+        })
     }
 }
 

--- a/tiledb/api/src/query/mod.rs
+++ b/tiledb/api/src/query/mod.rs
@@ -130,7 +130,10 @@ pub trait QueryBuilder<'ctx>: Sized {
 
     fn base(&self) -> &BuilderBase<'ctx>;
 
-    fn layout(self, layout: QueryLayout) -> TileDBResult<Self> {
+    fn layout(self, layout: QueryLayout) -> TileDBResult<Self>
+    where
+        Self: Sized,
+    {
         let c_context = self.base().context().capi();
         let c_query = **self.base().cquery();
         let c_layout = layout.capi_enum();
@@ -140,7 +143,10 @@ pub trait QueryBuilder<'ctx>: Sized {
         Ok(self)
     }
 
-    fn start_subarray(self) -> TileDBResult<SubarrayBuilder<'ctx, Self>> {
+    fn start_subarray(self) -> TileDBResult<SubarrayBuilder<'ctx, Self>>
+    where
+        Self: Sized,
+    {
         SubarrayBuilder::for_query(self)
     }
 

--- a/tiledb/api/src/query/mod.rs
+++ b/tiledb/api/src/query/mod.rs
@@ -175,16 +175,12 @@ impl<'ctx> QueryBuilder<'ctx> for BuilderBase<'ctx> {
 }
 
 impl<'ctx> BuilderBase<'ctx> {
-    fn new(
-        context: &'ctx Context,
-        array: Array<'ctx>,
-        query_type: QueryType,
-    ) -> TileDBResult<Self> {
-        let c_context = context.capi();
+    fn new(array: Array<'ctx>, query_type: QueryType) -> TileDBResult<Self> {
+        let c_context = array.context().capi();
         let c_array = **array.capi();
         let c_query_type = query_type.capi_enum();
         let mut c_query: *mut ffi::tiledb_query_t = out_ptr!();
-        context.capi_return(unsafe {
+        array.capi_return(unsafe {
             ffi::tiledb_query_alloc(
                 c_context,
                 c_array,

--- a/tiledb/api/src/query/mod.rs
+++ b/tiledb/api/src/query/mod.rs
@@ -74,6 +74,10 @@ impl<'ctx> QueryBase<'ctx> {
         })
         .map(|_| c_status)
     }
+
+    pub fn array(&self) -> &Array<'ctx> {
+        &self.array
+    }
 }
 
 impl<'ctx> Query<'ctx> for QueryBase<'ctx> {
@@ -165,6 +169,10 @@ impl<'ctx> BuilderBase<'ctx> {
     }
     fn cquery(&self) -> &RawQuery {
         &self.query.raw
+    }
+
+    pub fn array(&self) -> &Array<'ctx> {
+        &self.query.array
     }
 }
 

--- a/tiledb/api/src/query/read/callback.rs
+++ b/tiledb/api/src/query/read/callback.rs
@@ -536,38 +536,6 @@ macro_rules! query_read_callback {
                 T: $callback,
                 B: ReadQueryBuilder<'ctx, 'data>,
             {
-                type IntoRaw = RawReadBuilder<'data, Self>;
-                type IntoVarRaw = VarRawReadBuilder<'data, Self>;
-
-                /// Register a raw memory location to write query results into.
-                fn register_raw<S, C>(
-                    self,
-                    field: S,
-                    scratch: &'data RefCell<QueryBuffersMut<'data, C>>,
-                ) -> TileDBResult<Self::IntoRaw>
-                where
-                    Self: Sized,
-                    S: AsRef<str>,
-                    RawReadHandle<'data, C>: Into<TypedReadHandle<'data>>,
-                {
-                    Ok(RawReadBuilder {
-                        raw_read_output: RawReadHandle::new(field.as_ref(), scratch).into(),
-                        base: self,
-                    })
-                }
-
-                fn register_var_raw<I>(
-                    self,
-                    fields: I,
-                ) -> TileDBResult<Self::IntoVarRaw>
-                where
-                    I: IntoIterator<Item = TypedReadHandle<'data>>,
-                {
-                    Ok(VarRawReadBuilder {
-                        raw_read_output: fields.into_iter().collect(),
-                        base: self,
-                    })
-                }
             }
         }
     }
@@ -723,35 +691,6 @@ impl<'ctx, 'data, T, B> ReadQueryBuilder<'ctx, 'data>
 where
     B: QueryBuilder<'ctx>,
 {
-    type IntoRaw = RawReadBuilder<'data, Self>;
-    type IntoVarRaw = VarRawReadBuilder<'data, Self>;
-
-    /// Register a raw memory location to write query results into.
-    fn register_raw<S, C>(
-        self,
-        field: S,
-        scratch: &'data RefCell<QueryBuffersMut<'data, C>>,
-    ) -> TileDBResult<Self::IntoRaw>
-    where
-        Self: Sized,
-        S: AsRef<str>,
-        RawReadHandle<'data, C>: Into<TypedReadHandle<'data>>,
-    {
-        Ok(RawReadBuilder {
-            raw_read_output: RawReadHandle::new(field.as_ref(), scratch).into(),
-            base: self,
-        })
-    }
-
-    fn register_var_raw<I>(self, fields: I) -> TileDBResult<Self::IntoVarRaw>
-    where
-        I: IntoIterator<Item = TypedReadHandle<'data>>,
-    {
-        Ok(VarRawReadBuilder {
-            raw_read_output: fields.into_iter().collect(),
-            base: self,
-        })
-    }
 }
 
 #[cfg(test)]

--- a/tiledb/api/src/query/read/callback.rs
+++ b/tiledb/api/src/query/read/callback.rs
@@ -4,8 +4,10 @@ use anyhow::anyhow;
 use itertools::izip;
 use paste::paste;
 
-use crate::query::buffer::{RefTypedQueryBuffersMut, TypedQueryBuffers};
-use crate::query::read::output::{FromQueryOutput, RawReadOutput};
+use crate::query::buffer::RefTypedQueryBuffersMut;
+use crate::query::read::output::{
+    FromQueryOutput, RawReadOutput, TypedRawReadOutput,
+};
 
 macro_rules! trait_read_callback {
     ($name:ident, $($U:ident),+) => {
@@ -48,12 +50,6 @@ trait_read_callback!(ReadCallback, Unit);
 trait_read_callback!(ReadCallback2Arg, Unit1, Unit2);
 trait_read_callback!(ReadCallback3Arg, Unit1, Unit2, Unit3);
 trait_read_callback!(ReadCallback4Arg, Unit1, Unit2, Unit3, Unit4);
-
-pub struct TypedRawReadOutput<'data> {
-    pub nvalues: usize,
-    pub nbytes: usize,
-    pub buffers: TypedQueryBuffers<'data>,
-}
 
 pub trait ReadCallbackVarArg: Sized {
     type Intermediate;
@@ -577,9 +573,9 @@ query_read_callback!(
 
 #[derive(ContextBound, Query)]
 pub struct CallbackVarArgReadQuery<'data, T, Q> {
-    callback: Option<T>,
+    pub(crate) callback: Option<T>,
     #[base(ContextBound, Query)]
-    base: VarRawReadQuery<'data, Q>,
+    pub(crate) base: VarRawReadQuery<'data, Q>,
 }
 
 impl<'ctx, 'data, T, Q> ReadQuery<'ctx> for CallbackVarArgReadQuery<'data, T, Q>
@@ -662,9 +658,9 @@ where
 
 #[derive(ContextBound)]
 pub struct CallbackVarArgReadBuilder<'data, T, B> {
-    callback: T,
+    pub(crate) callback: T,
     #[base(ContextBound)]
-    base: VarRawReadBuilder<'data, B>,
+    pub(crate) base: VarRawReadBuilder<'data, B>,
 }
 
 impl<'ctx, 'data, T, B> QueryBuilder<'ctx>

--- a/tiledb/api/src/query/read/callback.rs
+++ b/tiledb/api/src/query/read/callback.rs
@@ -497,6 +497,45 @@ macro_rules! query_read_callback {
                     }
                 }
             }
+
+            impl<'ctx, 'data, T, B> ReadQueryBuilder<'ctx, 'data> for $Builder<'data, T, B>
+            where
+                T: $callback,
+                B: ReadQueryBuilder<'ctx, 'data>,
+            {
+                type IntoRaw = RawReadBuilder<'data, Self>;
+                type IntoVarRaw = VarRawReadBuilder<'data, Self>;
+
+                /// Register a raw memory location to write query results into.
+                fn register_raw<S, C>(
+                    self,
+                    field: S,
+                    scratch: &'data RefCell<QueryBuffersMut<'data, C>>,
+                ) -> TileDBResult<Self::IntoRaw>
+                where
+                    Self: Sized,
+                    S: AsRef<str>,
+                    RawReadHandle<'data, C>: Into<TypedReadHandle<'data>>,
+                {
+                    Ok(RawReadBuilder {
+                        raw_read_output: RawReadHandle::new(field.as_ref(), scratch).into(),
+                        base: self,
+                    })
+                }
+
+                fn register_var_raw<I>(
+                    self,
+                    fields: I,
+                ) -> TileDBResult<Self::IntoVarRaw>
+                where
+                    I: IntoIterator<Item = TypedReadHandle<'data>>,
+                {
+                    Ok(VarRawReadBuilder {
+                        raw_read_output: fields.into_iter().collect(),
+                        base: self,
+                    })
+                }
+            }
         }
     }
 }

--- a/tiledb/api/src/query/read/managed.rs
+++ b/tiledb/api/src/query/read/managed.rs
@@ -107,6 +107,26 @@ macro_rules! managed_output_location_go {
     };
 }
 
+pub enum ScratchStrategy<'data, C> {
+    AttributeDefault,
+    RawBuffers(&'data RefCell<QueryBuffersMut<'data, C>>),
+    CustomAllocator(Box<dyn ScratchAllocator<C> + 'data>),
+}
+
+impl<'data, C> Default for ScratchStrategy<'data, C> {
+    fn default() -> Self {
+        ScratchStrategy::AttributeDefault
+    }
+}
+
+impl<'data, C> From<&'data RefCell<QueryBuffersMut<'data, C>>>
+    for ScratchStrategy<'data, C>
+{
+    fn from(value: &'data RefCell<QueryBuffersMut<'data, C>>) -> Self {
+        ScratchStrategy::RawBuffers(value)
+    }
+}
+
 /// Adapter for a read result which allocates and manages scratch space opaquely.
 #[derive(ContextBound, Query)]
 pub struct ManagedReadQuery<'data, Q> {

--- a/tiledb/api/src/query/read/managed.rs
+++ b/tiledb/api/src/query/read/managed.rs
@@ -107,16 +107,12 @@ macro_rules! managed_output_location_go {
     };
 }
 
+#[derive(Default)]
 pub enum ScratchStrategy<'data, C> {
+    #[default]
     AttributeDefault,
     RawBuffers(&'data RefCell<QueryBuffersMut<'data, C>>),
     CustomAllocator(Box<dyn ScratchAllocator<C> + 'data>),
-}
-
-impl<'data, C> Default for ScratchStrategy<'data, C> {
-    fn default() -> Self {
-        ScratchStrategy::AttributeDefault
-    }
 }
 
 impl<'data, C> From<&'data RefCell<QueryBuffersMut<'data, C>>>

--- a/tiledb/api/src/query/read/managed.rs
+++ b/tiledb/api/src/query/read/managed.rs
@@ -84,9 +84,38 @@ where
     }
 }
 
-impl<'ctx, 'data, C, A, B> ReadQueryBuilder<'ctx>
+impl<'ctx, 'data, C, A, B> ReadQueryBuilder<'ctx, 'data>
     for ManagedReadBuilder<'data, C, A, B>
 where
-    B: ReadQueryBuilder<'ctx>,
+    B: ReadQueryBuilder<'ctx, 'data>,
 {
+    type IntoRaw = RawReadBuilder<'data, Self>;
+    type IntoVarRaw = VarRawReadBuilder<'data, Self>;
+
+    /// Register a raw memory location to write query results into.
+    fn register_raw<S, C2>(
+        self,
+        field: S,
+        scratch: &'data RefCell<QueryBuffersMut<'data, C2>>,
+    ) -> TileDBResult<Self::IntoRaw>
+    where
+        Self: Sized,
+        S: AsRef<str>,
+        RawReadHandle<'data, C2>: Into<TypedReadHandle<'data>>,
+    {
+        Ok(RawReadBuilder {
+            raw_read_output: RawReadHandle::new(field.as_ref(), scratch).into(),
+            base: self,
+        })
+    }
+
+    fn register_var_raw<I>(self, fields: I) -> TileDBResult<Self::IntoVarRaw>
+    where
+        I: IntoIterator<Item = TypedReadHandle<'data>>,
+    {
+        Ok(VarRawReadBuilder {
+            raw_read_output: fields.into_iter().collect(),
+            base: self,
+        })
+    }
 }

--- a/tiledb/api/src/query/read/managed.rs
+++ b/tiledb/api/src/query/read/managed.rs
@@ -215,33 +215,4 @@ impl<'ctx, 'data, B> ReadQueryBuilder<'ctx, 'data>
 where
     B: ReadQueryBuilder<'ctx, 'data>,
 {
-    type IntoRaw = RawReadBuilder<'data, Self>;
-    type IntoVarRaw = VarRawReadBuilder<'data, Self>;
-
-    /// Register a raw memory location to write query results into.
-    fn register_raw<S, C>(
-        self,
-        field: S,
-        scratch: &'data RefCell<QueryBuffersMut<'data, C>>,
-    ) -> TileDBResult<Self::IntoRaw>
-    where
-        Self: Sized,
-        S: AsRef<str>,
-        RawReadHandle<'data, C>: Into<TypedReadHandle<'data>>,
-    {
-        Ok(RawReadBuilder {
-            raw_read_output: RawReadHandle::new(field.as_ref(), scratch).into(),
-            base: self,
-        })
-    }
-
-    fn register_var_raw<I>(self, fields: I) -> TileDBResult<Self::IntoVarRaw>
-    where
-        I: IntoIterator<Item = TypedReadHandle<'data>>,
-    {
-        Ok(VarRawReadBuilder {
-            raw_read_output: fields.into_iter().collect(),
-            base: self,
-        })
-    }
 }

--- a/tiledb/api/src/query/read/mod.rs
+++ b/tiledb/api/src/query/read/mod.rs
@@ -168,7 +168,7 @@ impl<U> ReadStepOutput<U, U> {
 }
 
 /// Trait for runnable read queries.
-pub trait ReadQuery<'ctx>: Query<'ctx> + Sized {
+pub trait ReadQuery<'ctx>: Query<'ctx> {
     type Intermediate;
     type Final;
 
@@ -203,6 +203,7 @@ macro_rules! fn_register_callback {
                 callback: T
             ) -> TileDBResult<$Builder<'data, T, Self>>
             where
+                Self: Sized,
                 T: $Callback
             {
                 let base = self;
@@ -226,7 +227,7 @@ macro_rules! fn_register_callback {
 /// Trait for constructing a read query.
 /// Provides methods for flexibly adapting requested attributes into raw results,
 /// callbacks, or strongly-typed objects.
-pub trait ReadQueryBuilder<'ctx>: Sized + QueryBuilder<'ctx> {
+pub trait ReadQueryBuilder<'ctx>: QueryBuilder<'ctx> {
     /// Register a raw memory location to write query results into.
     fn register_raw<'data, S, C>(
         self,
@@ -234,6 +235,7 @@ pub trait ReadQueryBuilder<'ctx>: Sized + QueryBuilder<'ctx> {
         scratch: &'data RefCell<QueryBuffersMut<'data, C>>,
     ) -> TileDBResult<RawReadBuilder<C, Self>>
     where
+        Self: Sized,
         S: AsRef<str>,
         C: CAPISameRepr,
     {
@@ -288,6 +290,7 @@ pub trait ReadQueryBuilder<'ctx>: Sized + QueryBuilder<'ctx> {
         ManagedReadBuilder<'data, C, A, CallbackReadBuilder<'data, T, Self>>,
     >
     where
+        Self: Sized,
         S: AsRef<str>,
         T: ReadCallback<Unit = C> + HasScratchSpaceStrategy<C, Strategy = A>,
         A: ScratchAllocator<C>,
@@ -336,6 +339,7 @@ pub trait ReadQueryBuilder<'ctx>: Sized + QueryBuilder<'ctx> {
         >,
     ) -> TileDBResult<TypedReadBuilder<'data, T, Self>>
     where
+        Self: Sized,
         S: AsRef<str>,
         T: ReadResult,
         <T as ReadResult>::Constructor: Default,
@@ -357,6 +361,7 @@ pub trait ReadQueryBuilder<'ctx>: Sized + QueryBuilder<'ctx> {
         ManagedReadBuilder<'data, C, A, TypedReadBuilder<'data, T, Self>>,
     >
     where
+        Self: Sized,
         S: AsRef<str>,
         T: ReadResult<Constructor = R>
             + HasScratchSpaceStrategy<C, Strategy = A>,

--- a/tiledb/api/src/query/read/mod.rs
+++ b/tiledb/api/src/query/read/mod.rs
@@ -397,12 +397,9 @@ pub struct ReadBuilder<'ctx> {
 }
 
 impl<'ctx> ReadBuilder<'ctx> {
-    pub fn new(
-        context: &'ctx Context,
-        array: Array<'ctx>,
-    ) -> TileDBResult<Self> {
+    pub fn new(array: Array<'ctx>) -> TileDBResult<Self> {
         Ok(ReadBuilder {
-            base: BuilderBase::new(context, array, QueryType::Read)?,
+            base: BuilderBase::new(array, QueryType::Read)?,
         })
     }
 }

--- a/tiledb/api/src/query/read/mod.rs
+++ b/tiledb/api/src/query/read/mod.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use std::cell::{RefCell, RefMut};
+use std::cell::RefCell;
 use std::pin::Pin;
 
 use paste::paste;
@@ -233,14 +233,14 @@ pub trait ReadQueryBuilder<'ctx>: QueryBuilder<'ctx> {
         self,
         field: S,
         scratch: &'data RefCell<QueryBuffersMut<'data, C>>,
-    ) -> TileDBResult<RawReadBuilder<C, Self>>
+    ) -> TileDBResult<RawReadBuilder<'data, Self>>
     where
         Self: Sized,
         S: AsRef<str>,
-        C: CAPISameRepr,
+        RawReadHandle<'data, C>: Into<TypedReadHandle<'data>>,
     {
         Ok(RawReadBuilder {
-            raw_read_output: RawReadHandle::new(field.as_ref(), scratch),
+            raw_read_output: RawReadHandle::new(field.as_ref(), scratch).into(),
             base: self,
         })
     }

--- a/tiledb/api/src/query/read/mod.rs
+++ b/tiledb/api/src/query/read/mod.rs
@@ -216,11 +216,7 @@ macro_rules! fn_register_callback {
                                 RawReadHandle::new(field, qb)
                             },
                             ScratchStrategy::CustomAllocator(a) => {
-                                let qb = Box::pin(RefCell::new(a.alloc().into()));
-                                let managed = ManagedBuffer {
-                                    buffers: qb,
-                                    allocator: a
-                                };
+                                let managed = ManagedBuffer::from(a);
                                 RawReadHandle::managed(field, managed)
                             }
                         }
@@ -307,6 +303,20 @@ pub trait ReadQueryBuilder<'ctx, 'data>: QueryBuilder<'ctx> {
         Unit3,
         Unit4
     );
+
+    fn register_callback_var<I, T>(
+        self,
+        fields: I,
+        callback: T,
+    ) -> TileDBResult<CallbackVarArgReadBuilder<'data, T, Self>>
+    where
+        I: IntoIterator<Item = TypedReadHandle<'data>>,
+    {
+        Ok(CallbackVarArgReadBuilder {
+            callback,
+            base: self.register_var_raw(fields)?,
+        })
+    }
 
     /// Register a typed result to be constructed from the query results.
     /// Intermediate raw results are written into the provided scratch space.

--- a/tiledb/api/src/query/read/output.rs
+++ b/tiledb/api/src/query/read/output.rs
@@ -70,7 +70,7 @@ impl<'data, C> From<ScratchSpace<C>> for QueryBuffersMut<'data, C> {
     }
 }
 
-pub trait ScratchAllocator<C>: Default {
+pub trait ScratchAllocator<C> {
     fn alloc(&self) -> ScratchSpace<C>;
     fn realloc(&self, old: ScratchSpace<C>) -> ScratchSpace<C>;
 }

--- a/tiledb/api/src/query/read/raw.rs
+++ b/tiledb/api/src/query/read/raw.rs
@@ -412,44 +412,9 @@ where
     }
 }
 
-impl<'ctx, 'data, B> ReadQueryBuilder<'ctx, 'data> for RawReadBuilder<'data, B>
-where
-    B: ReadQueryBuilder<'ctx, 'data>,
+impl<'ctx, 'data, B> ReadQueryBuilder<'ctx, 'data> for RawReadBuilder<'data, B> where
+    B: ReadQueryBuilder<'ctx, 'data>
 {
-    type IntoRaw = VarRawReadBuilder<'data, B>;
-    type IntoVarRaw = VarRawReadBuilder<'data, B>;
-
-    /// Register a raw memory location to write query results into.
-    fn register_raw<S, C>(
-        self,
-        field: S,
-        scratch: &'data RefCell<QueryBuffersMut<'data, C>>,
-    ) -> TileDBResult<Self::IntoRaw>
-    where
-        Self: Sized,
-        S: AsRef<str>,
-        RawReadHandle<'data, C>: Into<TypedReadHandle<'data>>,
-    {
-        Ok(VarRawReadBuilder {
-            raw_read_output: vec![
-                self.raw_read_output,
-                RawReadHandle::new(field.as_ref(), scratch).into(),
-            ],
-            base: self.base,
-        })
-    }
-
-    fn register_var_raw<I>(self, fields: I) -> TileDBResult<Self::IntoVarRaw>
-    where
-        I: IntoIterator<Item = TypedReadHandle<'data>>,
-    {
-        Ok(VarRawReadBuilder {
-            raw_read_output: std::iter::once(self.raw_read_output)
-                .chain(fields.into_iter())
-                .collect(),
-            base: self.base,
-        })
-    }
 }
 
 /// Reads query results into raw buffers.
@@ -553,33 +518,4 @@ impl<'ctx, 'data, B> ReadQueryBuilder<'ctx, 'data>
 where
     B: ReadQueryBuilder<'ctx, 'data>,
 {
-    type IntoRaw = Self;
-    type IntoVarRaw = Self;
-
-    /// Register a raw memory location to write query results into.
-    fn register_raw<S, C>(
-        mut self,
-        field: S,
-        scratch: &'data RefCell<QueryBuffersMut<'data, C>>,
-    ) -> TileDBResult<Self::IntoRaw>
-    where
-        Self: Sized,
-        S: AsRef<str>,
-        RawReadHandle<'data, C>: Into<TypedReadHandle<'data>>,
-    {
-        self.raw_read_output
-            .push(RawReadHandle::new(field.as_ref(), scratch).into());
-        Ok(self)
-    }
-
-    fn register_var_raw<I>(
-        mut self,
-        fields: I,
-    ) -> TileDBResult<Self::IntoVarRaw>
-    where
-        I: IntoIterator<Item = TypedReadHandle<'data>>,
-    {
-        self.raw_read_output.extend(fields);
-        Ok(self)
-    }
 }

--- a/tiledb/api/src/query/read/raw.rs
+++ b/tiledb/api/src/query/read/raw.rs
@@ -10,6 +10,26 @@ pub struct ManagedBuffer<'data, C> {
     pub allocator: Box<dyn ScratchAllocator<C> + 'data>,
 }
 
+impl<'data, C> ManagedBuffer<'data, C> {
+    pub fn new<A>(allocator: A) -> Self
+    where
+        A: ScratchAllocator<C> + 'data,
+    {
+        let allocator: Box<dyn ScratchAllocator<C> + 'data> =
+            Box::new(allocator);
+        ManagedBuffer::from(allocator)
+    }
+}
+
+impl<'data, C> From<Box<dyn ScratchAllocator<C> + 'data>>
+    for ManagedBuffer<'data, C>
+{
+    fn from(allocator: Box<dyn ScratchAllocator<C> + 'data>) -> Self {
+        let buffers = Box::pin(RefCell::new(allocator.alloc().into()));
+        ManagedBuffer { buffers, allocator }
+    }
+}
+
 /// Encapsulates data for writing intermediate query results for a data field.
 pub struct RawReadHandle<'data, C> {
     /// Name of the field which this handle receives data from

--- a/tiledb/api/src/query/read/typed.rs
+++ b/tiledb/api/src/query/read/typed.rs
@@ -75,35 +75,6 @@ where
     T: ReadResult,
     B: ReadQueryBuilder<'ctx, 'data>,
 {
-    type IntoRaw = RawReadBuilder<'data, Self>;
-    type IntoVarRaw = VarRawReadBuilder<'data, Self>;
-
-    /// Register a raw memory location to write query results into.
-    fn register_raw<S, C>(
-        self,
-        field: S,
-        scratch: &'data RefCell<QueryBuffersMut<'data, C>>,
-    ) -> TileDBResult<Self::IntoRaw>
-    where
-        Self: Sized,
-        S: AsRef<str>,
-        RawReadHandle<'data, C>: Into<TypedReadHandle<'data>>,
-    {
-        Ok(RawReadBuilder {
-            raw_read_output: RawReadHandle::new(field.as_ref(), scratch).into(),
-            base: self,
-        })
-    }
-
-    fn register_var_raw<I>(self, fields: I) -> TileDBResult<Self::IntoVarRaw>
-    where
-        I: IntoIterator<Item = TypedReadHandle<'data>>,
-    {
-        Ok(VarRawReadBuilder {
-            raw_read_output: fields.into_iter().collect(),
-            base: self,
-        })
-    }
 }
 
 mod impls {

--- a/tiledb/api/src/query/write/input.rs
+++ b/tiledb/api/src/query/write/input.rs
@@ -84,7 +84,7 @@ where
 {
     type Unit = C;
 
-    fn as_tiledb_input(&self) -> InputData<Self::Unit> {
+    fn as_tiledb_input(&self) -> QueryBuffers<Self::Unit> {
         let mut offset_accumulator = 0;
         let offsets = self
             .iter()
@@ -101,7 +101,7 @@ where
             data.extend(s);
         });
 
-        InputData {
+        QueryBuffers {
             data: Buffer::Owned(data.into_boxed_slice()),
             cell_offsets: Some(Buffer::Owned(offsets)),
         }

--- a/tiledb/api/src/query/write/input.rs
+++ b/tiledb/api/src/query/write/input.rs
@@ -104,6 +104,7 @@ where
         QueryBuffers {
             data: Buffer::Owned(data.into_boxed_slice()),
             cell_offsets: Some(Buffer::Owned(offsets)),
+            validity: None,
         }
     }
 }

--- a/tiledb/api/src/query/write/input.rs
+++ b/tiledb/api/src/query/write/input.rs
@@ -24,8 +24,7 @@ where
     ) -> QueryBuffers<Self::Unit> {
         let ptr = self.data.as_ptr();
         let byte_len = std::mem::size_of_val(&self.data);
-        let raw_slice =
-            unsafe { std::slice::from_raw_parts(ptr as *const C, byte_len) };
+        let raw_slice = unsafe { std::slice::from_raw_parts(ptr, byte_len) };
         QueryBuffers {
             data: Buffer::Borrowed(raw_slice),
             cell_offsets: Option::map(self.cell_offsets.as_ref(), |c| {
@@ -51,8 +50,7 @@ where
     ) -> QueryBuffers<Self::Unit> {
         let ptr = self.data.as_ptr();
         let byte_len = std::mem::size_of_val(&self.data);
-        let raw_slice =
-            unsafe { std::slice::from_raw_parts(ptr as *const C, byte_len) };
+        let raw_slice = unsafe { std::slice::from_raw_parts(ptr, byte_len) };
         QueryBuffers {
             data: Buffer::Borrowed(raw_slice),
             cell_offsets: Option::map(self.cell_offsets.as_ref(), |c| {
@@ -98,7 +96,7 @@ where
         };
 
         QueryBuffers {
-            data: Buffer::Borrowed(self.as_ref()),
+            data: Buffer::Borrowed(self),
             cell_offsets: None,
             validity,
         }

--- a/tiledb/api/src/query/write/mod.rs
+++ b/tiledb/api/src/query/write/mod.rs
@@ -24,6 +24,8 @@ pub enum TypedQueryBuffers<'data> {
     Int16(QueryBuffers<'data, i16>),
     Int32(QueryBuffers<'data, i32>),
     Int64(QueryBuffers<'data, i64>),
+    Float32(QueryBuffers<'data, f32>),
+    Float64(QueryBuffers<'data, f64>),
 }
 
 macro_rules! typed_input_data {
@@ -40,6 +42,7 @@ macro_rules! typed_input_data {
 
 typed_input_data!(UInt8: u8, UInt16: u16, UInt32: u32, UInt64: u64);
 typed_input_data!(Int8: i8, Int16: i16, Int32: i32, Int64: i64);
+typed_input_data!(Float32: f32, Float64: f64);
 
 type InputMap<'data> = HashMap<String, RawWriteInput<'data>>;
 

--- a/tiledb/api/src/query/write/mod.rs
+++ b/tiledb/api/src/query/write/mod.rs
@@ -9,11 +9,37 @@ use crate::query::write::input::DataProvider;
 pub mod input;
 
 struct RawWriteInput<'data> {
-    data_size: Pin<Box<u64>>,
-    offsets_size: Option<Pin<Box<u64>>>,
-    validity_size: Option<Pin<Box<u64>>>,
-    input: QueryBuffers<'data>,
+    _data_size: Pin<Box<u64>>,
+    _offsets_size: Option<Pin<Box<u64>>>,
+    _validity_size: Option<Pin<Box<u64>>>,
+    _input: TypedQueryBuffers<'data>,
 }
+
+pub enum TypedQueryBuffers<'data> {
+    UInt8(QueryBuffers<'data, u8>),
+    UInt16(QueryBuffers<'data, u16>),
+    UInt32(QueryBuffers<'data, u32>),
+    UInt64(QueryBuffers<'data, u64>),
+    Int8(QueryBuffers<'data, i8>),
+    Int16(QueryBuffers<'data, i16>),
+    Int32(QueryBuffers<'data, i32>),
+    Int64(QueryBuffers<'data, i64>),
+}
+
+macro_rules! typed_input_data {
+    ($($V:ident : $U:ty),+) => {
+        $(
+            impl<'data> From<QueryBuffers<'data, $U>> for TypedQueryBuffers<'data> {
+                fn from(value: QueryBuffers<'data, $U>) -> Self {
+                    TypedQueryBuffers::$V(value)
+                }
+            }
+        )+
+    }
+}
+
+typed_input_data!(UInt8: u8, UInt16: u16, UInt32: u32, UInt64: u64);
+typed_input_data!(Int8: i8, Int16: i16, Int32: i32, Int64: i64);
 
 type InputMap<'data> = HashMap<String, RawWriteInput<'data>>;
 
@@ -82,31 +108,22 @@ impl<'ctx, 'data> WriteBuilder<'ctx, 'data> {
     where
         S: AsRef<str>,
         T: DataProvider,
+        QueryBuffers<'data, <T as DataProvider>::Unit>:
+            Into<TypedQueryBuffers<'data>>,
     {
         let field = field.as_ref();
         let input = data.as_tiledb_input();
-        let mut raw_write_input = RawWriteInput {
-            data_size: Box::pin(input.data.size() as u64),
-            offsets_size: input
-                .cell_offsets
-                .as_ref()
-                .map(|b| Box::pin(b.size() as u64)),
-            validity_size: input
-                .validity
-                .as_ref()
-                .map(|v| Box::pin(v.size() as u64)),
-            input,
-        };
 
         let c_context = self.context().capi();
         let c_query = **self.base().cquery();
         let c_name = cstring!(field);
 
+        let mut data_size = Box::pin(input.data.size() as u64);
+
         self.capi_return(unsafe {
-            let c_bufptr = raw_write_input.input.data.as_ref().as_ptr()
-                as *mut std::ffi::c_void;
-            let c_sizeptr =
-                raw_write_input.data_size.as_mut().get_mut() as *mut u64;
+            let c_bufptr =
+                input.data.as_ref().as_ptr() as *mut std::ffi::c_void;
+            let c_sizeptr = data_size.as_mut().get_mut() as *mut u64;
 
             ffi::tiledb_query_set_data_buffer(
                 c_context,
@@ -117,16 +134,15 @@ impl<'ctx, 'data> WriteBuilder<'ctx, 'data> {
             )
         })?;
 
-        if let Some(ref mut offsets_size) =
-            raw_write_input.offsets_size.as_mut()
-        {
-            let c_offptr = raw_write_input
-                .input
-                .cell_offsets
-                .as_ref()
-                .unwrap()
-                .as_ref()
-                .as_ptr() as *mut u64;
+        let mut offsets_size = input
+            .cell_offsets
+            .as_ref()
+            .map(|b| Box::pin(b.size() as u64));
+
+        if let Some(ref mut offsets_size) = offsets_size.as_mut() {
+            let c_offptr =
+                input.cell_offsets.as_ref().unwrap().as_ref().as_ptr()
+                    as *mut u64;
             let c_sizeptr = offsets_size.as_mut().get_mut() as *mut u64;
 
             self.capi_return(unsafe {
@@ -140,16 +156,12 @@ impl<'ctx, 'data> WriteBuilder<'ctx, 'data> {
             })?;
         }
 
-        if let Some(ref mut validity_size) =
-            raw_write_input.validity_size.as_mut()
-        {
-            let c_validityptr = raw_write_input
-                .input
-                .validity
-                .as_ref()
-                .unwrap()
-                .as_ref()
-                .as_ptr() as *mut u8;
+        let mut validity_size =
+            input.validity.as_ref().map(|b| Box::pin(b.size() as u64));
+
+        if let Some(ref mut validity_size) = validity_size.as_mut() {
+            let c_validityptr =
+                input.validity.as_ref().unwrap().as_ref().as_ptr() as *mut u8;
             let c_sizeptr = validity_size.as_mut().get_mut() as *mut u64;
 
             self.capi_return(unsafe {
@@ -162,6 +174,13 @@ impl<'ctx, 'data> WriteBuilder<'ctx, 'data> {
                 )
             })?;
         }
+
+        let raw_write_input = RawWriteInput {
+            _data_size: data_size,
+            _offsets_size: offsets_size,
+            _validity_size: validity_size,
+            _input: input.into(),
+        };
 
         self.inputs.insert(String::from(field), raw_write_input);
 

--- a/tiledb/api/src/query/write/mod.rs
+++ b/tiledb/api/src/query/write/mod.rs
@@ -3,7 +3,7 @@ use super::*;
 use std::collections::HashMap;
 use std::pin::Pin;
 
-use crate::query::buffer::QueryBuffers;
+use crate::query::buffer::{QueryBuffers, TypedQueryBuffers};
 use crate::query::write::input::DataProvider;
 
 pub mod input;
@@ -14,35 +14,6 @@ struct RawWriteInput<'data> {
     _validity_size: Option<Pin<Box<u64>>>,
     _input: TypedQueryBuffers<'data>,
 }
-
-pub enum TypedQueryBuffers<'data> {
-    UInt8(QueryBuffers<'data, u8>),
-    UInt16(QueryBuffers<'data, u16>),
-    UInt32(QueryBuffers<'data, u32>),
-    UInt64(QueryBuffers<'data, u64>),
-    Int8(QueryBuffers<'data, i8>),
-    Int16(QueryBuffers<'data, i16>),
-    Int32(QueryBuffers<'data, i32>),
-    Int64(QueryBuffers<'data, i64>),
-    Float32(QueryBuffers<'data, f32>),
-    Float64(QueryBuffers<'data, f64>),
-}
-
-macro_rules! typed_input_data {
-    ($($V:ident : $U:ty),+) => {
-        $(
-            impl<'data> From<QueryBuffers<'data, $U>> for TypedQueryBuffers<'data> {
-                fn from(value: QueryBuffers<'data, $U>) -> Self {
-                    TypedQueryBuffers::$V(value)
-                }
-            }
-        )+
-    }
-}
-
-typed_input_data!(UInt8: u8, UInt16: u16, UInt32: u32, UInt64: u64);
-typed_input_data!(Int8: i8, Int16: i16, Int32: i32, Int64: i64);
-typed_input_data!(Float32: f32, Float64: f64);
 
 type InputMap<'data> = HashMap<String, RawWriteInput<'data>>;
 

--- a/tiledb/api/src/query/write/mod.rs
+++ b/tiledb/api/src/query/write/mod.rs
@@ -32,18 +32,6 @@ impl<'ctx, 'data> WriteQuery<'ctx, 'data> {
     }
 }
 
-impl<'ctx, 'data> WriteQuery<'ctx, 'data> {
-    pub fn finalize(self) -> TileDBResult<Array<'ctx>> {
-        let c_context = self.context().capi();
-        let c_query = **self.base().cquery();
-        self.capi_return(unsafe {
-            ffi::tiledb_query_finalize(c_context, c_query)
-        })?;
-
-        Ok(self.base.array)
-    }
-}
-
 #[derive(ContextBound)]
 pub struct WriteBuilder<'ctx, 'data> {
     #[base(ContextBound)]

--- a/tiledb/api/src/query/write/mod.rs
+++ b/tiledb/api/src/query/write/mod.rs
@@ -190,3 +190,6 @@ impl<'ctx, 'data> WriteBuilder<'ctx, 'data> {
         Ok(self)
     }
 }
+
+#[cfg(any(test, feature = "proptest-strategies"))]
+pub mod strategy;

--- a/tiledb/api/src/query/write/mod.rs
+++ b/tiledb/api/src/query/write/mod.rs
@@ -67,12 +67,9 @@ impl<'ctx, 'data> QueryBuilder<'ctx> for WriteBuilder<'ctx, 'data> {
 }
 
 impl<'ctx, 'data> WriteBuilder<'ctx, 'data> {
-    pub fn new(
-        context: &'ctx Context,
-        array: Array<'ctx>,
-    ) -> TileDBResult<Self> {
+    pub fn new(array: Array<'ctx>) -> TileDBResult<Self> {
         Ok(WriteBuilder {
-            base: BuilderBase::new(context, array, QueryType::Write)?,
+            base: BuilderBase::new(array, QueryType::Write)?,
             inputs: HashMap::new(),
         })
     }

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -1,0 +1,461 @@
+use std::fmt::Debug;
+use std::rc::Rc;
+
+use paste::paste;
+use proptest::prelude::*;
+use proptest::strategy::{NewTree, ValueTree};
+use proptest::test_runner::TestRunner;
+
+use super::*;
+use crate::array::{ArrayType, CellValNum, SchemaData};
+use crate::fn_typed;
+
+trait WriteFieldInput<C>: DataProvider<Unit = C> + Debug {}
+
+impl<T, C> WriteFieldInput<C> for T where T: DataProvider<Unit = C> + Debug {}
+
+#[derive(Clone, Debug)]
+pub enum WriteFieldData {
+    UInt8(Vec<u8>),
+    UInt16(Vec<u16>),
+    UInt32(Vec<u32>),
+    UInt64(Vec<u64>),
+    Int8(Vec<i8>),
+    Int16(Vec<i16>),
+    Int32(Vec<i32>),
+    Int64(Vec<i64>),
+    Float32(Vec<f32>),
+    Float64(Vec<f64>),
+    VecUInt8(Vec<Vec<u8>>),
+    VecUInt16(Vec<Vec<u16>>),
+    VecUInt32(Vec<Vec<u32>>),
+    VecUInt64(Vec<Vec<u64>>),
+    VecInt8(Vec<Vec<i8>>),
+    VecInt16(Vec<Vec<i16>>),
+    VecInt32(Vec<Vec<i32>>),
+    VecInt64(Vec<Vec<i64>>),
+    VecFloat32(Vec<Vec<f32>>),
+    VecFloat64(Vec<Vec<f64>>),
+}
+
+macro_rules! typed_write_field {
+    ($($V:ident : $U:ty),+) => {
+        $(
+            impl From<Vec<$U>> for WriteFieldData {
+                fn from(value: Vec<$U>) -> Self {
+                    WriteFieldData::$V(value)
+                }
+            }
+
+            impl From<Vec<Vec<$U>>> for WriteFieldData {
+                fn from(value: Vec<Vec<$U>>) -> Self {
+                    paste! {
+                        WriteFieldData::[< Vec $V >](value)
+                    }
+                }
+            }
+        )+
+    };
+}
+
+typed_write_field!(UInt8: u8, UInt16: u16, UInt32: u32, UInt64: u64);
+typed_write_field!(Int8: i8, Int16: i16, Int32: i32, Int64: i64);
+typed_write_field!(Float32: f32, Float64: f64);
+
+macro_rules! fn_write_field {
+    ($field:expr, $DT:ident, $data:ident, $then:expr) => {
+        match $field {
+            WriteFieldData::UInt8(ref $data) => {
+                type $DT = Vec<u8>;
+                $then
+            }
+            WriteFieldData::UInt16(ref $data) => {
+                type $DT = Vec<u16>;
+                $then
+            }
+            WriteFieldData::UInt32(ref $data) => {
+                type $DT = Vec<u32>;
+                $then
+            }
+            WriteFieldData::UInt64(ref $data) => {
+                type $DT = Vec<u64>;
+                $then
+            }
+            WriteFieldData::Int8(ref $data) => {
+                type $DT = Vec<i8>;
+                $then
+            }
+            WriteFieldData::Int16(ref $data) => {
+                type $DT = Vec<i16>;
+                $then
+            }
+            WriteFieldData::Int32(ref $data) => {
+                type $DT = Vec<i32>;
+                $then
+            }
+            WriteFieldData::Int64(ref $data) => {
+                type $DT = Vec<i64>;
+                $then
+            }
+            WriteFieldData::Float32(ref $data) => {
+                type $DT = Vec<f32>;
+                $then
+            }
+            WriteFieldData::Float64(ref $data) => {
+                type $DT = Vec<f64>;
+                $then
+            }
+            WriteFieldData::VecUInt8(ref $data) => {
+                type $DT = Vec<Vec<u8>>;
+                $then
+            }
+            WriteFieldData::VecUInt16(ref $data) => {
+                type $DT = Vec<Vec<u16>>;
+                $then
+            }
+            WriteFieldData::VecUInt32(ref $data) => {
+                type $DT = Vec<Vec<u32>>;
+                $then
+            }
+            WriteFieldData::VecUInt64(ref $data) => {
+                type $DT = Vec<Vec<u64>>;
+                $then
+            }
+            WriteFieldData::VecInt8(ref $data) => {
+                type $DT = Vec<Vec<i8>>;
+                $then
+            }
+            WriteFieldData::VecInt16(ref $data) => {
+                type $DT = Vec<Vec<i16>>;
+                $then
+            }
+            WriteFieldData::VecInt32(ref $data) => {
+                type $DT = Vec<Vec<i32>>;
+                $then
+            }
+            WriteFieldData::VecInt64(ref $data) => {
+                type $DT = Vec<Vec<i64>>;
+                $then
+            }
+            WriteFieldData::VecFloat32(ref $data) => {
+                type $DT = Vec<Vec<f32>>;
+                $then
+            }
+            WriteFieldData::VecFloat64(ref $data) => {
+                type $DT = Vec<Vec<f64>>;
+                $then
+            }
+        }
+    };
+}
+
+#[derive(Clone, Debug)]
+pub struct WriteQueryData {
+    fields: Vec<(String, WriteFieldData)>,
+}
+
+impl WriteQueryData {
+    pub fn attach_write<'ctx, 'data>(
+        &'data self,
+        b: WriteBuilder<'ctx, 'data>,
+    ) -> TileDBResult<WriteBuilder<'ctx, 'data>> {
+        let mut b = b;
+        for f in self.fields.iter() {
+            b = fn_write_field!(
+                &f.1,
+                DT,
+                data,
+                b.data_typed::<_, DT>(&f.0, data)
+            )?;
+        }
+        Ok(b)
+    }
+
+    pub fn attach_read<'ctx, 'data, B>(
+        &'data mut self,
+        b: B,
+    ) -> <B as ReadQueryBuilder<'ctx, 'data>>::IntoVarRaw
+    where
+        B: ReadQueryBuilder<'ctx, 'data>,
+    {
+        self.fields.iter_mut().map(|(name, data)| unimplemented!());
+        unimplemented!()
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum WriteFieldMask {
+    /// This field must appear in the write set
+    Include,
+    /// This field appears in the write set but simplification may change that
+    TentativelyInclude,
+    /// This field may appear in the write set again after complication
+    TentativelyExclude,
+    /// This field may not appear in the write set again
+    Exclude,
+}
+
+impl WriteFieldMask {
+    pub fn is_included(&self) -> bool {
+        matches!(
+            self,
+            WriteFieldMask::Include | WriteFieldMask::TentativelyInclude
+        )
+    }
+}
+
+struct WriteQueryDataValueTree {
+    schema: Rc<SchemaData>,
+    field_mask: Vec<WriteFieldMask>,
+    field_data: Vec<Option<WriteFieldData>>,
+}
+
+impl ValueTree for WriteQueryDataValueTree {
+    type Value = WriteQueryData;
+
+    fn current(&self) -> Self::Value {
+        let fields = self
+            .field_mask
+            .iter()
+            .enumerate()
+            .filter(|(_, f)| f.is_included())
+            .map(|(i, _)| {
+                let f = self.schema.field(i);
+                (f.name.clone(), self.field_data[i].clone().unwrap())
+            })
+            .collect::<Vec<(String, WriteFieldData)>>();
+
+        WriteQueryData { fields }
+    }
+
+    fn simplify(&mut self) -> bool {
+        unimplemented!()
+    }
+
+    fn complicate(&mut self) -> bool {
+        unimplemented!()
+    }
+}
+
+#[derive(Debug)]
+struct WriteQueryDataStrategy {
+    schema: Rc<SchemaData>,
+}
+
+impl WriteQueryDataStrategy {
+    pub fn new(schema: &Rc<SchemaData>) -> Self {
+        WriteQueryDataStrategy {
+            schema: Rc::clone(schema),
+        }
+    }
+}
+
+impl Strategy for WriteQueryDataStrategy {
+    type Tree = WriteQueryDataValueTree;
+    type Value = WriteQueryData;
+
+    fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
+        const WRITE_QUERY_MIN_RECORDS: usize = 0;
+        const WRITE_QUERY_MAX_RECORDS: usize = 1024 * 1024;
+
+        const WRITE_QUERY_MIN_VAR_SIZE: usize = 0;
+        const WRITE_QUERY_MAX_VAR_SIZE: usize = 1024 * 128;
+
+        /* Choose the maximum number of records */
+        let nrecords = (WRITE_QUERY_MIN_RECORDS..=WRITE_QUERY_MAX_RECORDS)
+            .new_tree(runner)?
+            .current();
+
+        /* generate a random set of fields to query */
+        let field_mask = {
+            let ndimensions = self.schema.domain.dimension.len();
+            let nattributes = self.schema.attributes.len();
+
+            let dimensions_mask = match self.schema.array_type {
+                ArrayType::Dense => {
+                    /* dense array coordinates are handled by a subarray */
+                    vec![WriteFieldMask::Exclude; ndimensions]
+                }
+                ArrayType::Sparse => {
+                    /* sparse array must write coordinates */
+                    vec![WriteFieldMask::Include; ndimensions]
+                }
+            };
+
+            /* choose a random set of attributes to initially manifest */
+            let attributes_mask: Vec<WriteFieldMask> =
+                proptest::collection::vec(
+                    prop_oneof![
+                        Just(WriteFieldMask::TentativelyInclude),
+                        Just(WriteFieldMask::Exclude)
+                    ],
+                    nattributes..=nattributes,
+                )
+                .prop_shuffle()
+                .new_tree(runner)?
+                .current();
+
+            dimensions_mask
+                .into_iter()
+                .chain(attributes_mask.into_iter())
+                .collect::<Vec<_>>()
+        };
+
+        let field_data = field_mask
+            .iter()
+            .enumerate()
+            .map(|(i, f)| {
+                if f.is_included() {
+                    let field = self.schema.field(i);
+                    let datatype = field.datatype;
+                    let cell_val_num = field
+                        .cell_val_num
+                        .unwrap_or(CellValNum::try_from(1).unwrap());
+
+                    if cell_val_num == 1u32 {
+                        Some(fn_typed!(datatype, DT, {
+                            let data = proptest::collection::vec(
+                                any::<DT>(),
+                                nrecords..=nrecords,
+                            )
+                            .new_tree(runner)
+                            .expect("Error generating query data")
+                            .current();
+
+                            WriteFieldData::from(data)
+                        }))
+                    } else {
+                        let (min, max) = if cell_val_num.is_var_sized() {
+                            (WRITE_QUERY_MIN_VAR_SIZE, WRITE_QUERY_MAX_VAR_SIZE)
+                        } else {
+                            let fixed_bound =
+                                Into::<u32>::into(cell_val_num) as usize;
+                            (fixed_bound, fixed_bound)
+                        };
+                        Some(fn_typed!(datatype, DT, {
+                            let data = proptest::collection::vec(
+                                proptest::collection::vec(
+                                    any::<DT>(),
+                                    min..=max,
+                                ),
+                                nrecords..=nrecords,
+                            )
+                            .new_tree(runner)
+                            .expect("Error generating query data")
+                            .current();
+
+                            WriteFieldData::from(data)
+                        }))
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<Option<WriteFieldData>>>();
+
+        Ok(WriteQueryDataValueTree {
+            schema: self.schema.clone(),
+            field_mask,
+            field_data,
+        })
+    }
+}
+
+impl Arbitrary for WriteQueryData {
+    type Parameters = Option<Rc<SchemaData>>;
+    type Strategy = BoxedStrategy<WriteQueryData>;
+
+    fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+        if let Some(schema) = args {
+            WriteQueryDataStrategy::new(&schema).boxed()
+        } else {
+            any::<SchemaData>()
+                .prop_flat_map(|schema| {
+                    WriteQueryDataStrategy::new(&Rc::new(schema))
+                })
+                .boxed()
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct WriteSequence {
+    writes: Vec<WriteQueryData>,
+}
+
+impl Arbitrary for WriteSequence {
+    type Parameters = Option<Rc<SchemaData>>;
+    type Strategy = BoxedStrategy<WriteSequence>;
+
+    fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+        if let Some(schema) = args {
+            prop_write_sequence(&schema).boxed()
+        } else {
+            any::<SchemaData>()
+                .prop_flat_map(|schema| prop_write_sequence(&Rc::new(schema)))
+                .boxed()
+        }
+    }
+}
+
+impl IntoIterator for WriteSequence {
+    type Item = WriteQueryData;
+    type IntoIter = <Vec<Self::Item> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.writes.into_iter()
+    }
+}
+
+pub fn prop_write_sequence(
+    schema: &Rc<SchemaData>,
+) -> impl Strategy<Value = WriteSequence> {
+    const MAX_WRITES: usize = 8;
+    proptest::collection::vec(
+        any_with::<WriteQueryData>(Some(Rc::clone(schema))),
+        0..MAX_WRITES,
+    )
+    .prop_map(|writes| WriteSequence { writes })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    use crate::array::Mode;
+    use crate::Factory;
+
+    /// Test that each write in the sequence can be read back correctly at the right timestamp
+    #[test]
+    fn write_readback() {
+        let ctx = Context::new().expect("Error creating context");
+
+        let strategy = any::<SchemaData>().prop_flat_map(|schema| {
+            let schema = Rc::new(schema);
+            (
+                Just(Rc::clone(&schema)),
+                any_with::<WriteSequence>(Some(Rc::clone(&schema))),
+            )
+        });
+
+        proptest!(|((schema_spec, write_sequence) in strategy)| {
+            let tempdir = TempDir::new().expect("Error creating temp dir");
+            let uri = String::from("file:///") + tempdir.path().join("array").to_str().unwrap();
+
+            let schema_in = schema_spec.create(&ctx)
+                .expect("Error constructing arbitrary schema");
+            Array::create(&ctx, &uri, schema_in)
+                .expect("Error creating array");
+
+            let array = Array::open(&ctx, &uri, Mode::Write).expect("Error opening array");
+
+            for write in write_sequence {
+                let write = write.attach(WriteBuilder::new(array)).expect("Error building write query")
+                    .build();
+                write.submit()?;
+                array = write.finalize()?;
+            }
+        })
+    }
+}

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -174,7 +174,7 @@ impl WriteQueryData {
     pub fn attach_read<'ctx, 'data, B>(
         &'data mut self,
         b: B,
-    ) -> <B as ReadQueryBuilder<'ctx, 'data>>::IntoVarRaw
+    ) -> VarCallbackReadQueryBuilder<'data, B>
     where
         B: ReadQueryBuilder<'ctx, 'data>,
     {
@@ -451,7 +451,7 @@ mod tests {
             let array = Array::open(&ctx, &uri, Mode::Write).expect("Error opening array");
 
             for write in write_sequence {
-                let write = write.attach(WriteBuilder::new(array)).expect("Error building write query")
+                let write = write.attach_write(WriteBuilder::new(array)).expect("Error building write query")
                     .build();
                 write.submit()?;
                 array = write.finalize()?;

--- a/tiledb/proc-macro/src/query.rs
+++ b/tiledb/proc-macro/src/query.rs
@@ -147,6 +147,10 @@ fn query_capi_interface_impl_fields_named_base(
             fn base(&self) -> &QueryBase<'ctx> {
                 self.#fname.base()
             }
+
+            fn finalize(self) -> TileDBResult<Array<'ctx>> {
+                self.#fname.finalize()
+            }
         }
     };
 

--- a/tiledb/sys/src/array.rs
+++ b/tiledb/sys/src/array.rs
@@ -51,4 +51,10 @@ extern "C" {
         ctx: *mut tiledb_ctx_t,
         array: *mut tiledb_array_t,
     ) -> i32;
+
+    pub fn tiledb_array_get_schema(
+        ctx: *mut tiledb_ctx_t,
+        array: *mut tiledb_array_t,
+        array_schema: *mut *mut tiledb_array_schema_t,
+    ) -> i32;
 }


### PR DESCRIPTION
This pull request takes the first serious look at using our query API to do something beyond the simple examples.  Generating an arbitrary write query means poking at an arbitrary schema's attributes, generating data to write into those attributes, generating a write query for them, and then also generating a read query to check that what we wrote is actually correct.

This pull request modifies various components so that there is a path to implementing all of the above, and then implements a proptest which generates a series of write queries and then does an array read at each point in the series to check that everything  was written correctly.

The read query API is heavily modified, as it previously had nigh-nonexistent support for dynamic queries.  We have that now with `VarRawReadQuery` and `CallbackVarArgReadQuery`, along with some other improvements.