### PR TITLE
Replace capi_return with capi_call

### DIFF
--- a/tiledb/api/src/array/attribute/arrow.rs
+++ b/tiledb/api/src/array/attribute/arrow.rs
@@ -89,7 +89,7 @@ pub fn arrow_field(
                     )
                 })?;
         Ok(Some(
-            arrow_schema::Field::new(name, arrow_dt, attr.is_nullable())
+            arrow_schema::Field::new(name, arrow_dt, attr.is_nullable()?)
                 .with_metadata(HashMap::<String, String>::from([(
                     String::from("tiledb"),
                     metadata,

--- a/tiledb/api/src/array/fragment_info.rs
+++ b/tiledb/api/src/array/fragment_info.rs
@@ -51,32 +51,31 @@ impl<'ctx> FragmentInfoInternal<'ctx> {
     }
 
     pub fn config(&self) -> TileDBResult<Config> {
+        let c_frag = self.capi();
         let mut c_config: *mut ffi::tiledb_config_t = out_ptr!();
-        self.capi_return(unsafe {
-            ffi::tiledb_fragment_info_get_config(
-                self.context.capi(),
-                self.capi(),
-                &mut c_config,
-            )
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_fragment_info_get_config(ctx, c_frag, &mut c_config)
         })?;
 
         Ok(Config::from_raw(RawConfig::Owned(c_config)))
     }
 
     pub fn load(&self) -> TileDBResult<()> {
-        self.capi_return(unsafe {
-            ffi::tiledb_fragment_info_load(self.context.capi(), self.capi())
+        let c_frag = self.capi();
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_fragment_info_load(ctx, c_frag)
         })?;
 
         Ok(())
     }
 
     pub fn unconsolidated_metadata_num(&self) -> TileDBResult<u32> {
+        let c_frag = self.capi();
         let mut result: u32 = 0;
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_fragment_info_get_unconsolidated_metadata_num(
-                self.context.capi(),
-                self.capi(),
+                ctx,
+                c_frag,
                 &mut result,
             )
         })?;
@@ -85,11 +84,12 @@ impl<'ctx> FragmentInfoInternal<'ctx> {
     }
 
     pub fn num_to_vacuum(&self) -> TileDBResult<u32> {
+        let c_frag = self.capi();
         let mut result: u32 = 0;
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_fragment_info_get_to_vacuum_num(
-                self.context.capi(),
-                self.capi(),
+                ctx,
+                c_frag,
                 &mut result,
             )
         })?;
@@ -98,12 +98,11 @@ impl<'ctx> FragmentInfoInternal<'ctx> {
     }
 
     pub fn total_cell_count(&self) -> TileDBResult<u64> {
+        let c_frag = self.capi();
         let mut count: u64 = 0;
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_fragment_info_get_total_cell_num(
-                self.context.capi(),
-                self.capi(),
-                &mut count,
+                ctx, c_frag, &mut count,
             )
         })?;
 
@@ -111,26 +110,21 @@ impl<'ctx> FragmentInfoInternal<'ctx> {
     }
 
     pub fn num_fragments(&self) -> TileDBResult<u32> {
+        let c_frag = self.capi();
         let mut ret: u32 = 0;
-        self.capi_return(unsafe {
-            ffi::tiledb_fragment_info_get_fragment_num(
-                self.context.capi(),
-                self.capi(),
-                &mut ret,
-            )
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_fragment_info_get_fragment_num(ctx, c_frag, &mut ret)
         })?;
 
         Ok(ret)
     }
 
     pub fn num_cells(&self, frag_idx: u32) -> TileDBResult<u64> {
+        let c_frag = self.capi();
         let mut cells: u64 = 0;
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_fragment_info_get_cell_num(
-                self.context.capi(),
-                self.capi(),
-                frag_idx,
-                &mut cells,
+                ctx, c_frag, frag_idx, &mut cells,
             )
         })?;
 
@@ -138,11 +132,12 @@ impl<'ctx> FragmentInfoInternal<'ctx> {
     }
 
     pub fn version(&self, frag_idx: u32) -> TileDBResult<u32> {
+        let c_frag = self.capi();
         let mut version: u32 = 0;
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_fragment_info_get_version(
-                self.context.capi(),
-                self.capi(),
+                ctx,
+                c_frag,
                 frag_idx,
                 &mut version,
             )
@@ -152,11 +147,12 @@ impl<'ctx> FragmentInfoInternal<'ctx> {
     }
 
     pub fn schema(&self, frag_idx: u32) -> TileDBResult<Schema<'ctx>> {
+        let c_frag = self.capi();
         let mut c_schema: *mut ffi::tiledb_array_schema_t = out_ptr!();
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_fragment_info_get_array_schema(
-                self.context.capi(),
-                self.capi(),
+                ctx,
+                c_frag,
                 frag_idx,
                 &mut c_schema,
             )
@@ -166,13 +162,11 @@ impl<'ctx> FragmentInfoInternal<'ctx> {
     }
 
     pub fn schema_name(&self, frag_idx: u32) -> TileDBResult<String> {
+        let c_frag = self.capi();
         let mut c_str: *const std::ffi::c_char = out_ptr!();
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_fragment_info_get_array_schema_name(
-                self.context.capi(),
-                self.capi(),
-                frag_idx,
-                &mut c_str,
+                ctx, c_frag, frag_idx, &mut c_str,
             )
         })?;
 
@@ -183,13 +177,11 @@ impl<'ctx> FragmentInfoInternal<'ctx> {
     }
 
     pub fn fragment_name(&self, frag_idx: u32) -> TileDBResult<String> {
+        let c_frag = self.capi();
         let mut c_str: *mut ffi::tiledb_string_t = out_ptr!();
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_fragment_info_get_fragment_name_v2(
-                self.context.capi(),
-                self.capi(),
-                frag_idx,
-                &mut c_str,
+                ctx, c_frag, frag_idx, &mut c_str,
             )
         })?;
 
@@ -198,13 +190,11 @@ impl<'ctx> FragmentInfoInternal<'ctx> {
     }
 
     pub fn fragment_uri(&self, frag_idx: u32) -> TileDBResult<String> {
+        let c_frag = self.capi();
         let mut c_str: *const std::ffi::c_char = out_ptr!();
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_fragment_info_get_fragment_uri(
-                self.context.capi(),
-                self.capi(),
-                frag_idx,
-                &mut c_str,
+                ctx, c_frag, frag_idx, &mut c_str,
             )
         })?;
 
@@ -215,13 +205,11 @@ impl<'ctx> FragmentInfoInternal<'ctx> {
     }
 
     pub fn fragment_size(&self, frag_idx: u32) -> TileDBResult<u64> {
+        let c_frag = self.capi();
         let mut size: u64 = 0;
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_fragment_info_get_fragment_size(
-                self.context.capi(),
-                self.capi(),
-                frag_idx,
-                &mut size,
+                ctx, c_frag, frag_idx, &mut size,
             )
         })?;
 
@@ -229,13 +217,11 @@ impl<'ctx> FragmentInfoInternal<'ctx> {
     }
 
     pub fn fragment_type(&self, frag_idx: u32) -> TileDBResult<FragmentType> {
+        let c_frag = self.capi();
         let mut dense: i32 = 0;
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_fragment_info_get_dense(
-                self.context.capi(),
-                self.capi(),
-                frag_idx,
-                &mut dense,
+                ctx, c_frag, frag_idx, &mut dense,
             )
         })?;
 
@@ -247,15 +233,12 @@ impl<'ctx> FragmentInfoInternal<'ctx> {
     }
 
     pub fn timestamp_range(&self, frag_idx: u32) -> TileDBResult<[u64; 2]> {
+        let c_frag = self.capi();
         let mut start: u64 = 0;
         let mut end: u64 = 0;
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_fragment_info_get_timestamp_range(
-                self.context.capi(),
-                self.capi(),
-                frag_idx,
-                &mut start,
-                &mut end,
+                ctx, c_frag, frag_idx, &mut start, &mut end,
             )
         })?;
 
@@ -266,11 +249,12 @@ impl<'ctx> FragmentInfoInternal<'ctx> {
         &self,
         frag_idx: u32,
     ) -> TileDBResult<bool> {
+        let c_frag = self.capi();
         let mut result: i32 = 0;
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_fragment_info_has_consolidated_metadata(
-                self.context.capi(),
-                self.capi(),
+                ctx,
+                c_frag,
                 frag_idx,
                 &mut result,
             )
@@ -280,13 +264,11 @@ impl<'ctx> FragmentInfoInternal<'ctx> {
     }
 
     pub fn to_vacuum_uri(&self, frag_idx: u32) -> TileDBResult<String> {
+        let c_frag = self.capi();
         let mut c_str: *const std::ffi::c_char = out_ptr!();
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_fragment_info_get_to_vacuum_uri(
-                self.context.capi(),
-                self.capi(),
-                frag_idx,
-                &mut c_str,
+                ctx, c_frag, frag_idx, &mut c_str,
             )
         })?;
 
@@ -317,12 +299,13 @@ impl<'ctx> FragmentInfoInternal<'ctx> {
         dim_idx: u32,
     ) -> TileDBResult<TypedRange> {
         fn_typed!(datatype, DT, {
+            let c_frag = self.capi();
             let mut range = [DT::default(), DT::default()];
             let c_range = range.as_mut_ptr();
-            self.capi_return(unsafe {
+            self.capi_call(|ctx| unsafe {
                 ffi::tiledb_fragment_info_get_non_empty_domain_from_index(
-                    self.context.capi(),
-                    self.capi(),
+                    ctx,
+                    c_frag,
                     frag_idx,
                     dim_idx,
                     c_range as *mut std::ffi::c_void,
@@ -341,12 +324,13 @@ impl<'ctx> FragmentInfoInternal<'ctx> {
         frag_idx: u32,
         dim_idx: u32,
     ) -> TileDBResult<TypedRange> {
+        let c_frag = self.capi();
         let mut start_size: u64 = 0;
         let mut end_size: u64 = 0;
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_fragment_info_get_non_empty_domain_var_size_from_index(
-                self.context.capi(),
-                self.capi(),
+                ctx,
+                c_frag,
                 frag_idx,
                 dim_idx,
                 &mut start_size,
@@ -378,10 +362,10 @@ impl<'ctx> FragmentInfoInternal<'ctx> {
             let mut end: Box<[DT]> =
                 vec![Default::default(); end_elems as usize].into_boxed_slice();
 
-            self.capi_return(unsafe {
+            self.capi_call(|ctx| unsafe {
                 ffi::tiledb_fragment_info_get_non_empty_domain_var_from_index(
-                    self.context.capi(),
-                    self.capi(),
+                    ctx,
+                    c_frag,
                     frag_idx,
                     dim_idx,
                     start.as_mut_ptr() as *mut std::ffi::c_void,
@@ -394,13 +378,11 @@ impl<'ctx> FragmentInfoInternal<'ctx> {
     }
 
     pub fn num_mbrs(&self, frag_idx: u32) -> TileDBResult<u64> {
+        let c_frag = self.capi();
         let mut num: u64 = 0;
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_fragment_info_get_mbr_num(
-                self.context.capi(),
-                self.capi(),
-                frag_idx,
-                &mut num,
+                ctx, c_frag, frag_idx, &mut num,
             )
         })?;
 
@@ -429,13 +411,14 @@ impl<'ctx> FragmentInfoInternal<'ctx> {
         mbr_idx: u32,
         dim_idx: u32,
     ) -> TileDBResult<TypedRange> {
+        let c_frag = self.capi();
         fn_typed!(datatype, DT, {
             let mut range = [DT::default(), DT::default()];
             let c_range = range.as_mut_ptr();
-            self.capi_return(unsafe {
+            self.capi_call(|ctx| unsafe {
                 ffi::tiledb_fragment_info_get_mbr_from_index(
-                    self.context.capi(),
-                    self.capi(),
+                    ctx,
+                    c_frag,
                     frag_idx,
                     mbr_idx,
                     dim_idx,
@@ -457,12 +440,13 @@ impl<'ctx> FragmentInfoInternal<'ctx> {
         mbr_idx: u32,
         dim_idx: u32,
     ) -> TileDBResult<TypedRange> {
+        let c_frag = self.capi();
         let mut start_size: u64 = 0;
         let mut end_size: u64 = 0;
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_fragment_info_get_mbr_var_size_from_index(
-                self.context.capi(),
-                self.capi(),
+                ctx,
+                c_frag,
                 frag_idx,
                 mbr_idx,
                 dim_idx,
@@ -495,10 +479,10 @@ impl<'ctx> FragmentInfoInternal<'ctx> {
             let mut end: Box<[DT]> =
                 vec![Default::default(); end_elems as usize].into_boxed_slice();
 
-            self.capi_return(unsafe {
+            self.capi_call(|ctx| unsafe {
                 ffi::tiledb_fragment_info_get_mbr_var_from_index(
-                    self.context.capi(),
-                    self.capi(),
+                    ctx,
+                    c_frag,
                     frag_idx,
                     mbr_idx,
                     dim_idx,
@@ -701,13 +685,12 @@ impl<'ctx> Builder<'ctx> {
     where
         T: AsRef<str>,
     {
-        let c_context = context.capi();
         let c_uri = std::ffi::CString::new(uri.as_ref())
             .map_err(|e| Error::InvalidArgument(anyhow!(e)))?;
         let mut c_frag_info: *mut ffi::tiledb_fragment_info_t = out_ptr!();
-        context.capi_return(unsafe {
+        context.capi_call(|ctx| unsafe {
             ffi::tiledb_fragment_info_alloc(
-                c_context,
+                ctx,
                 c_uri.as_c_str().as_ptr(),
                 &mut c_frag_info,
             )
@@ -722,12 +705,10 @@ impl<'ctx> Builder<'ctx> {
     }
 
     pub fn config(self, config: &Config) -> TileDBResult<Self> {
-        self.capi_return(unsafe {
-            ffi::tiledb_fragment_info_set_config(
-                self.context().capi(),
-                self.info.capi(),
-                config.capi(),
-            )
+        let c_frag = self.info.capi();
+        let c_cfg = config.capi();
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_fragment_info_set_config(ctx, c_frag, c_cfg)
         })?;
         Ok(self)
     }

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -197,13 +197,11 @@ impl<'ctx> Array<'ctx> {
         S: AsRef<str>,
     {
         let c_name = cstring!(name.as_ref());
-        context.capi_return(unsafe {
-            ffi::tiledb_array_create(
-                context.capi(),
-                c_name.as_ptr(),
-                schema.capi(),
-            )
-        })
+        context.capi_call(|ctx| unsafe {
+            ffi::tiledb_array_create(ctx, c_name.as_ptr(), schema.capi())
+        })?;
+
+        Ok(())
     }
 
     pub fn exists<S>(context: &'ctx Context, uri: S) -> TileDBResult<bool>
@@ -224,19 +222,18 @@ impl<'ctx> Array<'ctx> {
     where
         S: AsRef<str>,
     {
-        let ctx = context.capi();
         let mut array_raw: *mut ffi::tiledb_array_t = std::ptr::null_mut();
-
         let c_uri = cstring!(uri.as_ref());
 
-        context.capi_return(unsafe {
+        context.capi_call(|ctx| unsafe {
             ffi::tiledb_array_alloc(ctx, c_uri.as_ptr(), &mut array_raw)
         })?;
 
         let mode_raw = mode.capi_enum();
-        context.capi_return(unsafe {
+        context.capi_call(|ctx| unsafe {
             ffi::tiledb_array_open(ctx, array_raw, mode_raw)
         })?;
+
         Ok(Array {
             context,
             raw: RawArray::Owned(array_raw),
@@ -244,13 +241,12 @@ impl<'ctx> Array<'ctx> {
     }
 
     pub fn schema(&self) -> TileDBResult<Schema> {
-        let c_context = self.context.capi();
         let c_array = *self.raw;
         let mut c_schema: *mut ffi::tiledb_array_schema_t = out_ptr!();
 
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_array_get_schema(
-                c_context,
+                ctx,
                 c_array,
                 &mut c_schema as *mut *mut ffi::tiledb_array_schema_t,
             )
@@ -262,12 +258,9 @@ impl<'ctx> Array<'ctx> {
 
 impl Drop for Array<'_> {
     fn drop(&mut self) {
-        let c_context = self.context.capi();
         let c_array = *self.raw;
-        self.capi_return(unsafe {
-            ffi::tiledb_array_close(c_context, c_array)
-        })
-        .expect("TileDB internal error when closing array");
+        self.capi_call(|ctx| unsafe { ffi::tiledb_array_close(ctx, c_array) })
+            .expect("TileDB internal error when closing array");
     }
 }
 

--- a/tiledb/api/src/context.rs
+++ b/tiledb/api/src/context.rs
@@ -1,6 +1,5 @@
 use std::convert::From;
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
-use std::ops::Deref;
 
 use crate::config::{Config, RawConfig};
 use crate::error::{Error, ObjectTypeErrorKind, RawError};

--- a/tiledb/api/src/context.rs
+++ b/tiledb/api/src/context.rs
@@ -35,23 +35,14 @@ impl Display for ObjectType {
     }
 }
 
-pub(crate) enum RawContext {
-    Owned(*mut ffi::tiledb_ctx_t),
-}
-
-impl Deref for RawContext {
-    type Target = *mut ffi::tiledb_ctx_t;
-    fn deref(&self) -> &Self::Target {
-        let RawContext::Owned(ref ffi) = *self;
-        ffi
-    }
+pub(crate) struct RawContext {
+    raw: *mut ffi::tiledb_ctx_t,
 }
 
 impl Drop for RawContext {
     fn drop(&mut self) {
-        let RawContext::Owned(ref mut ffi) = *self;
         unsafe {
-            ffi::tiledb_ctx_free(ffi);
+            ffi::tiledb_ctx_free(&mut self.raw as *mut *mut ffi::tiledb_ctx_t);
         }
     }
 }
@@ -61,15 +52,24 @@ pub trait ContextBound<'ctx> {
 }
 
 pub trait CApiInterface {
-    fn capi_return(&self, c_ret: i32) -> TileDBResult<()>;
+    // The callback is intentionally *not* returning a TileDBResult<i32> as this
+    // forces folks to avoid putting anything that can error into the callback.
+    // This will hopefully lead to our collective decision to do as minimal
+    // work as possible in unsafe blocks.
+    fn capi_call<Callable>(&self, action: Callable) -> TileDBResult<()>
+    where
+        Callable: FnOnce(*mut ffi::tiledb_ctx_t) -> i32;
 }
 
 impl<'ctx, T> CApiInterface for T
 where
     T: ContextBound<'ctx>,
 {
-    fn capi_return(&self, c_ret: i32) -> TileDBResult<()> {
-        self.context().capi_return(c_ret)
+    fn capi_call<Callable>(&self, action: Callable) -> TileDBResult<()>
+    where
+        Callable: FnOnce(*mut ffi::tiledb_ctx_t) -> i32,
+    {
+        self.context().capi_call(action)
     }
 }
 
@@ -78,10 +78,6 @@ pub struct Context {
 }
 
 impl Context {
-    pub fn capi(&self) -> *mut ffi::tiledb_ctx_t {
-        *self.raw
-    }
-
     pub fn new() -> TileDBResult<Context> {
         let cfg = Config::new()?;
         Context::from_config(&cfg)
@@ -92,48 +88,57 @@ impl Context {
         let res = unsafe { ffi::tiledb_ctx_alloc(cfg.capi(), &mut c_ctx) };
         if res == ffi::TILEDB_OK {
             Ok(Context {
-                raw: RawContext::Owned(c_ctx),
+                raw: RawContext { raw: c_ctx },
             })
         } else {
             Err(Error::LibTileDB(String::from("Could not create context")))
         }
     }
 
-    pub fn get_stats(&self) -> TileDBResult<String> {
-        let mut c_json = std::ptr::null_mut::<std::os::raw::c_char>();
-        let res = unsafe {
-            ffi::tiledb_ctx_get_stats(
-                *self.raw,
-                &mut c_json as *mut *mut std::os::raw::c_char,
-            )
-        };
-        if res == ffi::TILEDB_OK {
-            assert!(!c_json.is_null());
-            let raw = RawStatsString::Owned(c_json);
-            let json = unsafe { std::ffi::CStr::from_ptr(*raw) };
-            Ok(String::from(json.to_string_lossy()))
+    pub fn capi_call<Callable>(&self, action: Callable) -> TileDBResult<()>
+    where
+        Callable: FnOnce(*mut ffi::tiledb_ctx_t) -> i32,
+    {
+        if action(self.raw.raw) == ffi::TILEDB_OK {
+            Ok(())
         } else {
             Err(self.expect_last_error())
         }
+    }
+
+    pub fn get_stats(&self) -> TileDBResult<String> {
+        let mut c_json: *mut std::ffi::c_char = out_ptr!();
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_ctx_get_stats(
+                ctx,
+                &mut c_json as *mut *mut std::ffi::c_char,
+            )
+        })?;
+
+        assert!(!c_json.is_null());
+        let raw = RawStatsString::Owned(c_json);
+        let json = unsafe { std::ffi::CStr::from_ptr(*raw) };
+        Ok(String::from(json.to_string_lossy()))
     }
 
     pub fn get_config(&self) -> TileDBResult<Config> {
         let mut c_cfg: *mut ffi::tiledb_config_t = out_ptr!();
-        let res = unsafe { ffi::tiledb_ctx_get_config(*self.raw, &mut c_cfg) };
-        if res == ffi::TILEDB_OK {
-            Ok(Config {
-                raw: RawConfig::Owned(c_cfg),
-            })
-        } else {
-            Err(self.expect_last_error())
-        }
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_ctx_get_config(ctx, &mut c_cfg)
+        })?;
+
+        Ok(Config {
+            raw: RawConfig::Owned(c_cfg),
+        })
     }
 
     pub fn get_last_error(&self) -> Option<Error> {
         let mut c_err: *mut ffi::tiledb_error_t = out_ptr!();
-        let res =
-            unsafe { ffi::tiledb_ctx_get_last_error(*self.raw, &mut c_err) };
-        if res == ffi::TILEDB_OK && !c_err.is_null() {
+        let res = self.capi_call(|ctx| unsafe {
+            ffi::tiledb_ctx_get_last_error(ctx, &mut c_err)
+        });
+
+        if res.is_ok() && !c_err.is_null() {
             Some(Error::from(RawError::Owned(c_err)))
         } else {
             None
@@ -147,20 +152,13 @@ impl Context {
             )))
     }
 
-    pub fn is_supported_fs(&self, fs: Filesystem) -> bool {
+    pub fn is_supported_fs(&self, fs: Filesystem) -> TileDBResult<bool> {
         let mut supported: i32 = 0;
-        let res = unsafe {
-            ffi::tiledb_ctx_is_supported_fs(
-                *self.raw,
-                fs as u32,
-                &mut supported,
-            )
-        };
-        if res == ffi::TILEDB_OK {
-            supported == 1
-        } else {
-            false
-        }
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_ctx_is_supported_fs(ctx, fs as u32, &mut supported)
+        })?;
+
+        Ok(supported == 1)
     }
 
     pub fn set_tag(&self, key: &str, val: &str) -> TileDBResult<()> {
@@ -168,19 +166,15 @@ impl Context {
             std::ffi::CString::new(key).expect("Error creating CString");
         let c_val =
             std::ffi::CString::new(val).expect("Error creating CString");
-        let res = unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_ctx_set_tag(
-                *self.raw,
+                ctx,
                 c_key.as_c_str().as_ptr(),
                 c_val.as_c_str().as_ptr(),
             )
-        };
+        })?;
 
-        if res == ffi::TILEDB_OK {
-            Ok(())
-        } else {
-            Err(self.expect_last_error())
-        }
+        Ok(())
     }
 
     pub fn object_type<S>(&self, name: S) -> TileDBResult<Option<ObjectType>>
@@ -190,27 +184,15 @@ impl Context {
         let c_name = cstring!(name.as_ref());
         let mut c_objtype: ffi::tiledb_object_t = out_ptr!();
 
-        let c_ret = unsafe {
-            ffi::tiledb_object_type(*self.raw, c_name.as_ptr(), &mut c_objtype)
-        };
-        if c_ret == ffi::TILEDB_OK {
-            Ok(match c_objtype {
-                ffi::tiledb_object_t_TILEDB_ARRAY => Some(ObjectType::Array),
-                ffi::tiledb_object_t_TILEDB_GROUP => Some(ObjectType::Group),
-                _ => None,
-            })
-        } else {
-            Err(self.expect_last_error())
-        }
-    }
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_object_type(ctx, c_name.as_ptr(), &mut c_objtype)
+        })?;
 
-    /// Safely translate a return value from the C API into a TileDBResult
-    pub(crate) fn capi_return(&self, c_ret: i32) -> TileDBResult<()> {
-        if c_ret == ffi::TILEDB_OK {
-            Ok(())
-        } else {
-            Err(self.expect_last_error())
-        }
+        Ok(match c_objtype {
+            ffi::tiledb_object_t_TILEDB_ARRAY => Some(ObjectType::Array),
+            ffi::tiledb_object_t_TILEDB_GROUP => Some(ObjectType::Group),
+            _ => None,
+        })
     }
 }
 
@@ -251,7 +233,7 @@ mod tests {
         // MEMFS is by default enabled in TileDB builds while HDFS is rarely
         // enabled. These tests failing most likely means a non "standard"
         // build of libtiledb.{so,dylib,dll}
-        assert!(ctx.is_supported_fs(Filesystem::Memfs));
+        assert!(ctx.is_supported_fs(Filesystem::Memfs).unwrap());
 
         // We can't guarantee that any VFS backend is not present so any test
         // for an unsupported backend is guaranteed to fail somewhere.

--- a/tiledb/api/src/error.rs
+++ b/tiledb/api/src/error.rs
@@ -119,6 +119,9 @@ pub enum Error {
     /// This should be not occur in normal usage of tiledb.
     #[error("Internal error: {0}")]
     Internal(String),
+    /// Error locking the context mutex.
+    #[error("Error locking context: {0}")]
+    LockError(#[source] anyhow::Error),
     /// Error received from the libtiledb backend
     #[error("libtiledb error: {0}")]
     LibTileDB(String),

--- a/tiledb/api/src/filter/list.rs
+++ b/tiledb/api/src/filter/list.rs
@@ -42,23 +42,21 @@ impl<'ctx> FilterList<'ctx> {
     }
 
     pub fn get_num_filters(&self) -> TileDBResult<u32> {
+        let c_flist = self.capi();
         let mut num: u32 = 0;
-        self.capi_return(unsafe {
-            ffi::tiledb_filter_list_get_nfilters(
-                self.context.capi(),
-                *self.raw,
-                &mut num,
-            )
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_filter_list_get_nfilters(ctx, c_flist, &mut num)
         })?;
         Ok(num)
     }
 
     pub fn get_filter(&self, index: u32) -> TileDBResult<Filter<'ctx>> {
+        let c_flist = self.capi();
         let mut c_filter: *mut ffi::tiledb_filter_t = out_ptr!();
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_filter_list_get_filter_from_index(
-                self.context.capi(),
-                *self.raw,
+                ctx,
+                c_flist,
                 index,
                 &mut c_filter,
             )
@@ -73,13 +71,10 @@ impl<'ctx> FilterList<'ctx> {
     }
 
     pub fn get_max_chunk_size(&self) -> TileDBResult<u32> {
+        let c_flist = self.capi();
         let mut size: u32 = 0;
-        self.capi_return(unsafe {
-            ffi::tiledb_filter_list_get_max_chunk_size(
-                self.context.capi(),
-                *self.raw,
-                &mut size,
-            )
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_filter_list_get_max_chunk_size(ctx, c_flist, &mut size)
         })?;
         Ok(size)
     }
@@ -140,8 +135,8 @@ pub struct Builder<'ctx> {
 impl<'ctx> Builder<'ctx> {
     pub fn new(context: &'ctx Context) -> TileDBResult<Self> {
         let mut c_flist: *mut ffi::tiledb_filter_list_t = out_ptr!();
-        context.capi_return(unsafe {
-            ffi::tiledb_filter_list_alloc(context.capi(), &mut c_flist)
+        context.capi_call(|ctx| unsafe {
+            ffi::tiledb_filter_list_alloc(ctx, &mut c_flist)
         })?;
         Ok(Builder {
             filter_list: FilterList {
@@ -152,23 +147,17 @@ impl<'ctx> Builder<'ctx> {
     }
 
     pub fn set_max_chunk_size(self, size: u32) -> TileDBResult<Self> {
-        self.capi_return(unsafe {
-            ffi::tiledb_filter_list_set_max_chunk_size(
-                self.filter_list.context.capi(),
-                *self.filter_list.raw,
-                size,
-            )
+        let c_flist = self.filter_list.capi();
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_filter_list_set_max_chunk_size(ctx, c_flist, size)
         })?;
         Ok(self)
     }
 
     pub fn add_filter(self, filter: Filter<'ctx>) -> TileDBResult<Self> {
-        self.capi_return(unsafe {
-            ffi::tiledb_filter_list_add_filter(
-                self.filter_list.context.capi(),
-                *self.filter_list.raw,
-                filter.capi(),
-            )
+        let c_flist = self.filter_list.capi();
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_filter_list_add_filter(ctx, c_flist, filter.capi())
         })?;
         Ok(self)
     }

--- a/tiledb/api/src/group/mod.rs
+++ b/tiledb/api/src/group/mod.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use crate::config::{Config, RawConfig};
-use crate::context::{ContextBound, ObjectType};
+use crate::context::{CApiInterface, ContextBound, ObjectType};
 use crate::error::Error;
 use crate::key::LookupKey;
 use crate::{Context, Datatype};
@@ -63,8 +63,8 @@ impl<'ctx> Group<'ctx> {
         S: AsRef<str>,
     {
         let c_name = cstring!(name.as_ref());
-        context.capi_return(unsafe {
-            ffi::tiledb_group_create(context.capi(), c_name.as_ptr())
+        context.capi_call(|ctx| unsafe {
+            ffi::tiledb_group_create(ctx, c_name.as_ptr())
         })
     }
 
@@ -77,34 +77,31 @@ impl<'ctx> Group<'ctx> {
     where
         S: AsRef<str>,
     {
-        let c_context = context.capi();
         let mut group_raw: *mut ffi::tiledb_group_t = out_ptr!();
 
         let c_uri = cstring!(uri.as_ref());
 
-        context.capi_return(unsafe {
-            ffi::tiledb_group_alloc(c_context, c_uri.as_ptr(), &mut group_raw)
+        context.capi_call(|ctx| unsafe {
+            ffi::tiledb_group_alloc(ctx, c_uri.as_ptr(), &mut group_raw)
         })?;
 
         if let Some(cfg) = config {
             let c_cfg = cfg.capi();
-            context.capi_return(unsafe {
-                ffi::tiledb_group_set_config(c_context, group_raw, c_cfg)
+            context.capi_call(|ctx| unsafe {
+                ffi::tiledb_group_set_config(ctx, group_raw, c_cfg)
             })?;
         }
 
         let raw_group = RawGroup::new(group_raw);
         let query_type_raw = query_type.capi_enum();
-        context.capi_return(unsafe {
-            ffi::tiledb_group_open(c_context, group_raw, query_type_raw)
+        context.capi_call(|ctx| unsafe {
+            ffi::tiledb_group_open(ctx, group_raw, query_type_raw)
         })?;
 
         let mut c_open: i32 = out_ptr!();
-        context
-            .capi_return(unsafe {
-                ffi::tiledb_group_is_open(c_context, raw_group.ffi, &mut c_open)
-            })
-            .expect("TileDB internal error when checking for open group.");
+        context.capi_call(|ctx| unsafe {
+            ffi::tiledb_group_is_open(ctx, raw_group.ffi, &mut c_open)
+        })?;
 
         if c_open < 0 {
             return Err(Error::LibTileDB(
@@ -117,24 +114,19 @@ impl<'ctx> Group<'ctx> {
     }
 
     pub fn uri(&self) -> TileDBResult<String> {
-        let c_context = self.context.capi();
         let mut c_uri: *const std::ffi::c_char = out_ptr!();
-        self.context.capi_return(unsafe {
-            ffi::tiledb_group_get_uri(c_context, Self::capi(self), &mut c_uri)
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_group_get_uri(ctx, Self::capi(self), &mut c_uri)
         })?;
         let uri = unsafe { std::ffi::CStr::from_ptr(c_uri) };
         Ok(String::from(uri.to_string_lossy()))
     }
 
     pub fn query_type(&self) -> TileDBResult<QueryType> {
-        let c_context = self.context.capi();
+        let c_group = self.capi();
         let mut c_type: ffi::tiledb_query_type_t = out_ptr!();
-        self.context.capi_return(unsafe {
-            ffi::tiledb_group_get_query_type(
-                c_context,
-                Self::capi(self),
-                &mut c_type,
-            )
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_group_get_query_type(ctx, c_group, &mut c_type)
         })?;
         QueryType::try_from(c_type)
     }
@@ -144,13 +136,13 @@ impl<'ctx> Group<'ctx> {
     where
         S: AsRef<str>,
     {
-        let c_context = self.context.capi();
+        let c_group = self.capi();
         let c_uri = cstring!(uri.as_ref());
         let c_recursive: u8 = if recursive { 1 } else { 0 };
-        self.context.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_group_delete_group(
-                c_context,
-                Self::capi(&self),
+                ctx,
+                c_group,
                 c_uri.as_ptr(),
                 c_recursive,
             )
@@ -168,7 +160,7 @@ impl<'ctx> Group<'ctx> {
         S: AsRef<str>,
         T: AsRef<str>,
     {
-        let c_context = self.context.capi();
+        let c_group = self.capi();
         let c_uri = cstring!(uri.as_ref());
         let c_name = match name.as_ref() {
             None => None,
@@ -179,10 +171,10 @@ impl<'ctx> Group<'ctx> {
             Some(s) => s.as_ptr(),
         };
         let c_relative: u8 = if relative { 1 } else { 0 };
-        self.context.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_group_add_member(
-                c_context,
-                Self::capi(self),
+                ctx,
+                c_group,
                 c_uri.as_ptr(),
                 c_relative,
                 c_ptr,
@@ -196,12 +188,12 @@ impl<'ctx> Group<'ctx> {
     where
         S: AsRef<str>,
     {
-        let c_context = self.context.capi();
+        let c_group = self.capi();
         let c_name_or_uri = cstring!(name_or_uri.as_ref());
-        self.context.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_group_remove_member(
-                c_context,
-                Self::capi(self),
+                ctx,
+                c_group,
                 c_name_or_uri.as_ptr(),
             )
         })?;
@@ -209,30 +201,26 @@ impl<'ctx> Group<'ctx> {
     }
 
     pub fn num_members(&self) -> TileDBResult<u64> {
-        let c_context = self.context.capi();
+        let c_group = self.capi();
         let mut c_count: u64 = out_ptr!();
-        self.context.capi_return(unsafe {
-            ffi::tiledb_group_get_member_count(
-                c_context,
-                Self::capi(self),
-                &mut c_count,
-            )
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_group_get_member_count(ctx, c_group, &mut c_count)
         })?;
         Ok(c_count)
     }
 
     pub fn member(&self, key: LookupKey) -> TileDBResult<GroupInfo> {
-        let c_context = self.context.capi();
+        let c_group = self.capi();
         let mut tiledb_uri: *mut ffi::tiledb_string_t = out_ptr!();
         let mut tiledb_type: ffi::tiledb_object_t = out_ptr!();
         let name: String = match key {
             LookupKey::Index(index) => {
                 let mut tiledb_name: *mut ffi::tiledb_string_t = out_ptr!();
-                self.context.capi_return(unsafe {
+                self.capi_call(|ctx| unsafe {
                     ffi::tiledb_group_get_member_by_index_v2(
-                        c_context,
-                        Self::capi(self),
-                        index.try_into().unwrap(),
+                        ctx,
+                        c_group,
+                        index as u64,
                         &mut tiledb_uri as *mut *mut ffi::tiledb_string_t,
                         &mut tiledb_type,
                         &mut tiledb_name as *mut *mut ffi::tiledb_string_t,
@@ -247,10 +235,10 @@ impl<'ctx> Group<'ctx> {
             }
             LookupKey::Name(name) => {
                 let c_name = cstring!(name.as_ref() as &str);
-                self.context.capi_return(unsafe {
+                self.capi_call(|ctx| unsafe {
                     ffi::tiledb_group_get_member_by_name_v2(
-                        c_context,
-                        Self::capi(self),
+                        ctx,
+                        c_group,
                         c_name.as_ptr(),
                         &mut tiledb_uri as *mut *mut ffi::tiledb_string_t,
                         &mut tiledb_type,
@@ -278,13 +266,13 @@ impl<'ctx> Group<'ctx> {
     where
         S: AsRef<str>,
     {
-        let c_context = self.context.capi();
+        let c_group = self.capi();
         let mut c_relative: u8 = out_ptr!();
         let c_name = cstring!(name.as_ref());
-        self.context.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_group_get_is_relative_uri_by_name(
-                c_context,
-                Self::capi(self),
+                ctx,
+                c_group,
                 c_name.as_ptr(),
                 &mut c_relative,
             )
@@ -293,22 +281,22 @@ impl<'ctx> Group<'ctx> {
     }
 
     pub fn is_open(&self) -> TileDBResult<bool> {
-        let c_context = self.context.capi();
+        let c_group = self.capi();
         let mut c_open: i32 = out_ptr!();
-        self.context.capi_return(unsafe {
-            ffi::tiledb_group_is_open(c_context, Self::capi(self), &mut c_open)
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_group_is_open(ctx, c_group, &mut c_open)
         })?;
         Ok(c_open > 0)
     }
 
     pub fn dump(&self, recursive: bool) -> TileDBResult<String> {
-        let c_context = self.context.capi();
+        let c_group = self.capi();
         let mut c_str: *mut std::ffi::c_char = out_ptr!();
         let c_recursive = if recursive { 1 } else { 0 };
-        self.context.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_group_dump_str(
-                c_context,
-                Self::capi(self),
+                ctx,
+                c_group,
                 &mut c_str as *mut *mut std::ffi::c_char,
                 c_recursive,
             )
@@ -320,14 +308,10 @@ impl<'ctx> Group<'ctx> {
     }
 
     pub fn config(&self) -> TileDBResult<Config> {
-        let c_context = self.context.capi();
+        let c_group = self.capi();
         let mut c_cfg: *mut ffi::tiledb_config_t = out_ptr!();
-        self.context.capi_return(unsafe {
-            ffi::tiledb_group_get_config(
-                c_context,
-                Self::capi(self),
-                &mut c_cfg,
-            )
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_group_get_config(ctx, c_group, &mut c_cfg)
         })?;
 
         Ok(Config {
@@ -336,16 +320,16 @@ impl<'ctx> Group<'ctx> {
     }
 
     pub fn put_metadata(&mut self, metadata: Metadata) -> TileDBResult<()> {
-        let c_context = self.context.capi();
+        let c_group = self.capi();
         let (vec_size, vec_ptr, datatype) = metadata.c_data();
         let c_key = cstring!(metadata.key);
-        self.context.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_group_put_metadata(
-                c_context,
-                Self::capi(self),
+                ctx,
+                c_group,
                 c_key.as_ptr(),
                 datatype,
-                vec_size.try_into().unwrap(),
+                vec_size as u32,
                 vec_ptr,
             )
         })?;
@@ -356,33 +340,25 @@ impl<'ctx> Group<'ctx> {
     where
         S: AsRef<str>,
     {
-        let c_context = self.context.capi();
+        let c_group = self.capi();
         let c_name = cstring!(name.as_ref());
-        self.context.capi_return(unsafe {
-            ffi::tiledb_group_delete_metadata(
-                c_context,
-                Self::capi(self),
-                c_name.as_ptr(),
-            )
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_group_delete_metadata(ctx, c_group, c_name.as_ptr())
         })?;
         Ok(())
     }
 
     pub fn num_metadata(&self) -> TileDBResult<u64> {
-        let c_context = self.context.capi();
+        let c_group = self.capi();
         let mut num: u64 = out_ptr!();
-        self.context.capi_return(unsafe {
-            ffi::tiledb_group_get_metadata_num(
-                c_context,
-                Self::capi(self),
-                &mut num,
-            )
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_group_get_metadata_num(ctx, c_group, &mut num)
         })?;
         Ok(num)
     }
 
     pub fn metadata(&self, key: LookupKey) -> TileDBResult<Metadata> {
-        let c_context = self.context.capi();
+        let c_group = self.capi();
         let mut vec_size: u32 = out_ptr!();
         let mut c_datatype: ffi::tiledb_datatype_t = out_ptr!();
         let mut vec_ptr: *const std::ffi::c_void = out_ptr!();
@@ -391,11 +367,11 @@ impl<'ctx> Group<'ctx> {
             LookupKey::Index(index) => {
                 let mut key_ptr: *const std::ffi::c_char = out_ptr!();
                 let mut key_len: u32 = out_ptr!();
-                self.context.capi_return(unsafe {
+                self.capi_call(|ctx| unsafe {
                     ffi::tiledb_group_get_metadata_from_index(
-                        c_context,
-                        Self::capi(self),
-                        index.try_into().unwrap(),
+                        ctx,
+                        c_group,
+                        index as u64,
                         &mut key_ptr,
                         &mut key_len,
                         &mut c_datatype,
@@ -408,10 +384,10 @@ impl<'ctx> Group<'ctx> {
             }
             LookupKey::Name(name) => {
                 let c_name = cstring!(name.as_ref() as &str);
-                self.context.capi_return(unsafe {
+                self.capi_call(|ctx| unsafe {
                     ffi::tiledb_group_get_metadata(
-                        c_context,
-                        Self::capi(self),
+                        ctx,
+                        c_group,
                         c_name.as_ptr(),
                         &mut c_datatype,
                         &mut vec_size,
@@ -429,14 +405,14 @@ impl<'ctx> Group<'ctx> {
     where
         S: AsRef<str>,
     {
-        let c_context = self.context.capi();
+        let c_group = self.capi();
         let c_name = cstring!(name.as_ref());
         let mut c_datatype: ffi::tiledb_datatype_t = out_ptr!();
         let mut exists: i32 = out_ptr!();
-        self.context.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_group_has_metadata_key(
-                c_context,
-                Self::capi(self),
+                ctx,
+                c_group,
                 c_name.as_ptr(),
                 &mut c_datatype,
                 &mut exists,
@@ -458,12 +434,11 @@ impl<'ctx> Group<'ctx> {
     where
         S: AsRef<str>,
     {
-        let c_context = self.context.capi();
         let c_group_uri = cstring!(group_uri.as_ref());
         let cfg = config.capi();
-        self.context.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_group_consolidate_metadata(
-                c_context,
+                ctx,
                 c_group_uri.as_ptr(),
                 cfg,
             )
@@ -479,15 +454,10 @@ impl<'ctx> Group<'ctx> {
     where
         S: AsRef<str>,
     {
-        let c_context = self.context.capi();
         let c_group_uri = cstring!(group_uri.as_ref());
         let cfg = config.capi();
-        self.context.capi_return(unsafe {
-            ffi::tiledb_group_vacuum_metadata(
-                c_context,
-                c_group_uri.as_ptr(),
-                cfg,
-            )
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_group_vacuum_metadata(ctx, c_group_uri.as_ptr(), cfg)
         })?;
         Ok(())
     }
@@ -495,24 +465,20 @@ impl<'ctx> Group<'ctx> {
 
 impl Drop for Group<'_> {
     fn drop(&mut self) {
-        let c_context = self.context.capi();
-        let c_group = Self::capi(self);
-
+        let c_group = self.capi();
         let mut c_open: i32 = out_ptr!();
-        self.context
-            .capi_return(unsafe {
-                ffi::tiledb_group_is_open(c_context, c_group, &mut c_open)
-            })
-            .expect("TileDB internal error when checking for open group.");
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_group_is_open(ctx, c_group, &mut c_open)
+        })
+        .expect("TileDB internal error when checking for open group.");
 
         // We check if the group is open, and only delete when the group is open, because
         // if delete_group is called, then we should not close the group.
         if c_open > 0 {
-            self.context
-                .capi_return(unsafe {
-                    ffi::tiledb_group_close(c_context, c_group)
-                })
-                .expect("TileDB internal error when closing group");
+            self.capi_call(|ctx| unsafe {
+                ffi::tiledb_group_close(ctx, c_group)
+            })
+            .expect("TileDB internal error when closing group");
         }
     }
 }

--- a/tiledb/api/src/query/conditions.rs
+++ b/tiledb/api/src/query/conditions.rs
@@ -259,10 +259,9 @@ impl EqualityPredicate {
         &self,
         ctx: &'ctx Context,
     ) -> TileDBResult<QueryCondition<'ctx>> {
-        let c_ctx = ctx.capi();
         let mut c_cond: *mut ffi::tiledb_query_condition_t = out_ptr!();
-        ctx.capi_return(unsafe {
-            ffi::tiledb_query_condition_alloc(c_ctx, &mut c_cond)
+        ctx.capi_call(|ctx| unsafe {
+            ffi::tiledb_query_condition_alloc(ctx, &mut c_cond)
         })?;
 
         let cond = QueryCondition {
@@ -270,16 +269,15 @@ impl EqualityPredicate {
             raw: RawQueryCondition::Owned(c_cond),
         };
 
-        let c_ctx = ctx.capi();
         let c_cond = cond.capi();
         let c_name = cstring!(self.field.as_str());
         let val = self.value.to_bytes();
         let c_ptr = val.as_ptr() as *const std::ffi::c_void;
         let c_size = val.len() as u64;
         let c_op = self.op.capi_enum();
-        ctx.capi_return(unsafe {
+        ctx.capi_call(|ctx| unsafe {
             ffi::tiledb_query_condition_init(
-                c_ctx,
+                ctx,
                 c_cond,
                 c_name.as_ptr(),
                 c_ptr,
@@ -338,12 +336,11 @@ impl SetMembershipPredicate {
             let c_offsets_size = std::mem::size_of_val(&offsets) as u64;
 
             // Create the query condition
-            let c_ctx = ctx.capi();
             let c_name = cstring!(self.field.as_str());
             let c_op = self.op.capi_enum();
-            ctx.capi_return(unsafe {
+            ctx.capi_call(|ctx| unsafe {
                 ffi::tiledb_query_condition_alloc_set_membership(
-                    c_ctx,
+                    ctx,
                     c_name.as_ptr(),
                     c_data,
                     c_data_size,
@@ -381,12 +378,11 @@ impl SetMembershipPredicate {
             let c_offsets_size = std::mem::size_of_val(&offsets) as u64;
 
             // And create the query condition
-            let c_ctx = ctx.capi();
             let c_name = cstring!(self.field.as_str());
             let c_op = self.op.capi_enum();
-            ctx.capi_return(unsafe {
+            ctx.capi_call(|ctx| unsafe {
                 ffi::tiledb_query_condition_alloc_set_membership(
-                    c_ctx,
+                    ctx,
                     c_name.as_ptr(),
                     c_data,
                     c_data_size,
@@ -417,8 +413,8 @@ impl NullnessPredicate {
         ctx: &'ctx Context,
     ) -> TileDBResult<QueryCondition<'ctx>> {
         let mut c_cond: *mut ffi::tiledb_query_condition_t = out_ptr!();
-        ctx.capi_return(unsafe {
-            ffi::tiledb_query_condition_alloc(ctx.capi(), &mut c_cond)
+        ctx.capi_call(|ctx| unsafe {
+            ffi::tiledb_query_condition_alloc(ctx, &mut c_cond)
         })?;
 
         let cond = QueryCondition {
@@ -426,13 +422,12 @@ impl NullnessPredicate {
             raw: RawQueryCondition::Owned(c_cond),
         };
 
-        let c_ctx = ctx.capi();
         let c_cond = cond.capi();
         let c_name = cstring!(self.field.as_str());
         let c_op = self.op.capi_enum();
-        ctx.capi_return(unsafe {
+        ctx.capi_call(|ctx| unsafe {
             ffi::tiledb_query_condition_init(
-                c_ctx,
+                ctx,
                 c_cond,
                 c_name.as_ptr(),
                 std::ptr::null(),
@@ -582,14 +577,13 @@ impl QueryConditionExpr {
                 let lhs = lhs.build(ctx)?;
                 let rhs = rhs.build(ctx)?;
 
-                let c_ctx = ctx.capi();
                 let c_lhs = lhs.capi();
                 let c_rhs = rhs.capi();
                 let c_op = op.capi_enum();
                 let mut c_cond: *mut ffi::tiledb_query_condition_t = out_ptr!();
-                ctx.capi_return(unsafe {
+                ctx.capi_call(|ctx| unsafe {
                     ffi::tiledb_query_condition_combine(
-                        c_ctx,
+                        ctx,
                         c_lhs,
                         c_rhs,
                         c_op,
@@ -604,13 +598,12 @@ impl QueryConditionExpr {
             }
             Self::Negate(expr) => {
                 let cond = expr.build(ctx)?;
-                let c_ctx = ctx.capi();
                 let c_cond = cond.capi();
                 let mut c_neg_cond: *mut ffi::tiledb_query_condition_t =
                     out_ptr!();
-                ctx.capi_return(unsafe {
+                ctx.capi_call(|ctx| unsafe {
                     ffi::tiledb_query_condition_negate(
-                        c_ctx,
+                        ctx,
                         c_cond,
                         &mut c_neg_cond,
                     )

--- a/tiledb/api/src/query/write/mod.rs
+++ b/tiledb/api/src/query/write/mod.rs
@@ -84,19 +84,17 @@ impl<'ctx, 'data> WriteBuilder<'ctx, 'data> {
             )
         };
 
-        let c_context = self.context().capi();
         let c_query = **self.base().cquery();
         let c_name = cstring!(field_name.clone());
 
         let mut data_size = Box::pin(input.data.size() as u64);
 
-        self.capi_return(unsafe {
-            let c_bufptr =
-                input.data.as_ref().as_ptr() as *mut std::ffi::c_void;
-            let c_sizeptr = data_size.as_mut().get_mut() as *mut u64;
+        let c_bufptr = input.data.as_ref().as_ptr() as *mut std::ffi::c_void;
+        let c_sizeptr = data_size.as_mut().get_mut() as *mut u64;
 
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_query_set_data_buffer(
-                c_context,
+                ctx,
                 c_query,
                 c_name.as_ptr(),
                 c_bufptr,
@@ -115,9 +113,9 @@ impl<'ctx, 'data> WriteBuilder<'ctx, 'data> {
                     as *mut u64;
             let c_sizeptr = offsets_size.as_mut().get_mut() as *mut u64;
 
-            self.capi_return(unsafe {
+            self.capi_call(|ctx| unsafe {
                 ffi::tiledb_query_set_offsets_buffer(
-                    c_context,
+                    ctx,
                     c_query,
                     c_name.as_ptr(),
                     c_offptr,
@@ -134,9 +132,9 @@ impl<'ctx, 'data> WriteBuilder<'ctx, 'data> {
                 input.validity.as_ref().unwrap().as_ref().as_ptr() as *mut u8;
             let c_sizeptr = validity_size.as_mut().get_mut() as *mut u64;
 
-            self.capi_return(unsafe {
+            self.capi_call(|ctx| unsafe {
                 ffi::tiledb_query_set_validity_buffer(
-                    c_context,
+                    ctx,
                     c_query,
                     c_name.as_ptr(),
                     c_validityptr,

--- a/tiledb/api/src/vfs.rs
+++ b/tiledb/api/src/vfs.rs
@@ -100,9 +100,10 @@ pub struct VFSHandle<'ctx> {
 
 impl<'ctx> VFS<'ctx> {
     pub fn new(ctx: &'ctx Context, config: &Config) -> TileDBResult<VFS<'ctx>> {
+        let c_config = config.capi();
         let mut c_vfs: *mut ffi::tiledb_vfs_t = out_ptr!();
-        ctx.capi_return(unsafe {
-            ffi::tiledb_vfs_alloc(ctx.capi(), config.capi(), &mut c_vfs)
+        ctx.capi_call(|ctx| unsafe {
+            ffi::tiledb_vfs_alloc(ctx, c_config, &mut c_vfs)
         })?;
         Ok(VFS {
             context: ctx,
@@ -111,11 +112,10 @@ impl<'ctx> VFS<'ctx> {
     }
 
     pub fn get_config(&self) -> TileDBResult<Config> {
-        let c_ctx = self.context.capi();
         let c_vfs = *self.raw;
         let mut c_cfg: *mut ffi::tiledb_config_t = out_ptr!();
-        self.capi_return(unsafe {
-            ffi::tiledb_vfs_get_config(c_ctx, c_vfs, &mut c_cfg)
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_vfs_get_config(ctx, c_vfs, &mut c_cfg)
         })?;
 
         Ok(Config {
@@ -124,13 +124,12 @@ impl<'ctx> VFS<'ctx> {
     }
 
     pub fn is_bucket(&self, uri: &str) -> TileDBResult<bool> {
-        let c_ctx = self.context.capi();
         let c_vfs = *self.raw;
         let c_uri = cstring!(uri);
         let mut c_is_bucket: i32 = 0;
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_vfs_is_empty_bucket(
-                c_ctx,
+                ctx,
                 c_vfs,
                 c_uri.as_ptr(),
                 &mut c_is_bucket,
@@ -141,13 +140,12 @@ impl<'ctx> VFS<'ctx> {
     }
 
     pub fn is_empty_bucket(&self, uri: &str) -> TileDBResult<bool> {
-        let c_ctx = self.context.capi();
         let c_vfs = *self.raw;
         let c_uri = cstring!(uri);
         let mut c_is_empty: i32 = 0;
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_vfs_is_empty_bucket(
-                c_ctx,
+                ctx,
                 c_vfs,
                 c_uri.as_ptr(),
                 &mut c_is_empty,
@@ -158,92 +156,84 @@ impl<'ctx> VFS<'ctx> {
     }
 
     pub fn create_bucket(&self, uri: &str) -> TileDBResult<()> {
-        let c_ctx = self.context.capi();
         let c_vfs = *self.raw;
         let c_uri = cstring!(uri);
-        self.capi_return(unsafe {
-            ffi::tiledb_vfs_create_bucket(c_ctx, c_vfs, c_uri.as_ptr())
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_vfs_create_bucket(ctx, c_vfs, c_uri.as_ptr())
         })?;
 
         Ok(())
     }
 
     pub fn remove_bucket(&self, uri: &str) -> TileDBResult<()> {
-        let c_ctx = self.context.capi();
         let c_vfs = *self.raw;
         let c_uri = cstring!(uri);
-        self.capi_return(unsafe {
-            ffi::tiledb_vfs_remove_bucket(c_ctx, c_vfs, c_uri.as_ptr())
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_vfs_remove_bucket(ctx, c_vfs, c_uri.as_ptr())
         })?;
 
         Ok(())
     }
 
     pub fn empty_bucket(&self, uri: &str) -> TileDBResult<()> {
-        let c_ctx = self.context.capi();
         let c_vfs = *self.raw;
         let c_uri = cstring!(uri);
-        self.capi_return(unsafe {
-            ffi::tiledb_vfs_empty_bucket(c_ctx, c_vfs, c_uri.as_ptr())
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_vfs_empty_bucket(ctx, c_vfs, c_uri.as_ptr())
         })?;
 
         Ok(())
     }
 
     pub fn is_dir(&self, uri: &str) -> TileDBResult<bool> {
-        let c_ctx = self.context.capi();
         let c_vfs = *self.raw;
         let c_uri = cstring!(uri);
         let mut c_is_dir: i32 = 0;
-        self.capi_return(unsafe {
-            ffi::tiledb_vfs_is_dir(c_ctx, c_vfs, c_uri.as_ptr(), &mut c_is_dir)
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_vfs_is_dir(ctx, c_vfs, c_uri.as_ptr(), &mut c_is_dir)
         })?;
 
         Ok(c_is_dir == 1)
     }
 
     pub fn dir_size(&self, uri: &str) -> TileDBResult<u64> {
-        let c_ctx = self.context.capi();
         let c_vfs = *self.raw;
         let c_uri = cstring!(uri);
         let mut c_size: u64 = 0;
-        self.capi_return(unsafe {
-            ffi::tiledb_vfs_dir_size(c_ctx, c_vfs, c_uri.as_ptr(), &mut c_size)
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_vfs_dir_size(ctx, c_vfs, c_uri.as_ptr(), &mut c_size)
         })?;
 
         Ok(c_size)
     }
 
     pub fn create_dir(&self, uri: &str) -> TileDBResult<()> {
-        let c_ctx = self.context.capi();
         let c_vfs = *self.raw;
         let c_uri = cstring!(uri);
-        self.capi_return(unsafe {
-            ffi::tiledb_vfs_create_dir(c_ctx, c_vfs, c_uri.as_ptr())
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_vfs_create_dir(ctx, c_vfs, c_uri.as_ptr())
         })?;
 
         Ok(())
     }
 
     pub fn remove_dir(&self, uri: &str) -> TileDBResult<()> {
-        let c_ctx = self.context.capi();
         let c_vfs = *self.raw;
         let c_uri = cstring!(uri);
-        self.capi_return(unsafe {
-            ffi::tiledb_vfs_remove_dir(c_ctx, c_vfs, c_uri.as_ptr())
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_vfs_remove_dir(ctx, c_vfs, c_uri.as_ptr())
         })?;
 
         Ok(())
     }
 
     pub fn copy_dir(&self, uri_src: &str, uri_tgt: &str) -> TileDBResult<()> {
-        let c_ctx = self.context.capi();
         let c_vfs = *self.raw;
         let c_uri_src = cstring!(uri_src);
         let c_uri_tgt = cstring!(uri_tgt);
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_vfs_copy_dir(
-                c_ctx,
+                ctx,
                 c_vfs,
                 c_uri_src.as_ptr(),
                 c_uri_tgt.as_ptr(),
@@ -254,13 +244,12 @@ impl<'ctx> VFS<'ctx> {
     }
 
     pub fn move_dir(&self, uri_src: &str, uri_tgt: &str) -> TileDBResult<()> {
-        let c_ctx = self.context.capi();
         let c_vfs = *self.raw;
         let c_uri_src = cstring!(uri_src);
         let c_uri_tgt = cstring!(uri_tgt);
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_vfs_move_dir(
-                c_ctx,
+                ctx,
                 c_vfs,
                 c_uri_src.as_ptr(),
                 c_uri_tgt.as_ptr(),
@@ -271,40 +260,32 @@ impl<'ctx> VFS<'ctx> {
     }
 
     pub fn is_file(&self, uri: &str) -> TileDBResult<bool> {
-        let c_ctx = self.context.capi();
         let c_vfs = *self.raw;
         let c_uri = cstring!(uri);
         let mut c_is_file: i32 = 0;
-        self.capi_return(unsafe {
-            ffi::tiledb_vfs_is_file(
-                c_ctx,
-                c_vfs,
-                c_uri.as_ptr(),
-                &mut c_is_file,
-            )
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_vfs_is_file(ctx, c_vfs, c_uri.as_ptr(), &mut c_is_file)
         })?;
 
         Ok(c_is_file == 1)
     }
 
     pub fn file_size(&self, uri: &str) -> TileDBResult<u64> {
-        let c_ctx = self.context.capi();
         let c_vfs = *self.raw;
         let c_uri = cstring!(uri);
         let mut c_size: u64 = 0;
-        self.capi_return(unsafe {
-            ffi::tiledb_vfs_file_size(c_ctx, c_vfs, c_uri.as_ptr(), &mut c_size)
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_vfs_file_size(ctx, c_vfs, c_uri.as_ptr(), &mut c_size)
         })?;
 
         Ok(c_size)
     }
 
     pub fn touch(&self, uri: &str) -> TileDBResult<()> {
-        let c_ctx = self.context.capi();
         let c_vfs = *self.raw;
         let c_uri = cstring!(uri);
-        self.capi_return(unsafe {
-            ffi::tiledb_vfs_touch(c_ctx, c_vfs, c_uri.as_ptr())
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_vfs_touch(ctx, c_vfs, c_uri.as_ptr())
         })?;
 
         Ok(())
@@ -320,12 +301,11 @@ impl<'ctx> VFS<'ctx> {
         mode: VFSMode,
     ) -> TileDBResult<VFSHandle<'ctx>> {
         let mut c_fh: *mut ffi::tiledb_vfs_fh_t = out_ptr!();
-        let c_ctx = self.context.capi();
         let c_vfs = *self.raw;
         let c_uri = cstring!(uri);
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_vfs_open(
-                c_ctx,
+                ctx,
                 c_vfs,
                 c_uri.as_ptr(),
                 mode.capi_enum(),
@@ -340,24 +320,22 @@ impl<'ctx> VFS<'ctx> {
     }
 
     pub fn remove_file(&self, uri: &str) -> TileDBResult<()> {
-        let c_ctx = self.context.capi();
         let c_vfs = *self.raw;
         let c_uri = cstring!(uri);
-        self.capi_return(unsafe {
-            ffi::tiledb_vfs_remove_file(c_ctx, c_vfs, c_uri.as_ptr())
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_vfs_remove_file(ctx, c_vfs, c_uri.as_ptr())
         })?;
 
         Ok(())
     }
 
     pub fn copy_file(&self, uri_src: &str, uri_tgt: &str) -> TileDBResult<()> {
-        let c_ctx = self.context.capi();
         let c_vfs = *self.raw;
         let c_uri_src = cstring!(uri_src);
         let c_uri_tgt = cstring!(uri_tgt);
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_vfs_copy_file(
-                c_ctx,
+                ctx,
                 c_vfs,
                 c_uri_src.as_ptr(),
                 c_uri_tgt.as_ptr(),
@@ -368,13 +346,12 @@ impl<'ctx> VFS<'ctx> {
     }
 
     pub fn move_file(&self, uri_src: &str, uri_tgt: &str) -> TileDBResult<()> {
-        let c_ctx = self.context.capi();
         let c_vfs = *self.raw;
         let c_uri_src = cstring!(uri_src);
         let c_uri_tgt = cstring!(uri_tgt);
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_vfs_move_file(
-                c_ctx,
+                ctx,
                 c_vfs,
                 c_uri_src.as_ptr(),
                 c_uri_tgt.as_ptr(),
@@ -388,7 +365,6 @@ impl<'ctx> VFS<'ctx> {
     where
         F: FnMut(&str) -> VFSLsStatus,
     {
-        let c_ctx = self.context.capi();
         let c_vfs = *self.raw;
         let c_uri = cstring!(uri);
 
@@ -396,9 +372,9 @@ impl<'ctx> VFS<'ctx> {
         let mut cb: &mut dyn FnMut(&str) -> VFSLsStatus = &mut callback;
         let cb = &mut cb;
 
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_vfs_ls(
-                c_ctx,
+                ctx,
                 c_vfs,
                 c_uri.as_ptr(),
                 Some(vfs_ls_cb_handler),
@@ -417,7 +393,6 @@ impl<'ctx> VFS<'ctx> {
     where
         F: FnMut(&str, u64) -> VFSLsStatus,
     {
-        let c_ctx = self.context.capi();
         let c_vfs = *self.raw;
         let c_uri = cstring!(uri);
 
@@ -425,9 +400,9 @@ impl<'ctx> VFS<'ctx> {
         let mut cb: &mut dyn FnMut(&str, u64) -> VFSLsStatus = &mut callback;
         let cb = &mut cb;
 
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_vfs_ls_recursive(
-                c_ctx,
+                ctx,
                 c_vfs,
                 c_uri.as_ptr(),
                 Some(vfs_ls_recursive_cb_handler),
@@ -508,30 +483,27 @@ extern "C" fn vfs_ls_recursive_cb_handler(
 
 impl<'ctx> VFSHandle<'ctx> {
     pub fn is_closed(&self) -> TileDBResult<bool> {
-        let c_ctx = self.context.capi();
         let c_fh = *self.raw;
         let mut c_is_closed: i32 = 0;
-        self.capi_return(unsafe {
-            ffi::tiledb_vfs_fh_is_closed(c_ctx, c_fh, &mut c_is_closed)
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_vfs_fh_is_closed(ctx, c_fh, &mut c_is_closed)
         })?;
 
         Ok(c_is_closed == 1)
     }
 
     pub fn close(&self) -> TileDBResult<()> {
-        let c_ctx = self.context.capi();
         let c_fh = *self.raw;
-        self.capi_return(unsafe { ffi::tiledb_vfs_close(c_ctx, c_fh) })?;
+        self.capi_call(|ctx| unsafe { ffi::tiledb_vfs_close(ctx, c_fh) })?;
 
         Ok(())
     }
 
     pub fn read(&self, offset: u64, buffer: &mut [u8]) -> TileDBResult<()> {
-        let c_ctx = self.context.capi();
         let c_fh = *self.raw;
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_vfs_read(
-                c_ctx,
+                ctx,
                 c_fh,
                 offset,
                 buffer.as_ptr() as *mut std::ffi::c_void,
@@ -543,11 +515,10 @@ impl<'ctx> VFSHandle<'ctx> {
     }
 
     pub fn write(&self, buffer: &[u8]) -> TileDBResult<()> {
-        let c_ctx = self.context.capi();
         let c_fh = *self.raw;
-        self.capi_return(unsafe {
+        self.capi_call(|ctx| unsafe {
             ffi::tiledb_vfs_write(
-                c_ctx,
+                ctx,
                 c_fh,
                 buffer.as_ptr() as *const std::ffi::c_void,
                 buffer.len() as u64,
@@ -558,9 +529,8 @@ impl<'ctx> VFSHandle<'ctx> {
     }
 
     pub fn sync(&self) -> TileDBResult<()> {
-        let c_ctx = self.context.capi();
         let c_fh = *self.raw;
-        self.capi_return(unsafe { ffi::tiledb_vfs_sync(c_ctx, c_fh) })?;
+        self.capi_call(|ctx| unsafe { ffi::tiledb_vfs_sync(ctx, c_fh) })?;
 
         Ok(())
     }


### PR DESCRIPTION
This removes all access to the underlying raw context pointer except through the `Context::capi_call` method. This method accepts a single argument that is a `FnOnce` callable. This callable must take a single argument which is a `*mut ffi::tiledb_ctx_t` that can be used to pass to all of the FFI calls that require it. The return value should be the i32 result of invoking one of the tiledb FFI functions.

A simple example looks like such:

```rust
pub fn version(&self) -> TileDBResult<i64> {
    let mut c_version: std::os::raw::c_int = out_ptr!();
    self.capi_call(|ctx| unsafe {
        ffi::tiledb_array_schema_get_allows_dups(
            ctx, c_schema, &mut c_version
        )
    })?;

    Ok(c_version as i64)
}
```