### PR TITLE
impl Send for Array by consuming the tiledb Context

### DIFF
--- a/tiledb/api/examples/fragment_info.rs
+++ b/tiledb/api/examples/fragment_info.rs
@@ -143,7 +143,7 @@ fn write_array() -> TileDBResult<()> {
     let tdb = tiledb::context::Context::new()?;
 
     let array = tiledb::Array::open(
-        &tdb,
+        tdb,
         FRAGMENT_INFO_ARRAY_URI,
         tiledb::array::Mode::Write,
     )?;

--- a/tiledb/api/examples/query_condition_sparse.rs
+++ b/tiledb/api/examples/query_condition_sparse.rs
@@ -20,44 +20,47 @@ const D_FILL_VALUE: f32 = 0.0;
 
 /// Demonstrate reading sparse arrays with query conditions.
 fn main() -> TileDBResult<()> {
-    let ctx = Context::new()?;
-    if !Array::exists(&ctx, ARRAY_URI)? {
-        create_array(&ctx)?;
-        write_array(&ctx)?;
+    {
+        let ctx = Context::new()?;
+        if !Array::exists(&ctx, ARRAY_URI)? {
+            create_array(&ctx)?;
+            write_array(ctx)?;
+        }
     }
 
     println!("Reading the entire array:");
-    read_array(&ctx, None)?;
+    read_array(None)?;
 
     println!("Reading: a is null");
     let qc = QC::field("a").is_null();
-    read_array(&ctx, Some(&qc))?;
+    read_array(Some(qc))?;
 
     println!("Reading: b < \"eve\"");
     let qc = QC::field("b").lt("eve");
-    read_array(&ctx, Some(&qc))?;
+    read_array(Some(qc))?;
 
     println!("Reading: c >= 1");
     let qc = QC::field("c").ge(1i32);
-    read_array(&ctx, Some(&qc))?;
+    read_array(Some(qc))?;
 
     println!("Reading: 3.0 <= d <= 4.0");
     let qc = QC::field("d").ge(3.0f32) & QC::field("d").le(4.0f32);
-    read_array(&ctx, Some(&qc))?;
+    read_array(Some(qc))?;
 
     println!("Reading: (a is not null) && (b < \"eve\") && (3.0 <= d <= 4.0)");
     let qc = QC::field("a").not_null()
         & QC::field("b").lt("eve")
         & QC::field("d").ge(3.0f32)
         & QC::field("d").le(4.0f32);
-    read_array(&ctx, Some(&qc))?;
+    read_array(Some(qc))?;
 
     Ok(())
 }
 
 /// Read the array with the optional query condition and print the results
 /// to stdout.
-fn read_array(ctx: &Context, qc: Option<&QC>) -> TileDBResult<()> {
+fn read_array(qc: Option<QC>) -> TileDBResult<()> {
+    let ctx = Context::new()?;
     let array = tiledb::Array::open(ctx, ARRAY_URI, tiledb::array::Mode::Read)?;
     let mut query = ReadBuilder::new(array)?
         .layout(tiledb::query::QueryLayout::RowMajor)?
@@ -74,7 +77,7 @@ fn read_array(ctx: &Context, qc: Option<&QC>) -> TileDBResult<()> {
         .finish_subarray()?;
 
     query = if let Some(qc) = qc {
-        query.query_condition(qc.build(ctx)?)?
+        query.query_condition(qc)?
     } else {
         query
     };
@@ -158,7 +161,7 @@ fn create_array(ctx: &Context) -> TileDBResult<()> {
 ///   7   | 8    | heidi | 2 | 4.9
 ///   8   | null | ivan  | 3 | 3.2
 ///   9   | 10   | judy  | 4 | 3.1
-fn write_array(ctx: &Context) -> TileDBResult<()> {
+fn write_array(ctx: Context) -> TileDBResult<()> {
     let index_input = vec![0u32, 1, 2, 3, 4, 5, 6, 7, 8, 9];
     let a_data = RefCell::new(QueryBuffersMut {
         data: BufferMut::Owned(

--- a/tiledb/api/examples/quickstart_dense.rs
+++ b/tiledb/api/examples/quickstart_dense.rs
@@ -81,7 +81,7 @@ fn write_array() -> TileDBResult<()> {
     let tdb = tiledb::context::Context::new()?;
 
     let array = tiledb::Array::open(
-        &tdb,
+        tdb,
         QUICKSTART_DENSE_ARRAY_URI,
         tiledb::array::Mode::Write,
     )?;
@@ -108,7 +108,7 @@ fn read_array() -> TileDBResult<()> {
     let tdb = tiledb::context::Context::new()?;
 
     let array = tiledb::Array::open(
-        &tdb,
+        tdb,
         QUICKSTART_DENSE_ARRAY_URI,
         tiledb::array::Mode::Read,
     )?;

--- a/tiledb/api/examples/reading_incomplete.rs
+++ b/tiledb/api/examples/reading_incomplete.rs
@@ -103,7 +103,7 @@ fn write_array() -> TileDBResult<()> {
     let tdb = tiledb::Context::new()?;
 
     let array =
-        tiledb::Array::open(&tdb, ARRAY_NAME, tiledb::array::Mode::Write)?;
+        tiledb::Array::open(tdb, ARRAY_NAME, tiledb::array::Mode::Write)?;
 
     let coords_rows = vec![1, 2, 2];
     let coords_cols = vec![1, 1, 2];
@@ -127,7 +127,7 @@ fn write_array() -> TileDBResult<()> {
 /// from a query.  The example wants to print out the query result set.
 /// Below are several different ways to implement this functionality.
 
-fn query_builder_start(tdb: &tiledb::Context) -> TileDBResult<ReadBuilder> {
+fn query_builder_start(tdb: tiledb::Context) -> TileDBResult<ReadBuilder> {
     let array =
         tiledb::Array::open(tdb, ARRAY_NAME, tiledb::array::Mode::Read)?;
 
@@ -186,7 +186,7 @@ fn read_array_step() -> TileDBResult<()> {
         validity: None,
     });
 
-    let mut qq = query_builder_start(&tdb)?
+    let mut qq = query_builder_start(tdb)?
         .register_raw("rows", &rows_output)?
         .register_raw("columns", &cols_output)?
         .register_raw(INT32_ATTRIBUTE_NAME, &int32_output)?
@@ -246,7 +246,7 @@ fn read_array_collect() -> TileDBResult<()> {
 
     let tdb = tiledb::context::Context::new()?;
 
-    let mut qq = query_builder_start(&tdb)?
+    let mut qq = query_builder_start(tdb)?
         .register_constructor::<_, Vec<i32>>(
             "rows",
             ScratchStrategy::CustomAllocator(Box::new(NonVarSized {
@@ -320,7 +320,7 @@ fn read_array_callback() -> TileDBResult<()> {
         )),
         validity: None,
     });
-    let mut qq = query_builder_start(&tdb)?
+    let mut qq = query_builder_start(tdb)?
         .register_callback4::<FnMutAdapter<(i32, i32, i32, String), _>>(
             ("rows", ScratchStrategy::RawBuffers(&rows_output)),
             ("columns", ScratchStrategy::RawBuffers(&cols_output)),

--- a/tiledb/api/examples/using_tiledb_stats.rs
+++ b/tiledb/api/examples/using_tiledb_stats.rs
@@ -99,7 +99,7 @@ pub fn create_array(
 pub fn write_array() -> TileDBResult<()> {
     let tdb = tiledb::context::Context::new()?;
     let array: Array =
-        tiledb::Array::open(&tdb, ARRAY_NAME, tiledb::array::Mode::Write)?;
+        tiledb::Array::open(tdb, ARRAY_NAME, tiledb::array::Mode::Write)?;
     let data: Vec<i32> = Vec::from_iter(0..12000 * 12000);
 
     let query = tiledb::query::WriteBuilder::new(array)?
@@ -128,7 +128,7 @@ pub fn read_array(json: bool) -> TileDBResult<()> {
     let tdb = tiledb::context::Context::new()?;
 
     let array =
-        tiledb::Array::open(&tdb, ARRAY_NAME, tiledb::array::Mode::Read)?;
+        tiledb::Array::open(tdb, ARRAY_NAME, tiledb::array::Mode::Read)?;
 
     let mut query = tiledb::query::ReadBuilder::new(array)?
         .layout(tiledb::query::QueryLayout::RowMajor)?

--- a/tiledb/api/src/array/attribute/mod.rs
+++ b/tiledb/api/src/array/attribute/mod.rs
@@ -38,6 +38,8 @@ impl Drop for RawAttribute {
     }
 }
 
+unsafe impl Send for RawAttribute {}
+
 #[derive(ContextBound)]
 pub struct Attribute<'ctx> {
     #[context]

--- a/tiledb/api/src/array/dimension/mod.rs
+++ b/tiledb/api/src/array/dimension/mod.rs
@@ -33,6 +33,8 @@ impl Drop for RawDimension {
     }
 }
 
+unsafe impl Send for RawDimension {}
+
 #[derive(ContextBound)]
 pub struct Dimension<'ctx> {
     #[context]

--- a/tiledb/api/src/array/domain/mod.rs
+++ b/tiledb/api/src/array/domain/mod.rs
@@ -33,6 +33,8 @@ impl Drop for RawDomain {
     }
 }
 
+unsafe impl Send for RawDomain {}
+
 #[derive(ContextBound)]
 pub struct Domain<'ctx> {
     #[context]

--- a/tiledb/api/src/array/enumeration/mod.rs
+++ b/tiledb/api/src/array/enumeration/mod.rs
@@ -32,6 +32,8 @@ impl Drop for RawEnumeration {
     }
 }
 
+unsafe impl Send for RawEnumeration {}
+
 #[derive(ContextBound)]
 pub struct Enumeration<'ctx> {
     #[context]

--- a/tiledb/api/src/array/fragment_info.rs
+++ b/tiledb/api/src/array/fragment_info.rs
@@ -38,6 +38,8 @@ impl Drop for RawFragmentInfo {
     }
 }
 
+unsafe impl Send for RawFragmentInfo {}
+
 #[derive(ContextBound)]
 struct FragmentInfoInternal<'ctx> {
     #[context]
@@ -750,15 +752,15 @@ pub mod tests {
 
     use crate::array::*;
     use crate::config::Config;
-    use crate::query::{QueryBuilder, WriteBuilder};
+    use crate::query::{Query, QueryBuilder, WriteBuilder};
     use crate::Datatype;
 
     #[test]
     fn test_set_config() -> TileDBResult<()> {
-        let ctx = Context::new().unwrap();
         let tmp_dir = TempDir::new().unwrap();
-        let array_uri = create_dense_array(&ctx, &tmp_dir).unwrap();
+        let array_uri = create_dense_array(&tmp_dir).unwrap();
 
+        let ctx = Context::new().unwrap();
         let config = Config::new()?;
         let frag_infos =
             Builder::new(&ctx, &array_uri)?.config(&config)?.build();
@@ -770,9 +772,10 @@ pub mod tests {
 
     #[test]
     fn test_get_config() -> TileDBResult<()> {
-        let ctx = Context::new().unwrap();
         let tmp_dir = TempDir::new().unwrap();
-        let array_uri = create_dense_array(&ctx, &tmp_dir).unwrap();
+        let array_uri = create_dense_array(&tmp_dir).unwrap();
+
+        let ctx = Context::new().unwrap();
         let frag_infos = Builder::new(&ctx, &array_uri)?.build()?;
 
         assert!(frag_infos.config().is_ok());
@@ -782,9 +785,10 @@ pub mod tests {
 
     #[test]
     fn test_load_infos() -> TileDBResult<()> {
-        let ctx = Context::new().unwrap();
         let tmp_dir = TempDir::new().unwrap();
-        let array_uri = create_dense_array(&ctx, &tmp_dir).unwrap();
+        let array_uri = create_dense_array(&tmp_dir).unwrap();
+
+        let ctx = Context::new().unwrap();
         let frag_infos =
             Builder::new(&ctx, &array_uri)?.build_without_loading();
 
@@ -795,9 +799,10 @@ pub mod tests {
 
     #[test]
     fn test_unconsolidated_metadata_num() -> TileDBResult<()> {
-        let ctx = Context::new().unwrap();
         let tmp_dir = TempDir::new().unwrap();
-        let array_uri = create_dense_array(&ctx, &tmp_dir).unwrap();
+        let array_uri = create_dense_array(&tmp_dir).unwrap();
+
+        let ctx = Context::new().unwrap();
         let frag_infos = Builder::new(&ctx, &array_uri)?.build()?;
 
         assert!(frag_infos.unconsolidated_metadata_num().is_ok());
@@ -807,9 +812,10 @@ pub mod tests {
 
     #[test]
     fn test_num_to_vacuum() -> TileDBResult<()> {
-        let ctx = Context::new().unwrap();
         let tmp_dir = TempDir::new().unwrap();
-        let array_uri = create_dense_array(&ctx, &tmp_dir).unwrap();
+        let array_uri = create_dense_array(&tmp_dir).unwrap();
+
+        let ctx = Context::new().unwrap();
         let frag_infos = Builder::new(&ctx, &array_uri)?.build()?;
 
         assert!(frag_infos.num_to_vacuum().is_ok());
@@ -819,9 +825,10 @@ pub mod tests {
 
     #[test]
     fn test_total_cell_count() -> TileDBResult<()> {
-        let ctx = Context::new().unwrap();
         let tmp_dir = TempDir::new().unwrap();
-        let array_uri = create_dense_array(&ctx, &tmp_dir).unwrap();
+        let array_uri = create_dense_array(&tmp_dir).unwrap();
+
+        let ctx = Context::new().unwrap();
         let frag_infos = Builder::new(&ctx, &array_uri)?.build()?;
 
         let cell_count = frag_infos.total_cell_count()?;
@@ -832,9 +839,10 @@ pub mod tests {
 
     #[test]
     fn test_num_fragments() -> TileDBResult<()> {
-        let ctx = Context::new().unwrap();
         let tmp_dir = TempDir::new().unwrap();
-        let array_uri = create_dense_array(&ctx, &tmp_dir).unwrap();
+        let array_uri = create_dense_array(&tmp_dir).unwrap();
+
+        let ctx = Context::new().unwrap();
         let frag_infos = Builder::new(&ctx, &array_uri)?.build()?;
 
         let num_frags = frag_infos.num_fragments()?;
@@ -845,9 +853,10 @@ pub mod tests {
 
     #[test]
     fn test_get_fragment() -> TileDBResult<()> {
-        let ctx = Context::new().unwrap();
         let tmp_dir = TempDir::new().unwrap();
-        let array_uri = create_dense_array(&ctx, &tmp_dir).unwrap();
+        let array_uri = create_dense_array(&tmp_dir).unwrap();
+
+        let ctx = Context::new().unwrap();
         let frag_infos = Builder::new(&ctx, &array_uri)?.build()?;
 
         assert!(frag_infos.get_fragment(0).is_ok());
@@ -857,9 +866,10 @@ pub mod tests {
 
     #[test]
     fn test_get_fragment_failure() -> TileDBResult<()> {
-        let ctx = Context::new().unwrap();
         let tmp_dir = TempDir::new().unwrap();
-        let array_uri = create_dense_array(&ctx, &tmp_dir).unwrap();
+        let array_uri = create_dense_array(&tmp_dir).unwrap();
+
+        let ctx = Context::new().unwrap();
         let frag_infos = Builder::new(&ctx, &array_uri)?.build()?;
 
         assert!(frag_infos.get_fragment(3).is_err());
@@ -869,9 +879,10 @@ pub mod tests {
 
     #[test]
     fn test_iter_fragments() -> TileDBResult<()> {
-        let ctx = Context::new().unwrap();
         let tmp_dir = TempDir::new().unwrap();
-        let array_uri = create_dense_array(&ctx, &tmp_dir).unwrap();
+        let array_uri = create_dense_array(&tmp_dir).unwrap();
+
+        let ctx = Context::new().unwrap();
         let frag_infos = Builder::new(&ctx, &array_uri)?.build()?;
 
         let mut num_frags = 0;
@@ -886,11 +897,11 @@ pub mod tests {
 
     #[test]
     fn test_fragment_info_apis() -> TileDBResult<()> {
-        let ctx = Context::new().unwrap();
         let tmp_dir = TempDir::new().unwrap();
-        let dense_array_uri = create_dense_array(&ctx, &tmp_dir).unwrap();
-        let sparse_array_uri = create_sparse_array(&ctx, &tmp_dir).unwrap();
+        let dense_array_uri = create_dense_array(&tmp_dir).unwrap();
+        let sparse_array_uri = create_sparse_array(&tmp_dir).unwrap();
 
+        let ctx = Context::new().unwrap();
         check_fragment_info_apis(&ctx, &dense_array_uri, FragmentType::Dense)?;
         check_fragment_info_apis(
             &ctx,
@@ -929,16 +940,14 @@ pub mod tests {
     }
 
     /// Create a simple dense test array with a couple fragments to inspect.
-    pub fn create_dense_array(
-        ctx: &Context,
-        dir: &TempDir,
-    ) -> TileDBResult<String> {
+    pub fn create_dense_array(dir: &TempDir) -> TileDBResult<String> {
+        let mut ctx = Context::new().unwrap();
         let array_dir = dir.path().join("fragment_info_test_dense");
         let array_uri = String::from(array_dir.to_str().unwrap());
 
         let domain = {
             let rows = DimensionBuilder::new::<i32>(
-                ctx,
+                &ctx,
                 "id",
                 Datatype::Int32,
                 &[1, 10],
@@ -946,44 +955,45 @@ pub mod tests {
             )?
             .build();
 
-            DomainBuilder::new(ctx)?.add_dimension(rows)?.build()
+            DomainBuilder::new(&ctx)?.add_dimension(rows)?.build()
         };
 
-        let schema = SchemaBuilder::new(ctx, ArrayType::Dense, domain)?
+        let schema = SchemaBuilder::new(&ctx, ArrayType::Dense, domain)?
             .add_attribute(
-                AttributeBuilder::new(ctx, "attr", Datatype::UInt64)?.build(),
+                AttributeBuilder::new(&ctx, "attr", Datatype::UInt64)?.build(),
             )?
             .build()?;
 
-        Array::create(ctx, &array_uri, schema)?;
+        Array::create(&ctx, &array_uri, schema)?;
 
         // Two writes for multiple fragments
-        write_dense_array(ctx, &array_uri)?;
+        ctx = write_dense_array(ctx, &array_uri)?;
         write_dense_array(ctx, &array_uri)?;
         Ok(array_uri)
     }
 
     /// Write another fragment to the test array.
-    fn write_dense_array(ctx: &Context, array_uri: &str) -> TileDBResult<()> {
+    fn write_dense_array(
+        ctx: Context,
+        array_uri: &str,
+    ) -> TileDBResult<Context> {
         let data = vec![1u64, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         let array = Array::open(ctx, array_uri, Mode::Write)?;
         let query =
             WriteBuilder::new(array)?.data_typed("attr", &data)?.build();
         query.submit()?;
-        Ok(())
+        query.finalize()?.close()
     }
 
     /// Create a simple sparse test array with a couple fragments to inspect.
-    pub fn create_sparse_array(
-        ctx: &Context,
-        dir: &TempDir,
-    ) -> TileDBResult<String> {
+    pub fn create_sparse_array(dir: &TempDir) -> TileDBResult<String> {
+        let mut ctx = Context::new().unwrap();
         let array_dir = dir.path().join("fragment_info_test_sparse");
         let array_uri = String::from(array_dir.to_str().unwrap());
 
         let domain = {
             let rows = DimensionBuilder::new::<i32>(
-                ctx,
+                &ctx,
                 "id",
                 Datatype::Int32,
                 &[1, 10],
@@ -991,25 +1001,28 @@ pub mod tests {
             )?
             .build();
 
-            DomainBuilder::new(ctx)?.add_dimension(rows)?.build()
+            DomainBuilder::new(&ctx)?.add_dimension(rows)?.build()
         };
 
-        let schema = SchemaBuilder::new(ctx, ArrayType::Sparse, domain)?
+        let schema = SchemaBuilder::new(&ctx, ArrayType::Sparse, domain)?
             .add_attribute(
-                AttributeBuilder::new(ctx, "attr", Datatype::UInt64)?.build(),
+                AttributeBuilder::new(&ctx, "attr", Datatype::UInt64)?.build(),
             )?
             .build()?;
 
-        Array::create(ctx, &array_uri, schema)?;
+        Array::create(&ctx, &array_uri, schema)?;
 
         // Two writes for multiple fragments
-        write_sparse_array(ctx, &array_uri)?;
+        ctx = write_sparse_array(ctx, &array_uri)?;
         write_sparse_array(ctx, &array_uri)?;
         Ok(array_uri)
     }
 
     /// Write another fragment to the test array.
-    fn write_sparse_array(ctx: &Context, array_uri: &str) -> TileDBResult<()> {
+    fn write_sparse_array(
+        ctx: Context,
+        array_uri: &str,
+    ) -> TileDBResult<Context> {
         let id_data = vec![1u32, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         let attr_data = vec![1u64, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         let array = Array::open(ctx, array_uri, Mode::Write)?;
@@ -1018,6 +1031,6 @@ pub mod tests {
             .data_typed("attr", &attr_data)?
             .build();
         query.submit()?;
-        Ok(())
+        query.finalize()?.close()
     }
 }

--- a/tiledb/api/src/array/schema/mod.rs
+++ b/tiledb/api/src/array/schema/mod.rs
@@ -137,6 +137,8 @@ impl Drop for RawSchema {
     }
 }
 
+unsafe impl Send for RawSchema {}
+
 /// Holds a field of the schema, which may be either a dimension or an attribute.
 #[derive(ContextBound)]
 pub enum Field<'ctx> {

--- a/tiledb/api/src/error.rs
+++ b/tiledb/api/src/error.rs
@@ -145,6 +145,8 @@ impl Serialize for Error {
     }
 }
 
+unsafe impl Send for RawError {}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tiledb/api/src/filter/list.rs
+++ b/tiledb/api/src/filter/list.rs
@@ -29,6 +29,8 @@ impl Drop for RawFilterList {
     }
 }
 
+unsafe impl Send for RawFilterList {}
+
 #[derive(ContextBound)]
 pub struct FilterList<'ctx> {
     #[context]

--- a/tiledb/api/src/filter/mod.rs
+++ b/tiledb/api/src/filter/mod.rs
@@ -322,6 +322,8 @@ impl Drop for RawFilter {
     }
 }
 
+unsafe impl Send for RawFilter {}
+
 #[derive(ContextBound)]
 pub struct Filter<'ctx> {
     #[context]
@@ -653,6 +655,11 @@ pub mod strategy;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn require_send() {
+        crate::require_send::<RawFilter>();
+    }
 
     /// Ensure that we can construct a filter from all options using default settings
     #[test]

--- a/tiledb/api/src/lib.rs
+++ b/tiledb/api/src/lib.rs
@@ -77,3 +77,6 @@ pub trait Factory<'ctx> {
 
     fn create(&self, context: &'ctx context::Context) -> Result<Self::Item>;
 }
+
+#[cfg(test)]
+pub(crate) fn require_send<T: Send>() {}

--- a/tiledb/api/src/query/read/mod.rs
+++ b/tiledb/api/src/query/read/mod.rs
@@ -182,7 +182,7 @@ impl<'data, C> From<&'data RefCell<QueryBuffersMut<'data, C>>>
 }
 
 /// Trait for runnable read queries.
-pub trait ReadQuery<'ctx>: Query<'ctx> {
+pub trait ReadQuery: Query {
     type Intermediate;
     type Final;
 
@@ -261,7 +261,7 @@ macro_rules! fn_register_callback {
 /// Trait for constructing a read query.
 /// Provides methods for flexibly adapting requested attributes into raw results,
 /// callbacks, or strongly-typed objects.
-pub trait ReadQueryBuilder<'ctx, 'data>: QueryBuilder<'ctx> {
+pub trait ReadQueryBuilder<'data>: QueryBuilder {
     /// Register a raw memory location to read query results into.
     fn register_raw<S, C>(
         self,
@@ -366,23 +366,23 @@ pub trait ReadQueryBuilder<'ctx, 'data>: QueryBuilder<'ctx> {
 }
 
 #[derive(ContextBound)]
-pub struct ReadBuilder<'ctx> {
+pub struct ReadBuilder {
     #[base(ContextBound)]
-    base: BuilderBase<'ctx>,
+    base: BuilderBase,
 }
 
-impl<'ctx> ReadBuilder<'ctx> {
-    pub fn new(array: Array<'ctx>) -> TileDBResult<Self> {
+impl ReadBuilder {
+    pub fn new(array: Array) -> TileDBResult<Self> {
         Ok(ReadBuilder {
             base: BuilderBase::new(array, QueryType::Read)?,
         })
     }
 }
 
-impl<'ctx> QueryBuilder<'ctx> for ReadBuilder<'ctx> {
-    type Query = QueryBase<'ctx>;
+impl QueryBuilder for ReadBuilder {
+    type Query = QueryBase;
 
-    fn base(&self) -> &BuilderBase<'ctx> {
+    fn base(&self) -> &BuilderBase {
         &self.base
     }
 
@@ -391,4 +391,4 @@ impl<'ctx> QueryBuilder<'ctx> for ReadBuilder<'ctx> {
     }
 }
 
-impl<'ctx, 'data> ReadQueryBuilder<'ctx, 'data> for ReadBuilder<'ctx> {}
+impl<'data> ReadQueryBuilder<'data> for ReadBuilder {}

--- a/tiledb/api/src/query/read/typed.rs
+++ b/tiledb/api/src/query/read/typed.rs
@@ -16,10 +16,10 @@ where
         CallbackReadQuery<'data, <T as ReadResult>::Constructor, Q>,
 }
 
-impl<'ctx, 'data, T, Q> ReadQuery<'ctx> for TypedReadQuery<'data, T, Q>
+impl<'data, T, Q> ReadQuery for TypedReadQuery<'data, T, Q>
 where
     T: ReadResult,
-    Q: ReadQuery<'ctx>,
+    Q: ReadQuery,
 {
     type Intermediate = Q::Intermediate;
     type Final = (T, Q::Final);
@@ -50,14 +50,14 @@ where
         CallbackReadBuilder<'data, <T as ReadResult>::Constructor, B>,
 }
 
-impl<'ctx, 'data, T, B> QueryBuilder<'ctx> for TypedReadBuilder<'data, T, B>
+impl<'data, T, B> QueryBuilder for TypedReadBuilder<'data, T, B>
 where
     T: ReadResult,
-    B: QueryBuilder<'ctx>,
+    B: QueryBuilder,
 {
     type Query = TypedReadQuery<'data, T, B::Query>;
 
-    fn base(&self) -> &BuilderBase<'ctx> {
+    fn base(&self) -> &BuilderBase {
         self.base.base()
     }
 
@@ -69,11 +69,10 @@ where
     }
 }
 
-impl<'ctx, 'data, T, B> ReadQueryBuilder<'ctx, 'data>
-    for TypedReadBuilder<'data, T, B>
+impl<'data, T, B> ReadQueryBuilder<'data> for TypedReadBuilder<'data, T, B>
 where
     T: ReadResult,
-    B: ReadQueryBuilder<'ctx, 'data>,
+    B: ReadQueryBuilder<'data>,
 {
 }
 

--- a/tiledb/api/src/query/subarray.rs
+++ b/tiledb/api/src/query/subarray.rs
@@ -30,19 +30,19 @@ impl Drop for RawSubarray {
 pub struct Subarray<'ctx> {
     #[context]
     context: &'ctx Context,
-    raw: RawSubarray,
+    _raw: RawSubarray,
 }
 
 #[derive(ContextBound)]
-pub struct Builder<'ctx, Q> {
-    query: Q,
+pub struct Builder<Q> {
     #[base(ContextBound)]
-    subarray: Subarray<'ctx>,
+    query: Q,
+    raw: RawSubarray,
 }
 
-impl<'ctx, Q> Builder<'ctx, Q>
+impl<Q> Builder<Q>
 where
-    Q: QueryBuilder<'ctx> + Sized,
+    Q: QueryBuilder + Sized,
 {
     pub(crate) fn for_query(query: Q) -> TileDBResult<Self> {
         let context = query.base().context();
@@ -56,10 +56,7 @@ where
 
         Ok(Builder {
             query,
-            subarray: Subarray {
-                context,
-                raw: RawSubarray::Owned(c_subarray),
-            },
+            raw: RawSubarray::Owned(c_subarray),
         })
     }
 
@@ -68,8 +65,8 @@ where
         key: K,
         range: &[Conv; 2],
     ) -> TileDBResult<Self> {
-        let c_context = self.subarray.context.capi();
-        let c_subarray = *self.subarray.raw;
+        let c_context = self.query.base().context().capi();
+        let c_subarray = *self.raw;
 
         let c_start = &range[0] as *const Conv as *const std::ffi::c_void;
         let c_end = &range[1] as *const Conv as *const std::ffi::c_void;
@@ -77,7 +74,7 @@ where
         match key.into() {
             LookupKey::Index(idx) => {
                 let c_idx = idx.try_into().unwrap();
-                self.capi_return(unsafe {
+                self.query.base().capi_return(unsafe {
                     ffi::tiledb_subarray_add_range(
                         c_context,
                         c_subarray,
@@ -90,7 +87,7 @@ where
             }
             LookupKey::Name(name) => {
                 let c_name = cstring!(name);
-                self.capi_return(unsafe {
+                self.query.base().capi_return(unsafe {
                     ffi::tiledb_subarray_add_range_by_name(
                         c_context,
                         c_subarray,
@@ -107,11 +104,11 @@ where
 
     /// Apply the subarray to the query, returning the query builder.
     pub fn finish_subarray(self) -> TileDBResult<Q> {
-        let c_context = self.subarray.context.capi();
+        let c_context = self.query.base().context().capi();
         let c_query = **self.query.base().cquery();
-        let c_subarray = *self.subarray.raw;
+        let c_subarray = *self.raw;
 
-        self.capi_return(unsafe {
+        self.query.base().capi_return(unsafe {
             ffi::tiledb_query_set_subarray_t(c_context, c_query, c_subarray)
         })?;
         Ok(self.query)

--- a/tiledb/api/src/query/write/mod.rs
+++ b/tiledb/api/src/query/write/mod.rs
@@ -18,31 +18,31 @@ struct RawWriteInput<'data> {
 type InputMap<'data> = HashMap<String, RawWriteInput<'data>>;
 
 #[derive(ContextBound, Query)]
-pub struct WriteQuery<'ctx, 'data> {
+pub struct WriteQuery<'data> {
     #[base(ContextBound, Query)]
-    base: QueryBase<'ctx>,
+    base: QueryBase,
 
     /// Hold on to query inputs to ensure they live long enough
     _inputs: InputMap<'data>,
 }
 
-impl<'ctx, 'data> WriteQuery<'ctx, 'data> {
+impl<'data> WriteQuery<'data> {
     pub fn submit(&self) -> TileDBResult<()> {
         self.base.do_submit()
     }
 }
 
 #[derive(ContextBound)]
-pub struct WriteBuilder<'ctx, 'data> {
+pub struct WriteBuilder<'data> {
     #[base(ContextBound)]
-    base: BuilderBase<'ctx>,
+    base: BuilderBase,
     inputs: InputMap<'data>,
 }
 
-impl<'ctx, 'data> QueryBuilder<'ctx> for WriteBuilder<'ctx, 'data> {
-    type Query = WriteQuery<'ctx, 'data>;
+impl<'data> QueryBuilder for WriteBuilder<'data> {
+    type Query = WriteQuery<'data>;
 
-    fn base(&self) -> &BuilderBase<'ctx> {
+    fn base(&self) -> &BuilderBase {
         &self.base
     }
 
@@ -54,8 +54,8 @@ impl<'ctx, 'data> QueryBuilder<'ctx> for WriteBuilder<'ctx, 'data> {
     }
 }
 
-impl<'ctx, 'data> WriteBuilder<'ctx, 'data> {
-    pub fn new(array: Array<'ctx>) -> TileDBResult<Self> {
+impl<'data> WriteBuilder<'data> {
+    pub fn new(array: Array) -> TileDBResult<Self> {
         Ok(WriteBuilder {
             base: BuilderBase::new(array, QueryType::Write)?,
             inputs: HashMap::new(),

--- a/tiledb/proc-macro/tests/context.rs
+++ b/tiledb/proc-macro/tests/context.rs
@@ -17,8 +17,8 @@ unsafe impl Send for Context {}
 
 unsafe impl Sync for Context {}
 
-trait ContextBound<'ctx> {
-    fn context(&self) -> &'ctx Context;
+trait ContextBound {
+    fn context(&self) -> &Context;
 }
 
 #[derive(ContextBound)]
@@ -53,7 +53,7 @@ impl<'ctx> DeriveBase<'ctx> {
     }
 }
 
-impl<'ctx> ContextBound<'ctx> for DeriveBase<'ctx> {
+impl<'ctx> ContextBound for DeriveBase<'ctx> {
     fn context(&self) -> &'ctx Context {
         *self.found.borrow_mut() = true;
         self.context
@@ -211,11 +211,11 @@ fn unbounded_ctx_base_not_ctx() {
 }
 
 #[derive(ContextBound)]
-struct ContextBoundBase<'ctx, T>
+struct ContextBoundBase<T>
 where
-    T: ContextBound<'ctx>,
+    T: ContextBound,
 {
-    _marker: std::marker::PhantomData<&'ctx u64>,
+    _marker: std::marker::PhantomData<u64>,
     #[base(ContextBound)]
     base: T,
 }


### PR DESCRIPTION
This test does `impl Send for Array` by having Array consume and own the `tiledb::Context`.  Array was not previously `Send` because the reference member `&'ctx Context` is only `Send` if `Context` is `Sync`.

This implementation is likely the quickest and dirtiest way to proceed but produces some usability warts which are very visible in the examples, so I think it's worth spending a little time exploring other possible ways to address the need for `impl Send for Array`.