### PR TITLE
Configure queries to return arrow-like results, i.e. "extra" offset and element offsets; remove RawReadOutput::nbytes

### DIFF
--- a/tiledb/api/examples/reading_incomplete.rs
+++ b/tiledb/api/examples/reading_incomplete.rs
@@ -199,9 +199,7 @@ fn read_array_step() -> TileDBResult<()> {
         let res = qq.step()?;
         let final_result = res.is_final();
 
-        if let Some((n_a2, b_a2, (n_a1, _, (n_cols, _, (n_rows, _, _))))) =
-            res.into_inner()
-        {
+        if let Some((n_a2, (n_a1, (n_cols, (n_rows, _))))) = res.into_inner() {
             let rows =
                 Ref::map(rows_output.borrow(), |o| &o.data.as_ref()[0..n_rows]);
             let cols =
@@ -211,7 +209,7 @@ fn read_array_step() -> TileDBResult<()> {
 
             let char_output: Ref<QueryBuffersMut<u8>> = char_output.borrow();
             let char_output: QueryBuffers<u8> = char_output.as_shared();
-            let a2 = VarDataIterator::new(n_a2, b_a2, char_output)
+            let a2 = VarDataIterator::new(n_a2, char_output)
                 .expect("Expected variable data offsets")
                 .map(|bytes| String::from_utf8_lossy(bytes).to_string());
 

--- a/tiledb/api/src/query/mod.rs
+++ b/tiledb/api/src/query/mod.rs
@@ -217,6 +217,7 @@ impl<'ctx> BuilderBase<'ctx> {
         array.capi_call(|ctx| unsafe {
             ffi::tiledb_query_alloc(ctx, c_array, c_query_type, &mut c_query)
         })?;
+
         Ok(BuilderBase {
             query: QueryBase {
                 array,

--- a/tiledb/api/src/query/read/output/mod.rs
+++ b/tiledb/api/src/query/read/output/mod.rs
@@ -703,8 +703,8 @@ impl<'data, C> Iterator for VarDataIterator<'data, C> {
 
         if s < self.ncells {
             let start = offset_buffer[s] as usize;
-            let slen = offset_buffer[s + 1] as usize - start;
-            Some(&data_buffer[start..start + slen])
+            let end = offset_buffer[s + 1] as usize;
+            Some(&data_buffer[start..end])
         } else {
             None
         }

--- a/tiledb/api/src/query/read/raw.rs
+++ b/tiledb/api/src/query/read/raw.rs
@@ -254,10 +254,15 @@ impl<'data, C> RawReadHandle<'data, C> {
     pub fn last_read_ncells(&self) -> usize {
         let ncells = match self.field.cell_val_num {
             CellValNum::Fixed(nz) => {
+                let nz = nz.get() as usize;
+
                 assert!(self.offsets_size.is_none());
                 let data_size = *self.data_size as usize;
-                assert_eq!(0, data_size % nz.get() as usize);
-                data_size / nz.get() as usize
+                let nvalues = data_size / nz / std::mem::size_of::<C>();
+
+                // assumption: core gives us an integral number of cells
+                assert_eq!(data_size, nvalues * nz * std::mem::size_of::<C>());
+                nvalues
             }
             CellValNum::Var => {
                 let offsets_size = **self.offsets_size.as_ref().unwrap();

--- a/tiledb/api/src/query/read/raw.rs
+++ b/tiledb/api/src/query/read/raw.rs
@@ -265,11 +265,22 @@ impl<'data, C> RawReadHandle<'data, C> {
                 nvalues
             }
             CellValNum::Var => {
-                let offsets_size = **self.offsets_size.as_ref().unwrap();
-                if offsets_size == 0 {
+                let offsets_size =
+                    **self.offsets_size.as_ref().unwrap() as usize;
+                let noffsets = offsets_size / std::mem::size_of::<u64>();
+
+                // assumption: core isn't lying about giving us u64 offsets
+                assert_eq!(offsets_size, noffsets * std::mem::size_of::<u64>());
+
+                /*
+                 * We use the "extra_offsets" mode.
+                 * Note that the core does not add a zero offset if
+                 * the result set is empty.
+                 */
+                if noffsets == 0 {
                     0
                 } else {
-                    (offsets_size - 1) as usize
+                    noffsets - 1
                 }
             }
         };

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -90,7 +90,6 @@ impl From<&TypedRawReadOutput<'_>> for FieldData {
         typed_query_buffers_go!(value.buffers, DT, ref handle, {
             let rr = RawReadOutput {
                 ncells: value.ncells,
-                nbytes: value.nbytes,
                 input: handle.borrow(),
             };
             if rr.input.cell_structure.is_var() {


### PR DESCRIPTION
Our primary use case requires us to manifest arrow record batches.  Core has an option to produce arrow-like offsets, so let's use those options instead of re-rolling them ourselves in the Rust layer.

But even on top of that, it makes a lot of sense with the current API design to use element-based offsets.  The buffers we attach to the query API express themselves in terms of a `Unit` type which is some primitive.  By using the element offsets we save the effort from doing arithmetic from the returned query sizes.

The `extra_offset` configuration also enables us to eliminate the `RawReadOutput::nbytes` field, which is now redundant with the last offset.  This change makes the `RawReadOutput` easier to use.