### PR TITLE
Fix minor bugs

### DIFF
--- a/tiledb/api/src/datatype/mod.rs
+++ b/tiledb/api/src/datatype/mod.rs
@@ -366,7 +366,7 @@ impl Datatype {
     pub fn is_byte_type(&self) -> bool {
         matches!(
             *self,
-            Datatype::Boolean | Datatype::GeometryWkb | Datatype::GeometryWkt
+            Datatype::Blob | Datatype::GeometryWkb | Datatype::GeometryWkt
         )
     }
 

--- a/tiledb/api/src/filter/mod.rs
+++ b/tiledb/api/src/filter/mod.rs
@@ -223,24 +223,13 @@ impl FilterData {
                 }
                 | CompressionType::DoubleDelta {
                     reinterpret_datatype,
-                } => {
-                    // these filters do not accept floating point
-                    let check_type =
-                        if let Some(Datatype::Any) = reinterpret_datatype {
-                            *input
-                        } else if let Some(reinterpret_datatype) =
-                            reinterpret_datatype
-                        {
-                            reinterpret_datatype
-                        } else {
-                            return None;
-                        };
-                    if check_type.is_real_type() {
-                        None
+                } => reinterpret_datatype.map_or(Some(*input), |dtype| {
+                    if !dtype.is_real_type() {
+                        Some(dtype)
                     } else {
-                        Some(check_type)
+                        None
                     }
-                }
+                }),
                 _ => Some(*input),
             },
             FilterData::ScaleFloat { byte_width, .. } => {

--- a/tiledb/api/src/filter/mod.rs
+++ b/tiledb/api/src/filter/mod.rs
@@ -223,13 +223,40 @@ impl FilterData {
                 }
                 | CompressionType::DoubleDelta {
                     reinterpret_datatype,
-                } => reinterpret_datatype.map_or(Some(*input), |dtype| {
-                    if !dtype.is_real_type() {
-                        Some(dtype)
-                    } else {
-                        None
+                } => {
+                    // Delta and Double Delta filters don't take float types
+                    // as input. However, it also has the ability to reinterpret
+                    // any datatype so we have to handle that as well.
+
+                    // If reinterpret_datatype is None, then we just check
+                    // the input datatype.
+                    if reinterpret_datatype.is_none() && !input.is_real_type() {
+                        return Some(*input);
                     }
-                }),
+
+                    let reinterpret_datatype = reinterpret_datatype.unwrap();
+
+                    // Reinterpret datatype is set. So now we have to match the
+                    // logic in core which is that if its set to Datatype::Any
+                    // (the internal default) then we check the input type
+                    // again.
+                    if matches!(reinterpret_datatype, Datatype::Any)
+                        && !input.is_real_type()
+                    {
+                        return Some(*input);
+                    }
+
+                    // Otherwise, we just have to make sure that the reinterpret
+                    // type is not a real type.
+
+                    if !reinterpret_datatype.is_real_type() {
+                        return Some(reinterpret_datatype);
+                    }
+
+                    // Otherwise a user set the reinterpret datatype to a real
+                    // type which is invalid.
+                    None
+                }
                 _ => Some(*input),
             },
             FilterData::ScaleFloat { byte_width, .. } => {


### PR DESCRIPTION
I spent a day today taking another stab at learning the proptest API. So far my FilterListData Strategy is generating about 100k/sec valid cases. During that work I found a couple minor bugs in our Rust logic that contradicted core.

The first bug is a simple typo fixed by doing a `s/Boolean/Blob/`.

The second one is actually interesting. [The C++ code looks like this][1]:

```c++
bool CompressionFilter::accepts_input_datatype(Datatype input_type)  const {
    auto this_filter_type = compressor_to_filter(compressor_);
    if (this_filter_type == FilterType::FILTER_DOUBLE_DELTA ||
        this_filter_type == FilterType::FILTER_DELTA) {
      // Delta filters do not accept floating point types.
      if (datatype_is_real(
        reinterpret_datatype_ != Datatype::ANY ? reinterpret_datatype_ :
                                                 input_type)) {
        return false;
    }
  }

  return true;
}
```

The previous Rust translation of that logic [looked like this][2]:

```rust
FilterData::Compression(CompressionData { kind, .. }) => match kind
{
    CompressionType::Delta {
        reinterpret_datatype,
    }
    | CompressionType::DoubleDelta {
        reinterpret_datatype,
    } => {
        // these filters do not accept floating point
        let check_type =
            if let Some(Datatype::Any) = reinterpret_datatype {
                *input
            } else if let Some(reinterpret_datatype) =
                reinterpret_datatype
            {
                reinterpret_datatype
            } else {
                return None;
            };
        if check_type.is_real_type() {
            None
        } else {
            Some(check_type)
        }
    }
    _ => Some(*input),
},
```

And the corrected translation looks like this:

```rust
FilterData::Compression(CompressionData { kind, .. }) => match kind
{
    CompressionType::Delta {
        reinterpret_datatype,
    }
    | CompressionType::DoubleDelta {
        reinterpret_datatype,
    } => reinterpret_datatype.map_or(Some(*input), |dtype| {
        if !dtype.is_real_type() {
            Some(dtype)
        } else {
            None
        }
    }),
    _ => Some(*input),
},
```

That's fairly subtle.

The reason the first Rust version is wrong is because it misses the one of four cases where reinterpret_datatype is None and the input type is valid for the filter which doesn't happen very often given the specificity of the input datatype.

I love proptets.

[1]: https://github.com/TileDB-Inc/TileDB/blob/d00866b64eab47929170fe61f3498319d7b9711d/tiledb/sm/filter/compression_filter.cc#L98-L111
[2]: https://github.com/TileDB-Inc/tiledb-rs/blob/94cdfa59064548e3e43bc77265c5022324ae73ad/tiledb/api/src/filter/mod.rs#L230-L248