### PR TITLE
Implement conversion from RawReadOutput to Arrow array

### DIFF
--- a/tiledb/api/examples/reading_incomplete.rs
+++ b/tiledb/api/examples/reading_incomplete.rs
@@ -209,7 +209,7 @@ fn read_array_step() -> TileDBResult<()> {
 
             let char_output: Ref<QueryBuffersMut<u8>> = char_output.borrow();
             let char_output: QueryBuffers<u8> = char_output.as_shared();
-            let a2 = VarDataIterator::new(n_a2, b_a2, &char_output)
+            let a2 = VarDataIterator::new(n_a2, b_a2, char_output)
                 .expect("Expected variable data offsets")
                 .map(|bytes| String::from_utf8_lossy(bytes).to_string());
 

--- a/tiledb/api/src/datatype/arrow.rs
+++ b/tiledb/api/src/datatype/arrow.rs
@@ -1,4 +1,50 @@
+use arrow::datatypes::{ArrowNativeTypeOp, ArrowPrimitiveType};
+
 use crate::Datatype;
+
+pub trait ArrowPrimitiveTypeNative: ArrowNativeTypeOp {
+    type ArrowPrimitiveType: ArrowPrimitiveType<Native = Self>;
+}
+
+impl ArrowPrimitiveTypeNative for i8 {
+    type ArrowPrimitiveType = arrow::datatypes::Int8Type;
+}
+
+impl ArrowPrimitiveTypeNative for i16 {
+    type ArrowPrimitiveType = arrow::datatypes::Int16Type;
+}
+
+impl ArrowPrimitiveTypeNative for i32 {
+    type ArrowPrimitiveType = arrow::datatypes::Int32Type;
+}
+
+impl ArrowPrimitiveTypeNative for i64 {
+    type ArrowPrimitiveType = arrow::datatypes::Int64Type;
+}
+
+impl ArrowPrimitiveTypeNative for u8 {
+    type ArrowPrimitiveType = arrow::datatypes::UInt8Type;
+}
+
+impl ArrowPrimitiveTypeNative for u16 {
+    type ArrowPrimitiveType = arrow::datatypes::UInt16Type;
+}
+
+impl ArrowPrimitiveTypeNative for u32 {
+    type ArrowPrimitiveType = arrow::datatypes::UInt32Type;
+}
+
+impl ArrowPrimitiveTypeNative for u64 {
+    type ArrowPrimitiveType = arrow::datatypes::UInt64Type;
+}
+
+impl ArrowPrimitiveTypeNative for f32 {
+    type ArrowPrimitiveType = arrow::datatypes::Float32Type;
+}
+
+impl ArrowPrimitiveTypeNative for f64 {
+    type ArrowPrimitiveType = arrow::datatypes::Float64Type;
+}
 
 /// For a TileDB type, returns an Arrow type if the bits of the canonical input type match.
 /// If this returns Some(arrow_dt), then values of arrow_dt can be used in functions which expect tdb_dt, and vice verse.

--- a/tiledb/api/src/datatype/strategy.rs
+++ b/tiledb/api/src/datatype/strategy.rs
@@ -75,3 +75,26 @@ pub fn prop_datatype_for_dense_dimension() -> impl Strategy<Value = Datatype> {
         |dt| dt.is_allowed_dimension_type_dense(),
     )
 }
+
+#[derive(Clone, Debug, Default)]
+pub enum DatatypeContext {
+    #[default]
+    Any,
+    DenseDimension,
+    Implemented,
+}
+
+impl Arbitrary for Datatype {
+    type Parameters = DatatypeContext;
+    type Strategy = BoxedStrategy<Datatype>;
+
+    fn arbitrary_with(p: Self::Parameters) -> Self::Strategy {
+        match p {
+            DatatypeContext::Any => prop_datatype().boxed(),
+            DatatypeContext::DenseDimension => {
+                prop_datatype_for_dense_dimension().boxed()
+            }
+            DatatypeContext::Implemented => prop_datatype_implemented().boxed(),
+        }
+    }
+}

--- a/tiledb/api/src/query/buffer.rs
+++ b/tiledb/api/src/query/buffer.rs
@@ -35,6 +35,12 @@ impl<'data, T> Deref for Buffer<'data, T> {
     }
 }
 
+impl<'data, T> From<Vec<T>> for Buffer<'data, T> {
+    fn from(value: Vec<T>) -> Self {
+        Buffer::Owned(value.into_boxed_slice())
+    }
+}
+
 pub struct QueryBuffers<'data, C> {
     pub data: Buffer<'data, C>,
     pub cell_offsets: Option<Buffer<'data, u64>>,

--- a/tiledb/api/src/query/read/callback.rs
+++ b/tiledb/api/src/query/read/callback.rs
@@ -442,11 +442,15 @@ macro_rules! query_read_callback {
 
                         let [< l_ $U:snake >] = self.[< arg_ $U:snake >].location.borrow();
                         let [< input_ $U:snake >] = [< l_ $U:snake >].as_shared();
+                            /*
+                             * TODO: if it is the final result, enable moving out of
+                             * this so that we can avoid a copy
+                             */
 
                         let [< arg_ $U:snake >] = RawReadOutput {
                             nvalues: [< nvalues_ $U:snake >],
                             nbytes: [< nbytes_ $U:snake >],
-                            input: &[< input_ $U:snake >]
+                            input: [< input_ $U:snake >]
                         };
                     )+
                 }
@@ -766,7 +770,7 @@ mod tests {
             let arg = RawReadOutput {
                 nvalues: ncells,
                 nbytes: ncells * std::mem::size_of::<u64>(),
-                input: &input_data,
+                input: input_data,
             };
 
             let prev_len = unitdst.len();
@@ -891,7 +895,7 @@ mod tests {
             let arg = RawReadOutput {
                 nvalues,
                 nbytes,
-                input: &input,
+                input,
             };
             stringdst
                 .intermediate_result(arg)

--- a/tiledb/api/src/query/read/callback.rs
+++ b/tiledb/api/src/query/read/callback.rs
@@ -60,12 +60,12 @@ pub trait ReadCallbackVarArg: Sized {
 
     fn intermediate_result(
         &mut self,
-        args: &[TypedRawReadOutput],
+        args: Vec<TypedRawReadOutput>,
     ) -> Result<Self::Intermediate, Self::Error>;
 
     fn final_result(
         self,
-        args: &[TypedRawReadOutput],
+        args: Vec<TypedRawReadOutput>,
     ) -> Result<Self::Final, Self::Error>;
 
     /// Optionally produce a blank instance of this callback to be run
@@ -632,7 +632,7 @@ where
                     })
                     .collect::<Vec<TypedRawReadOutput>>();
 
-                let ir = callback.intermediate_result(&args).map_err(|e| {
+                let ir = callback.intermediate_result(args).map_err(|e| {
                     let fields = self
                         .base
                         .raw_read_output
@@ -668,7 +668,7 @@ where
                     })
                     .collect::<Vec<TypedRawReadOutput>>();
 
-                let ir = callback_final.final_result(&args).map_err(|e| {
+                let ir = callback_final.final_result(args).map_err(|e| {
                     let fields = self
                         .base
                         .raw_read_output

--- a/tiledb/api/src/query/read/output/arrow.rs
+++ b/tiledb/api/src/query/read/output/arrow.rs
@@ -1,0 +1,340 @@
+use std::sync::Arc;
+
+use arrow::array::{Array as ArrowArray, GenericListArray, PrimitiveArray};
+use arrow::buffer::{OffsetBuffer, ScalarBuffer};
+use arrow::datatypes::Field;
+
+use crate::datatype::arrow::ArrowPrimitiveTypeNative;
+use crate::error::{DatatypeErrorKind, Error};
+use crate::query::buffer::{Buffer, QueryBuffers, TypedQueryBuffers};
+use crate::query::read::output::{RawReadOutput, TypedRawReadOutput};
+use crate::{typed_query_buffers_go, Result as TileDBResult};
+
+impl<'data, C> TryFrom<RawReadOutput<'data, C>>
+    for PrimitiveArray<<C as ArrowPrimitiveTypeNative>::ArrowPrimitiveType>
+where
+    C: ArrowPrimitiveTypeNative,
+    PrimitiveArray<<C as ArrowPrimitiveTypeNative>::ArrowPrimitiveType>:
+        From<Vec<C>> + From<Vec<Option<C>>>,
+{
+    type Error = crate::error::Error;
+
+    fn try_from(value: RawReadOutput<C>) -> TileDBResult<Self> {
+        type MyPrimitiveArray<C> =
+            PrimitiveArray<<C as ArrowPrimitiveTypeNative>::ArrowPrimitiveType>;
+
+        if value.input.cell_offsets.is_some() {
+            return Err(Error::Datatype(DatatypeErrorKind::ExpectedFixedSize(
+                None,
+            )));
+        }
+
+        Ok(if let Some(validity) = value.input.validity {
+            let data: Vec<C> = match value.input.data {
+                Buffer::Empty => vec![],
+                Buffer::Owned(data) => {
+                    let mut data = data.into_vec();
+                    data.truncate(value.nvalues);
+                    data
+                }
+                Buffer::Borrowed(data) => data[0..value.nvalues].to_vec(),
+            };
+
+            let validity = match validity {
+                Buffer::Empty => vec![],
+                Buffer::Owned(v) => {
+                    let mut v = v.into_vec();
+                    v.truncate(value.nvalues);
+                    v
+                }
+                Buffer::Borrowed(v) => v[0..value.nvalues].to_vec(),
+            };
+            let validity = validity
+                .into_iter()
+                .map(|v| v != 0)
+                .collect::<arrow::buffer::NullBuffer>();
+            MyPrimitiveArray::<C>::new(data.into(), Some(validity))
+        } else {
+            let mut v: Vec<C> = match value.input.data {
+                Buffer::Empty => vec![],
+                Buffer::Owned(b) => b.into_vec(),
+                Buffer::Borrowed(b) => b.to_vec(),
+            };
+            v.truncate(value.nvalues);
+            v.into()
+        })
+    }
+}
+
+impl<'data, C> From<RawReadOutput<'data, C>> for Arc<dyn ArrowArray>
+where
+    C: ArrowPrimitiveTypeNative,
+    PrimitiveArray<<C as ArrowPrimitiveTypeNative>::ArrowPrimitiveType>:
+        From<Vec<C>> + From<Vec<Option<C>>>,
+{
+    fn from(mut value: RawReadOutput<'data, C>) -> Self {
+        /* TODO: needs the cell val num to make the decision properly */
+
+        type MyPrimitiveArray<C> =
+            PrimitiveArray<<C as ArrowPrimitiveTypeNative>::ArrowPrimitiveType>;
+
+        let offsets = value.input.cell_offsets.take();
+
+        let mut v_offsets = if let Some(offsets) = offsets {
+            match offsets {
+                Buffer::Empty => vec![],
+                Buffer::Owned(offsets) => {
+                    let mut offsets = offsets.into_vec();
+                    offsets.truncate(value.nvalues);
+                    offsets
+                }
+                Buffer::Borrowed(offsets) => offsets[0..value.nvalues].to_vec(),
+            }
+        } else {
+            let flat = MyPrimitiveArray::<C>::try_from(value).unwrap();
+            return Arc::new(flat);
+        };
+
+        let arrow_values = {
+            let rr = RawReadOutput {
+                nvalues: value.nbytes / std::mem::size_of::<C>(),
+                nbytes: value.nbytes, // unused
+                input: QueryBuffers {
+                    data: value.input.data,
+                    cell_offsets: None,
+                    validity: None,
+                },
+            };
+            MyPrimitiveArray::<C>::try_from(rr).unwrap()
+        };
+
+        v_offsets.push(value.nbytes as u64); /* TODO: bytes is the unit of offsets, right? */
+
+        let v_offsets = v_offsets
+            .into_iter()
+            .map(|o| (o / std::mem::size_of::<C>() as u64) as i64)
+            .collect::<Vec<i64>>();
+
+        let field = Arc::new(Field::new_list_field(
+            arrow_values.data_type().clone(),
+            value.input.validity.is_some(),
+        ));
+
+        let arrow_offsets =
+            OffsetBuffer::<i64>::new(ScalarBuffer::<i64>::from(v_offsets));
+
+        let arrow_validity = if let Some(validity) = value.input.validity {
+            let validity: Vec<u8> = match validity {
+                Buffer::Empty => vec![],
+                Buffer::Owned(validity) => validity.into_vec(),
+                Buffer::Borrowed(validity) => {
+                    validity[0..value.nvalues].to_vec()
+                }
+            };
+            let arrow_validity = validity
+                .into_iter()
+                .take(value.nvalues)
+                .map(|v: u8| v != 0)
+                .collect::<arrow::buffer::NullBuffer>();
+            Some(arrow_validity)
+        } else {
+            None
+        };
+
+        let list_array = GenericListArray::<i64>::try_new(
+            field,
+            arrow_offsets,
+            Arc::new(arrow_values),
+            arrow_validity,
+        )
+        .expect("TileDB internal error constructing Arrow buffers");
+
+        Arc::new(list_array)
+    }
+}
+
+impl From<TypedRawReadOutput<'_>> for Arc<dyn ArrowArray> {
+    fn from(value: TypedRawReadOutput<'_>) -> Self {
+        typed_query_buffers_go!(value.buffers, _DT, input, {
+            RawReadOutput {
+                nvalues: value.nvalues,
+                nbytes: value.nbytes,
+                input,
+            }
+            .into()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::any::TypeId;
+
+    use super::*;
+    use proptest::prelude::*;
+
+    fn raw_read_to_arrow<C>(rr: RawReadOutput<C>)
+    where
+        C: ArrowPrimitiveTypeNative,
+        PrimitiveArray<<C as ArrowPrimitiveTypeNative>::ArrowPrimitiveType>:
+            From<Vec<C>> + From<Vec<Option<C>>>,
+    {
+        type MyPrimitiveArray<C> =
+            PrimitiveArray<<C as ArrowPrimitiveTypeNative>::ArrowPrimitiveType>;
+
+        let arrow = {
+            let rrborrow = RawReadOutput {
+                nvalues: rr.nvalues,
+                nbytes: rr.nbytes,
+                input: rr.input.borrow(),
+            };
+            Arc::<dyn ArrowArray>::from(rrborrow)
+        };
+
+        if let Some(offsets) = rr.input.cell_offsets {
+            assert_eq!(
+                TypeId::of::<GenericListArray<i64>>(),
+                arrow.as_any().type_id()
+            );
+            let gl = arrow
+                .as_any()
+                .downcast_ref::<GenericListArray<i64>>()
+                .unwrap();
+
+            let arrow_offsets = gl.offsets();
+            assert!(arrow_offsets.len() <= offsets.len() + 1);
+            assert_eq!(arrow_offsets.len(), rr.nvalues + 1);
+
+            /* arrow offsets are value, tiledb offsets are bytes */
+            let offset_scale = std::mem::size_of::<C>() as i64;
+
+            /* check that offsets are mapped correctly */
+            for o in 0..rr.nvalues {
+                assert_eq!(arrow_offsets[o] * offset_scale, offsets[o] as i64);
+            }
+            assert_eq!(
+                arrow_offsets[rr.nvalues] * offset_scale,
+                rr.nbytes as i64
+            );
+
+            /* check that values match */
+            let primitive = {
+                assert_eq!(
+                    TypeId::of::<MyPrimitiveArray<C>>(),
+                    gl.values().as_any().type_id()
+                );
+                gl.values()
+                    .as_any()
+                    .downcast_ref::<MyPrimitiveArray<C>>()
+                    .unwrap()
+            };
+            assert_eq!(None, primitive.nulls());
+
+            assert_eq!(rr.nbytes, primitive.len() * std::mem::size_of::<C>());
+            for (arrow, tiledb) in primitive
+                .iter()
+                .zip(rr.input.data[0..primitive.len()].iter())
+            {
+                assert_eq!(Some(*tiledb), arrow);
+            }
+
+            /* check that validity matches */
+            if let Some(validity) = rr.input.validity {
+                assert!(gl.nulls().is_some());
+                let arrow_nulls = gl.nulls().unwrap();
+                assert_eq!(rr.nvalues, arrow_nulls.len());
+
+                let arrow_nulls = arrow_nulls
+                    .iter()
+                    .map(|b| if b { 1 } else { 0 })
+                    .collect::<Vec<u8>>();
+                assert_eq!(validity[0..arrow_nulls.len()], arrow_nulls);
+            } else {
+                assert_eq!(None, gl.nulls());
+            }
+        } else {
+            assert_eq!(
+                TypeId::of::<MyPrimitiveArray<C>>(),
+                arrow.as_any().type_id()
+            );
+            let primitive = arrow
+                .as_any()
+                .downcast_ref::<MyPrimitiveArray<C>>()
+                .unwrap();
+
+            assert_eq!(rr.nvalues, primitive.len());
+
+            /* ensure that neither or both has validity values */
+            if rr.input.validity.is_some() {
+                assert!(primitive.nulls().is_some());
+                assert_eq!(rr.nvalues, primitive.nulls().unwrap().len());
+            } else {
+                assert_eq!(None, primitive.nulls());
+            }
+
+            /* check validity and data in stride */
+            for i in 0..primitive.len() {
+                if let Some(v) = rr.input.validity.as_ref().map(|v| v[i]) {
+                    assert_eq!(
+                        Some(v == 0),
+                        primitive.nulls().map(|n| n.is_null(i))
+                    );
+                } else {
+                    assert_eq!(rr.input.data[i], primitive.value(i));
+                }
+            }
+        };
+    }
+
+    proptest! {
+        #[test]
+        fn raw_read_to_arrow_u8(rr in any::<RawReadOutput<u8>>()) {
+            raw_read_to_arrow(rr);
+        }
+
+        #[test]
+        fn raw_read_to_arrow_u16(rr in any::<RawReadOutput<u16>>()) {
+            raw_read_to_arrow(rr);
+        }
+
+        #[test]
+        fn raw_read_to_arrow_u32(rr in any::<RawReadOutput<u32>>()) {
+            raw_read_to_arrow(rr);
+        }
+
+        #[test]
+        fn raw_read_to_arrow_u64(rr in any::<RawReadOutput<u64>>()) {
+            raw_read_to_arrow(rr);
+        }
+
+        #[test]
+        fn raw_read_to_arrow_i8(rr in any::<RawReadOutput<i8>>()) {
+            raw_read_to_arrow(rr);
+        }
+
+        #[test]
+        fn raw_read_to_arrow_i16(rr in any::<RawReadOutput<i16>>()) {
+            raw_read_to_arrow(rr);
+        }
+
+        #[test]
+        fn raw_read_to_arrow_i32(rr in any::<RawReadOutput<i32>>()) {
+            raw_read_to_arrow(rr);
+        }
+
+        #[test]
+        fn raw_read_to_arrow_i64(rr in any::<RawReadOutput<i64>>()) {
+            raw_read_to_arrow(rr);
+        }
+
+        #[test]
+        fn raw_read_to_arrow_f32(rr in any::<RawReadOutput<f32>>()) {
+            raw_read_to_arrow(rr);
+        }
+
+        #[test]
+        fn raw_read_to_arrow_f64(rr in any::<RawReadOutput<f64>>()) {
+            raw_read_to_arrow(rr);
+        }
+    }
+}

--- a/tiledb/api/src/query/read/output/arrow.rs
+++ b/tiledb/api/src/query/read/output/arrow.rs
@@ -108,7 +108,7 @@ where
             MyPrimitiveArray::<C>::try_from(rr).unwrap()
         };
 
-        v_offsets.push(value.nbytes as u64); /* TODO: bytes is the unit of offsets, right? */
+        v_offsets.push(value.nbytes as u64);
 
         let v_offsets = v_offsets
             .into_iter()

--- a/tiledb/api/src/query/read/output/mod.rs
+++ b/tiledb/api/src/query/read/output/mod.rs
@@ -30,21 +30,22 @@ where
     C: Debug,
 {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        let nrecords = self.nvalues;
         let nvalues = self.nbytes / std::mem::size_of::<C>();
 
         let offsets_json = self.input.cell_offsets.as_ref().map(|offsets| {
             json!({
                 "capacity": offsets.len(),
-                "defined": self.nvalues,
-                "values": format!("{:?}", &offsets.as_ref()[0.. self.nvalues])
+                "defined": nrecords,
+                "values": format!("{:?}", &offsets.as_ref()[0.. nrecords])
             })
         });
 
         let validity_json = self.input.validity.as_ref().map(|validity| {
             json!({
                 "capacity": validity.len(),
-                "defined": self.nvalues,
-                "values": format!("{:?}", &validity.as_ref()[0.. self.nvalues])
+                "defined": nrecords,
+                "values": format!("{:?}", &validity.as_ref()[0.. nrecords])
             })
         });
 
@@ -503,10 +504,8 @@ impl<'data, C> Iterator for VarDataIterator<'data, C> {
             /*
              * If `self.location.data` is `Buffer::Owned`, then the underlying
              * data will be dropped when `self` is.
-             * TODO: try to poke at this and see if it is not safe in practice.
-             * By creating a 'data Buffer, transforming it into Owned,
-             * moving it into an iterator, getting an item, dropping the iterator,
-             * then using the Item.
+             * TODO: this actually is unsafe and `test_var_data_iterator_lifetime`
+             * demonstrates that.
              *
              * If `self.location.data` is `Buffer::Borrowed`, then the underlying
              * data will be dropped when 'data expires, are returned items

--- a/tiledb/api/src/query/read/output/mod.rs
+++ b/tiledb/api/src/query/read/output/mod.rs
@@ -32,6 +32,22 @@ where
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         let nvalues = self.nbytes / std::mem::size_of::<C>();
 
+        let offsets_json = self.input.cell_offsets.as_ref().map(|offsets| {
+            json!({
+                "capacity": offsets.len(),
+                "defined": self.nvalues,
+                "values": format!("{:?}", &offsets.as_ref()[0.. self.nvalues])
+            })
+        });
+
+        let validity_json = self.input.validity.as_ref().map(|validity| {
+            json!({
+                "capacity": validity.len(),
+                "defined": self.nvalues,
+                "values": format!("{:?}", &validity.as_ref()[0.. self.nvalues])
+            })
+        });
+
         write!(
             f,
             "{}",
@@ -41,24 +57,9 @@ where
                     "defined": nvalues,
                     "values": format!("{:?}", &self.input.data.as_ref()[0.. nvalues])
                 },
-                "offsets": match self.input.cell_offsets.as_ref() {
-                    None => None,
-                    Some(offsets) => Some(json!({
-                        "capacity": offsets.len(),
-                        "defined": self.nvalues,
-                        "values": format!("{:?}", &offsets.as_ref()[0.. self.nvalues])
-                    }))
-                },
-                "validity": match self.input.validity.as_ref() {
-                    None => None,
-                    Some(validity) => Some(json!({
-                        "capacity": validity.len(),
-                        "defined": self.nvalues,
-                        "values": format!("{:?}", &validity.as_ref()[0.. self.nvalues])
-                    }))
-                }
+                "offsets": offsets_json,
+                "validity": validity_json,
             })
-            .to_string()
         )
     }
 }

--- a/tiledb/api/src/query/read/output/strategy.rs
+++ b/tiledb/api/src/query/read/output/strategy.rs
@@ -1,0 +1,306 @@
+use std::fmt::Debug;
+
+use proptest::prelude::*;
+
+use crate::query::buffer::QueryBuffers;
+use crate::query::read::output::{RawReadOutput, TypedRawReadOutput};
+use crate::{fn_typed, Datatype};
+
+pub struct RawReadOutputParameters {
+    is_var_sized: Option<bool>,
+    is_nullable: Option<bool>,
+    min_values_capacity: usize,
+    max_values_capacity: usize,
+    min_offset_capacity: usize,
+    max_offset_capacity: usize,
+    min_validity_capacity: usize,
+    max_validity_capacity: usize,
+}
+
+impl Default for RawReadOutputParameters {
+    fn default() -> Self {
+        const MIN_VALUES_CAPACITY: usize = 0;
+        const MAX_VALUES_CAPACITY: usize = 1024;
+        const MIN_OFFSET_CAPACITY: usize = 0;
+        const MAX_OFFSET_CAPACITY: usize = 128;
+        const MIN_VALIDITY_CAPACITY: usize = 0;
+        const MAX_VALIDITY_CAPACITY: usize = 128;
+
+        RawReadOutputParameters {
+            is_var_sized: None,
+            is_nullable: None,
+            min_values_capacity: MIN_VALUES_CAPACITY,
+            max_values_capacity: MAX_VALUES_CAPACITY,
+            min_offset_capacity: MIN_OFFSET_CAPACITY,
+            max_offset_capacity: MAX_OFFSET_CAPACITY,
+            min_validity_capacity: MIN_VALIDITY_CAPACITY,
+            max_validity_capacity: MAX_VALIDITY_CAPACITY,
+        }
+    }
+}
+
+impl<'data, C> Arbitrary for RawReadOutput<'data, C>
+where
+    C: Arbitrary + Clone + Debug + 'static,
+{
+    type Parameters = RawReadOutputParameters;
+    type Strategy = BoxedStrategy<RawReadOutput<'data, C>>;
+
+    fn arbitrary_with(p: Self::Parameters) -> Self::Strategy {
+        let strategy_data_buffer = proptest::collection::vec(
+            any::<C>(),
+            p.min_values_capacity..=p.max_values_capacity,
+        );
+
+        let strategy_cell_offsets_capacity = {
+            let strategy_capacity =
+                (p.min_offset_capacity..=p.max_offset_capacity).prop_map(Some);
+
+            if let Some(true) = p.is_var_sized {
+                strategy_capacity.boxed()
+            } else {
+                prop_oneof![Just(None).boxed(), strategy_capacity.boxed()]
+                    .boxed()
+            }
+        };
+
+        let strategy_validity_buffer = {
+            let strategy_buffer = proptest::collection::vec(
+                any::<bool>(),
+                p.min_validity_capacity..=p.max_validity_capacity,
+            )
+            .prop_map(|v| {
+                Some(
+                    v.into_iter()
+                        .map(|b| if b { 1 } else { 0 })
+                        .collect::<Vec<u8>>(),
+                )
+            });
+
+            if let Some(n) = p.is_nullable {
+                if n {
+                    strategy_buffer.boxed()
+                } else {
+                    Just(None).boxed()
+                }
+            } else {
+                prop_oneof![Just(None).boxed(), strategy_buffer.boxed()].boxed()
+            }
+        };
+
+        (
+            strategy_data_buffer,
+            strategy_cell_offsets_capacity,
+            strategy_validity_buffer,
+        )
+            .prop_flat_map(|(data, offsets_capacity, validity)| {
+                if let Some(o) = offsets_capacity {
+                    let max_values = data.len();
+                    let max_offsets = if let Some(v) = validity.as_ref() {
+                        std::cmp::min(o, v.len())
+                    } else {
+                        o
+                    };
+                    (
+                        0..=max_values,
+                        Just(max_offsets),
+                        Just(data),
+                        Just(validity),
+                    )
+                        .prop_flat_map(
+                            |(nvalues, max_offsets, data, validity)| {
+                                (
+                                    Just(data),
+                                    proptest::collection::vec(
+                                        0u64..=(nvalues as u64),
+                                        0..=max_offsets,
+                                    ),
+                                    Just(validity),
+                                )
+                                    .prop_map(
+                                        |(data, mut offsets, validity)| {
+                                            offsets = offsets
+                                                .into_iter()
+                                                .map(|o| {
+                                                    o * std::mem::size_of::<C>()
+                                                        as u64
+                                                })
+                                                .collect::<Vec<u64>>();
+                                            offsets.sort();
+                                            RawReadOutput {
+                                                nvalues: offsets.len(),
+                                                nbytes: data.len()
+                                                    * std::mem::size_of::<C>(),
+                                                input: QueryBuffers {
+                                                    data: data.into(),
+                                                    cell_offsets: Some(
+                                                        offsets.into(),
+                                                    ),
+                                                    validity: validity
+                                                        .map(|v| v.into()),
+                                                },
+                                            }
+                                        },
+                                    )
+                            },
+                        )
+                        .boxed()
+                } else {
+                    let max_values = if let Some(v) = validity.as_ref() {
+                        std::cmp::min(data.len(), v.len())
+                    } else {
+                        data.len()
+                    };
+
+                    (0..=max_values, Just(data), Just(validity))
+                        .prop_map(|(nvalues, data, validity)| {
+                            let nbytes = nvalues * std::mem::size_of::<C>();
+                            RawReadOutput {
+                                nvalues,
+                                nbytes,
+                                input: QueryBuffers {
+                                    data: data.into(),
+                                    cell_offsets: None,
+                                    validity: validity.map(|v| v.into()),
+                                },
+                            }
+                        })
+                        .boxed()
+                }
+            })
+            .boxed()
+    }
+}
+
+impl<'data> Arbitrary for TypedRawReadOutput<'data> {
+    type Parameters = Option<Datatype>;
+    type Strategy = BoxedStrategy<TypedRawReadOutput<'data>>;
+
+    fn arbitrary_with(params: Self::Parameters) -> Self::Strategy {
+        let strategy_datatype = if let Some(datatype) = params {
+            Just(datatype).boxed()
+        } else {
+            any::<Datatype>().boxed()
+        };
+
+        strategy_datatype
+            .prop_flat_map(|datatype| {
+                fn_typed!(
+                    datatype,
+                    DT,
+                    any::<RawReadOutput<DT>>()
+                        .prop_map(
+                            #[allow(clippy::redundant_closure)]
+                            |rr| TypedRawReadOutput::from(rr)
+                        )
+                        .boxed()
+                )
+            })
+            .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::proptest;
+
+    fn arbitrary_raw_read_handle<C>(rr: RawReadOutput<C>) {
+        if let Some(offsets) = rr.input.cell_offsets {
+            assert!(
+                rr.nbytes <= std::mem::size_of_val(rr.input.data.as_ref()),
+                "nbytes = {}, data.bytelen() = {}",
+                rr.nbytes,
+                std::mem::size_of_val(rr.input.data.as_ref())
+            );
+
+            let offsets = offsets.as_ref().to_vec();
+            assert!(
+                rr.nvalues <= offsets.len(),
+                "nvalues = {}, offsets.len() = {}",
+                rr.nvalues,
+                offsets.len()
+            );
+
+            // offsets are in bytes and are sorted
+            for w in offsets.windows(2) {
+                assert!(w[0] <= w[1]);
+
+                let delta = w[1] - w[0];
+                assert_eq!(0, delta % std::mem::size_of::<C>() as u64);
+            }
+
+            // offsets must be valid into `data`
+            if rr.nvalues > 0 {
+                let last_offset = offsets[rr.nvalues - 1];
+                let byte_bound =
+                    std::mem::size_of_val(rr.input.data.as_ref()) as u64;
+                assert!(
+                    last_offset <= rr.nbytes as u64,
+                    "last_offset = {}, nbytes = {}",
+                    last_offset,
+                    rr.nbytes
+                );
+                assert!(
+                    last_offset <= byte_bound,
+                    "last_offset = {}, byte_bound = {}",
+                    last_offset,
+                    byte_bound
+                );
+            }
+        } else {
+            assert!(
+                rr.nvalues <= rr.input.data.len(),
+                "nvalues = {}, data.len() = {}",
+                rr.nvalues,
+                rr.input.data.len()
+            );
+        }
+
+        if let Some(validity) = rr.input.validity {
+            let validity = validity.as_ref().to_vec();
+            assert!(
+                rr.nvalues <= validity.len(),
+                "nvalues = {}, validity.len() = {}",
+                rr.nvalues,
+                validity.len()
+            );
+
+            for v in validity.iter() {
+                assert!(*v == 0 || *v == 1);
+            }
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn arbitrary_raw_read_handle_u8(rr in any::<RawReadOutput<u8>>()) {
+            arbitrary_raw_read_handle::<u8>(rr);
+        }
+
+        #[test]
+        fn arbitrary_raw_read_handle_u16(rr in any::<RawReadOutput<u16>>()) {
+            arbitrary_raw_read_handle::<u16>(rr);
+        }
+
+        #[test]
+        fn arbitrary_raw_read_handle_u32(rr in any::<RawReadOutput<u32>>()) {
+            arbitrary_raw_read_handle::<u32>(rr);
+        }
+
+        #[test]
+        fn arbitrary_raw_read_handle_u64(rr in any::<RawReadOutput<u64>>()) {
+            arbitrary_raw_read_handle::<u64>(rr);
+        }
+
+        #[test]
+        fn arbitrary_raw_read_handle_f32(rr in any::<RawReadOutput<f32>>()) {
+            arbitrary_raw_read_handle::<f32>(rr);
+        }
+
+        #[test]
+        fn arbitrary_raw_read_handle_f64(rr in any::<RawReadOutput<f64>>()) {
+            arbitrary_raw_read_handle::<f64>(rr);
+        }
+    }
+}

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -104,8 +104,10 @@ impl From<&TypedRawReadOutput<'_>> for FieldData {
     }
 }
 
+#[macro_export]
 macro_rules! typed_field_data_go {
-    ($field:expr, $DT:ident, $data:pat, $then:expr) => {
+    ($field:expr, $DT:ident, $data:pat, $then:expr) => {{
+        use $crate::query::write::strategy::FieldData;
         match $field {
             FieldData::UInt8($data) => {
                 type $DT = Vec<u8>;
@@ -188,8 +190,9 @@ macro_rules! typed_field_data_go {
                 $then
             }
         }
-    };
-    ($lexpr:expr, $rexpr:expr, $DT:ident, $lpat:pat, $rpat:pat, $same_type:expr, $else:expr) => {
+    }};
+    ($lexpr:expr, $rexpr:expr, $DT:ident, $lpat:pat, $rpat:pat, $same_type:expr, $else:expr) => {{
+        use $crate::query::write::strategy::FieldData;
         match ($lexpr, $rexpr) {
             (FieldData::UInt8($lpat), FieldData::UInt8($rpat)) => {
                 type $DT = Vec<u8>;
@@ -273,7 +276,7 @@ macro_rules! typed_field_data_go {
             }
             _ => $else,
         }
-    };
+    }};
 }
 
 impl FieldData {
@@ -334,7 +337,7 @@ impl ReadCallbackVarArg for RawResultCallback {
 
 #[derive(Clone, Debug)]
 pub struct WriteQueryData {
-    fields: HashMap<String, FieldData>,
+    pub fields: HashMap<String, FieldData>,
 }
 
 impl WriteQueryData {

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -84,7 +84,7 @@ impl From<&TypedRawReadOutput<'_>> for FieldData {
             let rr = RawReadOutput {
                 nvalues: value.nvalues,
                 nbytes: value.nbytes,
-                input: handle,
+                input: handle.borrow(),
             };
             if rr.input.cell_offsets.is_some() {
                 Self::from(

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -78,6 +78,17 @@ typed_field_data!(UInt8: u8, UInt16: u16, UInt32: u32, UInt64: u64);
 typed_field_data!(Int8: i8, Int16: i16, Int32: i32, Int64: i64);
 typed_field_data!(Float32: f32, Float64: f64);
 
+impl From<Vec<String>> for FieldData {
+    fn from(value: Vec<String>) -> Self {
+        FieldData::from(
+            value
+                .into_iter()
+                .map(|s| s.into_bytes())
+                .collect::<Vec<Vec<u8>>>(),
+        )
+    }
+}
+
 impl From<&TypedRawReadOutput<'_>> for FieldData {
     fn from(value: &TypedRawReadOutput) -> Self {
         typed_query_buffers_go!(value.buffers, DT, ref handle, {

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -110,171 +110,171 @@ macro_rules! typed_field_data_go {
         use $crate::query::write::strategy::FieldData;
         match $field {
             FieldData::UInt8($data) => {
-                type $DT = Vec<u8>;
+                type $DT = u8;
                 $fixed
             }
             FieldData::UInt16($data) => {
-                type $DT = Vec<u16>;
+                type $DT = u16;
                 $fixed
             }
             FieldData::UInt32($data) => {
-                type $DT = Vec<u32>;
+                type $DT = u32;
                 $fixed
             }
             FieldData::UInt64($data) => {
-                type $DT = Vec<u64>;
+                type $DT = u64;
                 $fixed
             }
             FieldData::Int8($data) => {
-                type $DT = Vec<i8>;
+                type $DT = i8;
                 $fixed
             }
             FieldData::Int16($data) => {
-                type $DT = Vec<i16>;
+                type $DT = i16;
                 $fixed
             }
             FieldData::Int32($data) => {
-                type $DT = Vec<i32>;
+                type $DT = i32;
                 $fixed
             }
             FieldData::Int64($data) => {
-                type $DT = Vec<i64>;
+                type $DT = i64;
                 $fixed
             }
             FieldData::Float32($data) => {
-                type $DT = Vec<f32>;
+                type $DT = f32;
                 $fixed
             }
             FieldData::Float64($data) => {
-                type $DT = Vec<f64>;
+                type $DT = f64;
                 $fixed
             }
             FieldData::VecUInt8($data) => {
-                type $DT = Vec<Vec<u8>>;
+                type $DT = u8;
                 $var
             }
             FieldData::VecUInt16($data) => {
-                type $DT = Vec<Vec<u16>>;
+                type $DT = u16;
                 $var
             }
             FieldData::VecUInt32($data) => {
-                type $DT = Vec<Vec<u32>>;
+                type $DT = u32;
                 $var
             }
             FieldData::VecUInt64($data) => {
-                type $DT = Vec<Vec<u64>>;
+                type $DT = u64;
                 $var
             }
             FieldData::VecInt8($data) => {
-                type $DT = Vec<Vec<i8>>;
+                type $DT = i8;
                 $var
             }
             FieldData::VecInt16($data) => {
-                type $DT = Vec<Vec<i16>>;
+                type $DT = i16;
                 $var
             }
             FieldData::VecInt32($data) => {
-                type $DT = Vec<Vec<i32>>;
+                type $DT = i32;
                 $var
             }
             FieldData::VecInt64($data) => {
-                type $DT = Vec<Vec<i64>>;
+                type $DT = i64;
                 $var
             }
             FieldData::VecFloat32($data) => {
-                type $DT = Vec<Vec<f32>>;
+                type $DT = f32;
                 $var
             }
             FieldData::VecFloat64($data) => {
-                type $DT = Vec<Vec<f64>>;
+                type $DT = f64;
                 $var
             }
         }
     }};
-    ($field:expr, $DT:ident, $data:pat, $then:expr) => {
-        typed_field_data_go!($field, $DT, $data, $then, $then)
+    ($field:expr, $data:pat, $then:expr) => {
+        typed_field_data_go!($field, _DT, $data, $then, $then)
     };
     ($lexpr:expr, $rexpr:expr, $DT:ident, $lpat:pat, $rpat:pat, $same_type:expr, $else:expr) => {{
         use $crate::query::write::strategy::FieldData;
         match ($lexpr, $rexpr) {
             (FieldData::UInt8($lpat), FieldData::UInt8($rpat)) => {
-                type $DT = Vec<u8>;
+                type $DT = u8;
                 $same_type
             }
             (FieldData::UInt16($lpat), FieldData::UInt16($rpat)) => {
-                type $DT = Vec<u16>;
+                type $DT = u16;
                 $same_type
             }
             (FieldData::UInt32($lpat), FieldData::UInt32($rpat)) => {
-                type $DT = Vec<u32>;
+                type $DT = u32;
                 $same_type
             }
             (FieldData::UInt64($lpat), FieldData::UInt64($rpat)) => {
-                type $DT = Vec<u64>;
+                type $DT = u64;
                 $same_type
             }
             (FieldData::Int8($lpat), FieldData::Int8($rpat)) => {
-                type $DT = Vec<i8>;
+                type $DT = i8;
                 $same_type
             }
             (FieldData::Int16($lpat), FieldData::Int16($rpat)) => {
-                type $DT = Vec<i16>;
+                type $DT = i16;
                 $same_type
             }
             (FieldData::Int32($lpat), FieldData::Int32($rpat)) => {
-                type $DT = Vec<i32>;
+                type $DT = i32;
                 $same_type
             }
             (FieldData::Int64($lpat), FieldData::Int64($rpat)) => {
-                type $DT = Vec<i64>;
+                type $DT = i64;
                 $same_type
             }
             (FieldData::Float32($lpat), FieldData::Float32($rpat)) => {
-                type $DT = Vec<f32>;
+                type $DT = f32;
                 $same_type
             }
             (FieldData::Float64($lpat), FieldData::Float64($rpat)) => {
-                type $DT = Vec<f64>;
+                type $DT = f64;
                 $same_type
             }
             (FieldData::VecUInt8($lpat), FieldData::VecUInt8($rpat)) => {
-                type $DT = Vec<Vec<u8>>;
+                type $DT = u8;
                 $same_type
             }
             (FieldData::VecUInt16($lpat), FieldData::VecUInt16($rpat)) => {
-                type $DT = Vec<Vec<u16>>;
+                type $DT = u16;
                 $same_type
             }
             (FieldData::VecUInt32($lpat), FieldData::VecUInt32($rpat)) => {
-                type $DT = Vec<Vec<u32>>;
+                type $DT = u32;
                 $same_type
             }
             (FieldData::VecUInt64($lpat), FieldData::VecUInt64($rpat)) => {
-                type $DT = Vec<Vec<u64>>;
+                type $DT = u64;
                 $same_type
             }
             (FieldData::VecInt8($lpat), FieldData::VecInt8($rpat)) => {
-                type $DT = Vec<Vec<i8>>;
+                type $DT = i8;
                 $same_type
             }
             (FieldData::VecInt16($lpat), FieldData::VecInt16($rpat)) => {
-                type $DT = Vec<Vec<i16>>;
+                type $DT = i16;
                 $same_type
             }
             (FieldData::VecInt32($lpat), FieldData::VecInt32($rpat)) => {
-                type $DT = Vec<Vec<i32>>;
+                type $DT = i32;
                 $same_type
             }
             (FieldData::VecInt64($lpat), FieldData::VecInt64($rpat)) => {
-                type $DT = Vec<Vec<i64>>;
+                type $DT = i64;
                 $same_type
             }
             (FieldData::VecFloat32($lpat), FieldData::VecFloat32($rpat)) => {
-                type $DT = Vec<Vec<f32>>;
+                type $DT = f32;
                 $same_type
             }
             (FieldData::VecFloat64($lpat), FieldData::VecFloat64($rpat)) => {
-                type $DT = Vec<Vec<f64>>;
+                type $DT = f64;
                 $same_type
             }
             _ => $else,
@@ -284,15 +284,15 @@ macro_rules! typed_field_data_go {
 
 impl FieldData {
     pub fn is_empty(&self) -> bool {
-        typed_field_data_go!(self, _DT, v, v.is_empty())
+        typed_field_data_go!(self, v, v.is_empty())
     }
 
     pub fn len(&self) -> usize {
-        typed_field_data_go!(self, _DT, v, v.len())
+        typed_field_data_go!(self, v, v.len())
     }
 
     pub fn filter(&self, set: &VarBitSet) -> FieldData {
-        typed_field_data_go!(self, _DT, ref values, {
+        typed_field_data_go!(self, ref values, {
             FieldData::from(
                 values
                     .clone()
@@ -350,12 +350,7 @@ impl WriteQueryData {
     ) -> TileDBResult<WriteBuilder<'ctx, 'data>> {
         let mut b = b;
         for f in self.fields.iter() {
-            b = typed_field_data_go!(
-                f.1,
-                DT,
-                data,
-                b.data_typed::<_, DT>(f.0, data)
-            )?;
+            b = typed_field_data_go!(f.1, data, b.data_typed(f.0, data))?;
         }
         Ok(b)
     }
@@ -911,7 +906,7 @@ mod tests {
                                 };
 
                                 let wdata =
-                                    typed_field_data_go!(wdata, _DT, wdata, {
+                                    typed_field_data_go!(wdata, wdata, {
                                         FieldData::from(
                                             wdata[cursors[key]
                                                 ..cursors[key] + nv]

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -313,7 +313,7 @@ impl ReadCallbackVarArg for RawResultCallback {
 
     fn intermediate_result(
         &mut self,
-        args: &[TypedRawReadOutput],
+        args: Vec<TypedRawReadOutput>,
     ) -> Result<Self::Intermediate, Self::Error> {
         Ok(RawReadQueryResult(
             self.field_order
@@ -326,7 +326,7 @@ impl ReadCallbackVarArg for RawResultCallback {
 
     fn final_result(
         mut self,
-        args: &[TypedRawReadOutput],
+        args: Vec<TypedRawReadOutput>,
     ) -> Result<Self::Intermediate, Self::Error> {
         self.intermediate_result(args)
     }

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -106,91 +106,94 @@ impl From<&TypedRawReadOutput<'_>> for FieldData {
 
 #[macro_export]
 macro_rules! typed_field_data_go {
-    ($field:expr, $DT:ident, $data:pat, $then:expr) => {{
+    ($field:expr, $DT:ident, $data:pat, $fixed:expr, $var:expr) => {{
         use $crate::query::write::strategy::FieldData;
         match $field {
             FieldData::UInt8($data) => {
                 type $DT = Vec<u8>;
-                $then
+                $fixed
             }
             FieldData::UInt16($data) => {
                 type $DT = Vec<u16>;
-                $then
+                $fixed
             }
             FieldData::UInt32($data) => {
                 type $DT = Vec<u32>;
-                $then
+                $fixed
             }
             FieldData::UInt64($data) => {
                 type $DT = Vec<u64>;
-                $then
+                $fixed
             }
             FieldData::Int8($data) => {
                 type $DT = Vec<i8>;
-                $then
+                $fixed
             }
             FieldData::Int16($data) => {
                 type $DT = Vec<i16>;
-                $then
+                $fixed
             }
             FieldData::Int32($data) => {
                 type $DT = Vec<i32>;
-                $then
+                $fixed
             }
             FieldData::Int64($data) => {
                 type $DT = Vec<i64>;
-                $then
+                $fixed
             }
             FieldData::Float32($data) => {
                 type $DT = Vec<f32>;
-                $then
+                $fixed
             }
             FieldData::Float64($data) => {
                 type $DT = Vec<f64>;
-                $then
+                $fixed
             }
             FieldData::VecUInt8($data) => {
                 type $DT = Vec<Vec<u8>>;
-                $then
+                $var
             }
             FieldData::VecUInt16($data) => {
                 type $DT = Vec<Vec<u16>>;
-                $then
+                $var
             }
             FieldData::VecUInt32($data) => {
                 type $DT = Vec<Vec<u32>>;
-                $then
+                $var
             }
             FieldData::VecUInt64($data) => {
                 type $DT = Vec<Vec<u64>>;
-                $then
+                $var
             }
             FieldData::VecInt8($data) => {
                 type $DT = Vec<Vec<i8>>;
-                $then
+                $var
             }
             FieldData::VecInt16($data) => {
                 type $DT = Vec<Vec<i16>>;
-                $then
+                $var
             }
             FieldData::VecInt32($data) => {
                 type $DT = Vec<Vec<i32>>;
-                $then
+                $var
             }
             FieldData::VecInt64($data) => {
                 type $DT = Vec<Vec<i64>>;
-                $then
+                $var
             }
             FieldData::VecFloat32($data) => {
                 type $DT = Vec<Vec<f32>>;
-                $then
+                $var
             }
             FieldData::VecFloat64($data) => {
                 type $DT = Vec<Vec<f64>>;
-                $then
+                $var
             }
         }
     }};
+    ($field:expr, $DT:ident, $data:pat, $then:expr) => {
+        typed_field_data_go!($field, $DT, $data, $then, $then)
+    };
     ($lexpr:expr, $rexpr:expr, $DT:ident, $lpat:pat, $rpat:pat, $same_type:expr, $else:expr) => {{
         use $crate::query::write::strategy::FieldData;
         match ($lexpr, $rexpr) {


### PR DESCRIPTION
Proptest is used for testing.

RawReadOutput could be either a primitive array or a generic list array.  Arrow `RecordBatch` is just looking for `Arc<dyn Array>`, so we use that as the arrow array output type.