### PR TITLE
Change RawReadOutput::nvalues to RawReadOutput::ncells

### DIFF
--- a/tiledb/api/src/array/schema/mod.rs
+++ b/tiledb/api/src/array/schema/mod.rs
@@ -85,6 +85,15 @@ impl CellValNum {
     pub fn is_var_sized(&self) -> bool {
         matches!(self, CellValNum::Var)
     }
+
+    /// Return the fixed number of values per cell, if not variable.
+    pub fn fixed(&self) -> Option<NonZeroU32> {
+        if let CellValNum::Fixed(nz) = self {
+            Some(*nz)
+        } else {
+            None
+        }
+    }
 }
 
 impl Default for CellValNum {

--- a/tiledb/api/src/query/buffer.rs
+++ b/tiledb/api/src/query/buffer.rs
@@ -97,6 +97,15 @@ impl<'data> CellStructure<'data> {
         }
     }
 
+    /// Return the fixed number of values per cell, if not variable.
+    pub fn fixed(&self) -> Option<NonZeroU32> {
+        if let Self::Fixed(nz) = self {
+            Some(*nz)
+        } else {
+            None
+        }
+    }
+
     /// Returns a reference to the offsets buffer, if any.
     pub fn offsets_ref(&self) -> Option<&[u64]> {
         if let Self::Var(ref offsets) = self {
@@ -280,6 +289,15 @@ impl<'data> CellStructureMut<'data> {
     pub fn unwrap(self) -> Option<BufferMut<'data, u64>> {
         if let Self::Var(offsets) = self {
             Some(offsets)
+        } else {
+            None
+        }
+    }
+
+    /// Return the fixed number of values per cell, if not variable.
+    pub fn fixed(&self) -> Option<NonZeroU32> {
+        if let Self::Fixed(nz) = self {
+            Some(*nz)
         } else {
             None
         }

--- a/tiledb/api/src/query/read/callback.rs
+++ b/tiledb/api/src/query/read/callback.rs
@@ -471,7 +471,7 @@ macro_rules! query_read_callback {
                                 .map_err(|e| {
                                     let fields = paste! {
                                         vec![$(
-                                            self.[< arg_ $U:snake >].field.clone()
+                                            self.[< arg_ $U:snake >].field.name.clone()
                                         ),+]
                                     };
                                     crate::error::Error::QueryCallback(fields, anyhow!(e))
@@ -496,7 +496,7 @@ macro_rules! query_read_callback {
                                 .map_err(|e| {
                                     let fields = paste! {
                                         vec![$(
-                                            self.[< arg_ $U:snake >].field.clone()
+                                            self.[< arg_ $U:snake >].field.name.clone()
                                         ),+]
                                     };
                                     crate::error::Error::QueryCallback(fields, anyhow!(e))
@@ -620,15 +620,19 @@ where
                     .base
                     .raw_read_output
                     .iter()
-                    .map(|r| r.borrow_mut())
-                    .collect::<Vec<RefTypedQueryBuffersMut>>();
+                    .map(|r| (r.field(), r.borrow_mut()))
+                    .collect::<Vec<(&FieldMetadata, RefTypedQueryBuffersMut)>>(
+                    );
                 let args = sizes
                     .iter()
                     .zip(buffers.iter())
-                    .map(|(&(nvalues, nbytes), buffers)| TypedRawReadOutput {
-                        nvalues,
-                        nbytes,
-                        buffers: buffers.as_shared(),
+                    .map(|(&(nvalues, nbytes), (field, buffers))| {
+                        TypedRawReadOutput {
+                            nvalues,
+                            nbytes,
+                            buffers: buffers.as_shared(),
+                            datatype: field.datatype,
+                        }
                     })
                     .collect::<Vec<TypedRawReadOutput>>();
 
@@ -637,7 +641,7 @@ where
                         .base
                         .raw_read_output
                         .iter()
-                        .map(|rh| rh.field().clone())
+                        .map(|rh| rh.field().name.clone())
                         .collect::<Vec<String>>();
                     crate::error::Error::QueryCallback(fields, anyhow!(e))
                 })?;
@@ -656,15 +660,19 @@ where
                     .base
                     .raw_read_output
                     .iter()
-                    .map(|r| r.borrow_mut())
-                    .collect::<Vec<RefTypedQueryBuffersMut>>();
+                    .map(|r| (r.field(), r.borrow_mut()))
+                    .collect::<Vec<(&FieldMetadata, RefTypedQueryBuffersMut)>>(
+                    );
                 let args = sizes
                     .iter()
                     .zip(buffers.iter())
-                    .map(|(&(nvalues, nbytes), buffers)| TypedRawReadOutput {
-                        nvalues,
-                        nbytes,
-                        buffers: buffers.as_shared(),
+                    .map(|(&(nvalues, nbytes), (field, buffers))| {
+                        TypedRawReadOutput {
+                            nvalues,
+                            nbytes,
+                            buffers: buffers.as_shared(),
+                            datatype: field.datatype,
+                        }
                     })
                     .collect::<Vec<TypedRawReadOutput>>();
 
@@ -673,7 +681,7 @@ where
                         .base
                         .raw_read_output
                         .iter()
-                        .map(|rh| rh.field().clone())
+                        .map(|rh| rh.field().name.clone())
                         .collect::<Vec<String>>();
                     crate::error::Error::QueryCallback(fields, anyhow!(e))
                 })?;

--- a/tiledb/api/src/query/read/callback.rs
+++ b/tiledb/api/src/query/read/callback.rs
@@ -226,9 +226,7 @@ mod impls {
             &mut self,
             arg: RawReadOutput<Self::Unit>,
         ) -> Result<Self::Intermediate, Self::Error> {
-            let nvalues = arg.ncells
-                * arg.input.cell_structure.fixed().unwrap().get() as usize;
-            self.extend_from_slice(&arg.input.data.as_ref()[0..nvalues]);
+            self.extend_from_slice(&arg.input.data.as_ref()[0..arg.nvalues()]);
             Ok(())
         }
 
@@ -253,10 +251,8 @@ mod impls {
             &mut self,
             arg: RawReadOutput<Self::Unit>,
         ) -> Result<Self::Intermediate, Self::Error> {
-            let nvalues = arg.ncells
-                * arg.input.cell_structure.fixed().unwrap().get() as usize;
             self.0
-                .extend_from_slice(&arg.input.data.as_ref()[0..nvalues]);
+                .extend_from_slice(&arg.input.data.as_ref()[0..arg.nvalues()]);
             // TileDB Core currently ensures that all buffers are properly set
             // as required. Thus, this unwrap should never fail as its only
             // called after submit has returned successfully.

--- a/tiledb/api/src/query/read/output/strategy.rs
+++ b/tiledb/api/src/query/read/output/strategy.rs
@@ -318,9 +318,8 @@ mod tests {
                 }
             }
             CellStructure::Fixed(nz) => {
-                let nvalues = rr.ncells * nz.get() as usize;
                 assert!(
-                    nvalues <= rr.input.data.len(),
+                    rr.nvalues() <= rr.input.data.len(),
                     "ncells = {}, cell_val_num = {}, data.len() = {}",
                     rr.ncells,
                     nz.get(),

--- a/tiledb/api/src/query/read/raw.rs
+++ b/tiledb/api/src/query/read/raw.rs
@@ -2,11 +2,14 @@ use super::*;
 
 use std::cell::RefMut;
 
+use crate::array::schema::Field;
+use crate::array::CellValNum;
 use crate::error::Error;
 use crate::query::buffer::{
     CellStructureMut, QueryBuffersMut, RefTypedQueryBuffersMut,
 };
 use crate::query::read::output::ScratchSpace;
+use crate::Datatype;
 
 pub struct ManagedBuffer<'data, C> {
     pub buffers: Pin<Box<RefCell<QueryBuffersMut<'data, C>>>>,
@@ -48,10 +51,28 @@ impl<'data, C> From<Box<dyn ScratchAllocator<C> + 'data>>
     }
 }
 
+/// Metadata providing additional context for a field in a read query
+pub struct FieldMetadata {
+    pub name: String,
+    pub datatype: Datatype,
+    pub cell_val_num: CellValNum,
+}
+
+impl TryFrom<&Field<'_>> for FieldMetadata {
+    type Error = Error;
+    fn try_from(value: &Field<'_>) -> TileDBResult<Self> {
+        Ok(FieldMetadata {
+            name: value.name()?,
+            datatype: value.datatype()?,
+            cell_val_num: value.cell_val_num()?,
+        })
+    }
+}
+
 /// Encapsulates data for writing intermediate query results for a data field.
 pub struct RawReadHandle<'data, C> {
-    /// Name of the field which this handle receives data from
-    pub field: String,
+    /// Metadata describing the field which this handle receives data from
+    pub field: FieldMetadata,
 
     /// As input to the C API, the size of the data buffer.
     /// As output from the C API, the size in bytes of an intermediate result.
@@ -80,13 +101,10 @@ pub struct RawReadHandle<'data, C> {
 }
 
 impl<'data, C> RawReadHandle<'data, C> {
-    pub fn new<S>(
-        field: S,
+    pub fn new(
+        field: FieldMetadata,
         location: &'data RefCell<QueryBuffersMut<'data, C>>,
-    ) -> Self
-    where
-        S: AsRef<str>,
-    {
+    ) -> Self {
         let (data, cell_offsets, validity) = {
             let mut scratch: RefMut<QueryBuffersMut<'data, C>> =
                 location.borrow_mut();
@@ -120,7 +138,7 @@ impl<'data, C> RawReadHandle<'data, C> {
         });
 
         RawReadHandle {
-            field: field.as_ref().to_string(),
+            field,
             data_size,
             offsets_size,
             validity_size,
@@ -129,10 +147,10 @@ impl<'data, C> RawReadHandle<'data, C> {
         }
     }
 
-    pub fn managed<S>(field: S, managed: ManagedBuffer<'data, C>) -> Self
-    where
-        S: AsRef<str>,
-    {
+    pub fn managed(
+        field: FieldMetadata,
+        managed: ManagedBuffer<'data, C>,
+    ) -> Self {
         let qb = {
             let qb: Pin<&RefCell<QueryBuffersMut<'data, C>>> =
                 managed.buffers.as_ref();
@@ -164,7 +182,7 @@ impl<'data, C> RawReadHandle<'data, C> {
         context: &Context,
         c_query: *mut ffi::tiledb_query_t,
     ) -> TileDBResult<()> {
-        let c_name = cstring!(&*self.field);
+        let c_name = cstring!(&*self.field.name);
 
         let mut location = self.location.borrow_mut();
 
@@ -312,7 +330,7 @@ macro_rules! typed_read_handle_go {
 }
 
 impl<'data> TypedReadHandle<'data> {
-    pub fn field(&self) -> &String {
+    pub fn field(&self) -> &FieldMetadata {
         typed_read_handle_go!(self, _DT, handle, &handle.field)
     }
 

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -16,7 +16,7 @@ use crate::query::read::output::{
     FixedDataIterator, RawReadOutput, TypedRawReadOutput, VarDataIterator,
 };
 use crate::query::read::{
-    CallbackVarArgReadBuilder, ManagedBuffer, RawReadHandle,
+    CallbackVarArgReadBuilder, FieldMetadata, ManagedBuffer, RawReadHandle,
     ReadCallbackVarArg, TypedReadHandle,
 };
 use crate::{fn_typed, typed_query_buffers_go};
@@ -381,7 +381,8 @@ impl WriteQueryData {
                         let managed: ManagedBuffer<DT> = ManagedBuffer::new(
                             field.query_scratch_allocator().unwrap(),
                         );
-                        let rr = RawReadHandle::managed(name, managed);
+                        let metadata = FieldMetadata::try_from(&field).unwrap();
+                        let rr = RawReadHandle::managed(metadata, managed);
                         TypedReadHandle::from(rr)
                     })
                 })

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -89,7 +89,7 @@ impl From<&TypedRawReadOutput<'_>> for FieldData {
     fn from(value: &TypedRawReadOutput) -> Self {
         typed_query_buffers_go!(value.buffers, DT, ref handle, {
             let rr = RawReadOutput {
-                nvalues: value.nvalues,
+                ncells: value.ncells,
                 nbytes: value.nbytes,
                 input: handle.borrow(),
             };
@@ -930,15 +930,15 @@ mod tests {
                         None => unimplemented!(), /* TODO: allocate more */
                         Some((raw, _)) => {
                             let raw = &raw.0;
-                            let mut nvalues = None;
+                            let mut ncells = None;
                             for (key, rdata) in raw.iter() {
                                 let wdata = &accumulated_write.fields[key];
 
-                                let nv = if let Some(nv) = nvalues {
+                                let nv = if let Some(nv) = ncells {
                                     assert_eq!(nv, rdata.len());
                                     nv
                                 } else {
-                                    nvalues = Some(rdata.len());
+                                    ncells = Some(rdata.len());
                                     rdata.len()
                                 };
 


### PR DESCRIPTION
This is a probably not necessary but nevertheless useful step towards fixing up `CellValNum::Var` compatibility with arrow.  Users reading buffers will need to determine the number of cells and the number of values written.  Previously that determination could be made by dividing the number of values by the cell val num. This request flips it so that instead the number of values is determined by mulitplying the number of cells by the cell val num.  I consider multiplication to be a much more comfortable operation than division so this is a nice user-friendly change.