### PR TITLE
`typed_enum!` macro implements several step of our `TypedThing` pattern

### DIFF
--- a/tiledb/api/src/datatype/mod.rs
+++ b/tiledb/api/src/datatype/mod.rs
@@ -711,6 +711,255 @@ macro_rules! fn_typed {
     }};
 }
 
+#[macro_export]
+macro_rules! typed_enum {
+    ($src:ident < $range:ident > => $dst:ident) => {
+        typed_enum!($src <() enum $range> => $dst);
+    };
+    ($src:ident < $g1:tt, $range:ident > => $dst:ident) => {
+        typed_enum!($src <($g1) enum $range> => $dst);
+    };
+    ($src:ident < $g1:tt, $g2:tt, $range:ident > => $dst:ident) => {
+        typed_enum!($src <($g1, $g2) enum $range> => $dst);
+    };
+    ($src:ident < $g1:tt, $g2:tt, $g3:tt, $range:ident > => $dst:ident) => {
+        typed_enum!($src <($g1, $g2, $g3) enum $range> => $dst);
+    };
+    ($src:ident < $g1:tt, $g2:tt, $g3:tt, $g4:tt, $range:ident > => $dst:ident) => {
+        typed_enum!($src <($g1, $g2, $g3, $g4) enum $range> => $dst);
+    };
+    ($src:ident < ($($generics:tt),*) enum $range:ident > => $dst:ident) => {
+        pub enum $dst<$($generics),*> {
+            Int8($src<$($generics,)* <$crate::datatype::logical::Int8Type as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            Int16($src<$($generics,)* <$crate::datatype::logical::Int16Type as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            Int32($src<$($generics,)* <$crate::datatype::logical::Int32Type as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            Int64($src<$($generics,)* <$crate::datatype::logical::Int64Type as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            UInt8($src<$($generics,)* <$crate::datatype::logical::UInt8Type as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            UInt16($src<$($generics,)* <$crate::datatype::logical::UInt16Type as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            UInt32($src<$($generics,)* <$crate::datatype::logical::UInt32Type as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            UInt64($src<$($generics,)* <$crate::datatype::logical::UInt64Type as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            Float32($src<$($generics,)* <$crate::datatype::logical::Float32Type as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            Float64($src<$($generics,)* <$crate::datatype::logical::Float64Type as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            Char($src<$($generics,)* <$crate::datatype::logical::CharType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            StringAscii($src<$($generics,)* <$crate::datatype::logical::StringAsciiType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            StringUtf8($src<$($generics,)* <$crate::datatype::logical::StringUtf8Type as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            StringUtf16($src<$($generics,)* <$crate::datatype::logical::StringUtf16Type as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            StringUtf32($src<$($generics,)* <$crate::datatype::logical::StringUtf32Type as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            StringUcs2($src<$($generics,)* <$crate::datatype::logical::StringUcs2Type as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            StringUcs4($src<$($generics,)* <$crate::datatype::logical::StringUcs4Type as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            DateTimeYear($src<$($generics,)* <$crate::datatype::logical::DateTimeYearType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            DateTimeMonth($src<$($generics,)* <$crate::datatype::logical::DateTimeMonthType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            DateTimeWeek($src<$($generics,)* <$crate::datatype::logical::DateTimeWeekType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            DateTimeDay($src<$($generics,)* <$crate::datatype::logical::DateTimeDayType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            DateTimeHour($src<$($generics,)* <$crate::datatype::logical::DateTimeHourType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            DateTimeMinute($src<$($generics,)* <$crate::datatype::logical::DateTimeMinuteType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            DateTimeSecond($src<$($generics,)* <$crate::datatype::logical::DateTimeSecondType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            DateTimeMillisecond($src<$($generics,)* <$crate::datatype::logical::DateTimeMillisecondType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            DateTimeMicrosecond($src<$($generics,)* <$crate::datatype::logical::DateTimeMicrosecondType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            DateTimeNanosecond($src<$($generics,)* <$crate::datatype::logical::DateTimeNanosecondType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            DateTimePicosecond($src<$($generics,)* <$crate::datatype::logical::DateTimePicosecondType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            DateTimeFemtosecond($src<$($generics,)* <$crate::datatype::logical::DateTimeFemtosecondType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            DateTimeAttosecond($src<$($generics,)* <$crate::datatype::logical::DateTimeAttosecondType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            TimeHour($src<$($generics,)* <$crate::datatype::logical::TimeHourType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            TimeMinute($src<$($generics,)* <$crate::datatype::logical::TimeMinuteType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            TimeSecond($src<$($generics,)* <$crate::datatype::logical::TimeSecondType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            TimeMillisecond($src<$($generics,)* <$crate::datatype::logical::TimeMillisecondType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            TimeMicrosecond($src<$($generics,)* <$crate::datatype::logical::TimeMicrosecondType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            TimeNanosecond($src<$($generics,)* <$crate::datatype::logical::TimeNanosecondType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            TimePicosecond($src<$($generics,)* <$crate::datatype::logical::TimePicosecondType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            TimeFemtosecond($src<$($generics,)* <$crate::datatype::logical::TimeFemtosecondType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            TimeAttosecond($src<$($generics,)* <$crate::datatype::logical::TimeAttosecondType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            Blob($src<$($generics,)* <$crate::datatype::logical::BlobType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            Boolean($src<$($generics,)* <$crate::datatype::logical::BooleanType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            GeometryWkb($src<$($generics,)* <$crate::datatype::logical::GeometryWkbType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+            GeometryWkt($src<$($generics,)* <$crate::datatype::logical::GeometryWktType as $crate::datatype::logical::LogicalType>::PhysicalType>),
+        }
+
+        ::paste::paste! {
+            #[macro_export]
+            macro_rules! [< $dst:snake _go >] {
+                ($thing:expr, $typename:ident, $binding:pat, $then:expr) => {
+                    match $thing {
+                        $dst::Int8($binding) => {
+                            type $typename = $crate::datatype::logical::Int8Type;
+                            $then
+                        },
+                        $dst::Int16($binding) => {
+                            type $typename = $crate::datatype::logical::Int16Type;
+                            $then
+                        },
+                        $dst::Int32($binding) => {
+                            type $typename = $crate::datatype::logical::Int32Type;
+                            $then
+                        },
+                        $dst::Int64($binding) => {
+                            type $typename = $crate::datatype::logical::Int64Type;
+                            $then
+                        },
+                        $dst::UInt8($binding) => {
+                            type $typename = $crate::datatype::logical::UInt8Type;
+                            $then
+                        },
+                        $dst::UInt16($binding) => {
+                            type $typename = $crate::datatype::logical::UInt16Type;
+                            $then
+                        },
+                        $dst::UInt32($binding) => {
+                            type $typename = $crate::datatype::logical::UInt32Type;
+                            $then
+                        },
+                        $dst::UInt64($binding) => {
+                            type $typename = $crate::datatype::logical::UInt64Type;
+                            $then
+                        },
+                        $dst::Float32($binding) => {
+                            type $typename = $crate::datatype::logical::Float32Type;
+                            $then
+                        },
+                        $dst::Float64($binding) => {
+                            type $typename = $crate::datatype::logical::Float64Type;
+                            $then
+                        },
+                        $dst::Char($binding) => {
+                            type $typename = $crate::datatype::logical::CharType;
+                            $then
+                        },
+                        $dst::StringAscii($binding) => {
+                            type $typename = $crate::datatype::logical::StringAsciiType;
+                            $then
+                        },
+                        $dst::StringUtf8($binding) => {
+                            type $typename = $crate::datatype::logical::StringUtf8Type;
+                            $then
+                        },
+                        $dst::StringUtf16($binding) => {
+                            type $typename = $crate::datatype::logical::StringUtf16Type;
+                            $then
+                        },
+                        $dst::StringUtf32($binding) => {
+                            type $typename = $crate::datatype::logical::StringUtf32Type;
+                            $then
+                        },
+                        $dst::StringUcs2($binding) => {
+                            type $typename = $crate::datatype::logical::StringUcs2Type;
+                            $then
+                        },
+                        $dst::StringUcs4($binding) => {
+                            type $typename = $crate::datatype::logical::StringUcs4Type;
+                            $then
+                        },
+                        $dst::DateTimeYear($binding) => {
+                            type $typename = $crate::datatype::logical::DateTimeYearType;
+                            $then
+                        },
+                        $dst::DateTimeMonth($binding) => {
+                            type $typename = $crate::datatype::logical::DateTimeMonthType;
+                            $then
+                        },
+                        $dst::DateTimeWeek($binding) => {
+                            type $typename = $crate::datatype::logical::DateTimeWeekType;
+                            $then
+                        },
+                        $dst::DateTimeDay($binding) => {
+                            type $typename = $crate::datatype::logical::DateTimeDayType;
+                            $then
+                        },
+                        $dst::DateTimeHour($binding) => {
+                            type $typename = $crate::datatype::logical::DateTimeHourType;
+                            $then
+                        },
+                        $dst::DateTimeMinute($binding) => {
+                            type $typename = $crate::datatype::logical::DateTimeMinuteType;
+                            $then
+                        },
+                        $dst::DateTimeSecond($binding) => {
+                            type $typename = $crate::datatype::logical::DateTimeSecondType;
+                            $then
+                        },
+                        $dst::DateTimeMillisecond($binding) => {
+                            type $typename = $crate::datatype::logical::DateTimeMillisecondType;
+                            $then
+                        },
+                        $dst::DateTimeMicrosecond($binding) => {
+                            type $typename = $crate::datatype::logical::DateTimeMicrosecondType;
+                            $then
+                        },
+                        $dst::DateTimeNanosecond($binding) => {
+                            type $typename = $crate::datatype::logical::DateTimeNanosecondType;
+                            $then
+                        },
+                        $dst::DateTimePicosecond($binding) => {
+                            type $typename = $crate::datatype::logical::DateTimePicosecondType;
+                            $then
+                        },
+                        $dst::DateTimeFemtosecond($binding) => {
+                            type $typename = $crate::datatype::logical::DateTimeFemtosecondType;
+                            $then
+                        },
+                        $dst::DateTimeAttosecond($binding) => {
+                            type $typename = $crate::datatype::logical::DateTimeAttosecondType;
+                            $then
+                        },
+                        $dst::TimeHour($binding) => {
+                            type $typename = $crate::datatype::logical::TimeHourType;
+                            $then
+                        },
+                        $dst::TimeMinute($binding) => {
+                            type $typename = $crate::datatype::logical::TimeMinuteType;
+                            $then
+                        },
+                        $dst::TimeSecond($binding) => {
+                            type $typename = $crate::datatype::logical::TimeSecondType;
+                            $then
+                        },
+                        $dst::TimeMillisecond($binding) => {
+                            type $typename = $crate::datatype::logical::TimeMillisecondType;
+                            $then
+                        },
+                        $dst::TimeMicrosecond($binding) => {
+                            type $typename = $crate::datatype::logical::TimeMicrosecondType;
+                            $then
+                        },
+                        $dst::TimeNanosecond($binding) => {
+                            type $typename = $crate::datatype::logical::TimeNanosecondType;
+                            $then
+                        },
+                        $dst::TimePicosecond($binding) => {
+                            type $typename = $crate::datatype::logical::TimePicosecondType;
+                            $then
+                        },
+                        $dst::TimeFemtosecond($binding) => {
+                            type $typename = $crate::datatype::logical::TimeFemtosecondType;
+                            $then
+                        },
+                        $dst::TimeAttosecond($binding) => {
+                            type $typename = $crate::datatype::logical::TimeAttosecondType;
+                            $then
+                        },
+                        $dst::Blob($binding) => {
+                            type $typename = $crate::datatype::logical::BlobType;
+                            $then
+                        },
+                        $dst::Boolean($binding) => {
+                            type $typename = $crate::datatype::logical::BooleanType;
+                            $then
+                        },
+                        $dst::GeometryWkb($binding) => {
+                            type $typename = $crate::datatype::logical::GeometryWkbType;
+                            $then
+                        },
+                        $dst::GeometryWkt($binding) => {
+                            type $typename = $crate::datatype::logical::GeometryWktType;
+                            $then
+                        },
+                    }
+                }
+            }
+            pub use [< $dst:snake _go >];
+        }
+    };
+}
+
 #[cfg(feature = "arrow")]
 pub mod arrow;
 

--- a/tiledb/api/src/datatype/mod.rs
+++ b/tiledb/api/src/datatype/mod.rs
@@ -713,22 +713,23 @@ macro_rules! fn_typed {
 
 #[macro_export]
 macro_rules! typed_enum {
-    ($src:ident < $range:ident > => $dst:ident) => {
-        typed_enum!($src <() enum $range> => $dst);
+    ($src:ident < $range:ident > => $(#[ $($attrs:meta),+ ])? $dst:ident) => {
+        typed_enum!($src <() enum $range> => $(#[ $($attrs),+ ])? $dst);
     };
-    ($src:ident < $g1:tt, $range:ident > => $dst:ident) => {
-        typed_enum!($src <($g1) enum $range> => $dst);
+    ($src:ident < $g1:tt, $range:ident > => $(#[ $($attrs:meta),+ ])? $dst:ident) => {
+        typed_enum!($src <($g1) enum $range> => $(#[ $($attrs),+ ])? $dst);
     };
-    ($src:ident < $g1:tt, $g2:tt, $range:ident > => $dst:ident) => {
-        typed_enum!($src <($g1, $g2) enum $range> => $dst);
+    ($src:ident < $g1:tt, $g2:tt, $range:ident > => $(#[ $($attrs:meta),+ ])? $dst:ident) => {
+        typed_enum!($src <($g1, $g2) enum $range> => $(#[ $($attrs),+ ])? $dst);
     };
-    ($src:ident < $g1:tt, $g2:tt, $g3:tt, $range:ident > => $dst:ident) => {
-        typed_enum!($src <($g1, $g2, $g3) enum $range> => $dst);
+    ($src:ident < $g1:tt, $g2:tt, $g3:tt, $range:ident > => $(#[ $($attrs:meta),+ ])? $dst:ident) => {
+        typed_enum!($src <($g1, $g2, $g3) enum $range> => $(#[ $($attrs),+ ])? $dst);
     };
-    ($src:ident < $g1:tt, $g2:tt, $g3:tt, $g4:tt, $range:ident > => $dst:ident) => {
-        typed_enum!($src <($g1, $g2, $g3, $g4) enum $range> => $dst);
+    ($src:ident < $g1:tt, $g2:tt, $g3:tt, $g4:tt, $range:ident > => $(#[ $($attrs:meta),+ ])? $dst:ident) => {
+        typed_enum!($src <($g1, $g2, $g3, $g4) enum $range> => $(#[ $($attrs),+ ])? $dst);
     };
-    ($src:ident < ($($generics:tt),*) enum $range:ident > => $dst:ident) => {
+    ($src:ident < ($($generics:tt),*) enum $range:ident > => $(#[ $($attrs:meta),+ ])? $dst:ident) => {
+        $(#[ $($attrs),+ ])?
         pub enum $dst<$($generics),*> {
             Int8($src<$($generics,)* <$crate::datatype::logical::Int8Type as $crate::datatype::logical::LogicalType>::PhysicalType>),
             Int16($src<$($generics,)* <$crate::datatype::logical::Int16Type as $crate::datatype::logical::LogicalType>::PhysicalType>),

--- a/tiledb/api/src/group/mod.rs
+++ b/tiledb/api/src/group/mod.rs
@@ -551,10 +551,7 @@ mod tests {
             let metadata_aaa =
                 group1_read.metadata(LookupKey::Name("aaa".to_owned()))?;
             assert_eq!(metadata_aaa.datatype, Datatype::Int32);
-            assert_eq!(
-                metadata_aaa.value,
-                metadata::Value::Int32Value(vec!(5))
-            );
+            assert_eq!(metadata_aaa.value, metadata::Value::Int32(vec!(5)));
             assert_eq!(metadata_aaa.key, "aaa");
 
             let metadata_num = group1_read.num_metadata()?;
@@ -565,7 +562,7 @@ mod tests {
             assert_eq!(metadata_bb.key, "bb");
             assert_eq!(
                 metadata_bb.value,
-                metadata::Value::Float32Value(vec!(1.1f32, 2.2f32))
+                metadata::Value::Float32(vec!(1.1f32, 2.2f32))
             );
 
             let has_aaa = group1_read.has_metadata_key("aaa")?;

--- a/tiledb/api/src/metadata.rs
+++ b/tiledb/api/src/metadata.rs
@@ -5,22 +5,9 @@ use crate::Result as TileDBResult;
 use core::slice;
 use std::convert::From;
 
-#[derive(Debug, PartialEq)]
-pub enum Value {
-    UInt8Value(Vec<u8>),
-    UInt16Value(Vec<u16>),
-    UInt32Value(Vec<u32>),
-    UInt64Value(Vec<u64>),
-    Int8Value(Vec<i8>),
-    Int16Value(Vec<i16>),
-    Int32Value(Vec<i32>),
-    Int64Value(Vec<i64>),
-    Float32Value(Vec<f32>),
-    Float64Value(Vec<f64>),
-    //StringAsciiValue(CString),
-    //BooleanValue(bool),
-    // maybe blobs?
-}
+use crate::typed_enum;
+
+typed_enum!(Vec<T> => #[derive(Debug, PartialEq)] Value);
 
 fn get_value_vec<T>(vec: &[T]) -> (*const std::ffi::c_void, usize) {
     let vec_size = vec.len();
@@ -28,56 +15,9 @@ fn get_value_vec<T>(vec: &[T]) -> (*const std::ffi::c_void, usize) {
     (vec_ptr, vec_size)
 }
 
-macro_rules! value_typed {
-    ($valuetype:expr, $typename:ident, $vec:ident, $then: expr) => {
-        match $valuetype {
-            Value::Int8Value(ref $vec) => {
-                type $typename = i8;
-                $then
-            }
-            Value::Int16Value(ref $vec) => {
-                type $typename = i16;
-                $then
-            }
-            Value::Int32Value(ref $vec) => {
-                type $typename = i32;
-                $then
-            }
-            Value::Int64Value(ref $vec) => {
-                type $typename = i64;
-                $then
-            }
-            Value::UInt8Value(ref $vec) => {
-                type $typename = u8;
-                $then
-            }
-            Value::UInt16Value(ref $vec) => {
-                type $typename = u16;
-                $then
-            }
-            Value::UInt32Value(ref $vec) => {
-                type $typename = u32;
-                $then
-            }
-            Value::UInt64Value(ref $vec) => {
-                type $typename = u64;
-                $then
-            }
-            Value::Float32Value(ref $vec) => {
-                type $typename = f32;
-                $then
-            }
-            Value::Float64Value(ref $vec) => {
-                type $typename = f64;
-                $then
-            }
-        }
-    };
-}
-
 impl Value {
     pub fn c_vec(&self) -> (*const std::ffi::c_void, usize) {
-        value_typed!(self, _DT, vec, get_value_vec(vec))
+        value_go!(self, _DT, vec, get_value_vec(vec))
     }
 }
 
@@ -91,16 +31,16 @@ macro_rules! value_impl {
     };
 }
 
-value_impl!(i8, Value::Int8Value);
-value_impl!(i16, Value::Int16Value);
-value_impl!(i32, Value::Int32Value);
-value_impl!(i64, Value::Int64Value);
-value_impl!(u8, Value::UInt8Value);
-value_impl!(u16, Value::UInt16Value);
-value_impl!(u32, Value::UInt32Value);
-value_impl!(u64, Value::UInt64Value);
-value_impl!(f32, Value::Float32Value);
-value_impl!(f64, Value::Float64Value);
+value_impl!(i8, Value::Int8);
+value_impl!(i16, Value::Int16);
+value_impl!(i32, Value::Int32);
+value_impl!(i64, Value::Int64);
+value_impl!(u8, Value::UInt8);
+value_impl!(u16, Value::UInt16);
+value_impl!(u32, Value::UInt32);
+value_impl!(u64, Value::UInt64);
+value_impl!(f32, Value::Float32);
+value_impl!(f64, Value::Float64);
 
 #[derive(Debug)]
 pub struct Metadata {

--- a/tiledb/api/src/query/buffer.rs
+++ b/tiledb/api/src/query/buffer.rs
@@ -3,6 +3,7 @@ use std::num::NonZeroU32;
 use std::ops::{Deref, DerefMut};
 
 use crate::array::CellValNum;
+use crate::typed_enum;
 
 pub enum Buffer<'data, T = u8> {
     Empty,
@@ -393,31 +394,11 @@ impl<'data, T> QueryBuffersMut<'data, T> {
     }
 }
 
-pub enum TypedQueryBuffers<'data> {
-    UInt8(QueryBuffers<'data, u8>),
-    UInt16(QueryBuffers<'data, u16>),
-    UInt32(QueryBuffers<'data, u32>),
-    UInt64(QueryBuffers<'data, u64>),
-    Int8(QueryBuffers<'data, i8>),
-    Int16(QueryBuffers<'data, i16>),
-    Int32(QueryBuffers<'data, i32>),
-    Int64(QueryBuffers<'data, i64>),
-    Float32(QueryBuffers<'data, f32>),
-    Float64(QueryBuffers<'data, f64>),
-}
+typed_enum!(QueryBuffers<'data, T> => TypedQueryBuffers);
 
-pub enum RefTypedQueryBuffersMut<'cell, 'data> {
-    UInt8(Ref<'cell, QueryBuffersMut<'data, u8>>),
-    UInt16(Ref<'cell, QueryBuffersMut<'data, u16>>),
-    UInt32(Ref<'cell, QueryBuffersMut<'data, u32>>),
-    UInt64(Ref<'cell, QueryBuffersMut<'data, u64>>),
-    Int8(Ref<'cell, QueryBuffersMut<'data, i8>>),
-    Int16(Ref<'cell, QueryBuffersMut<'data, i16>>),
-    Int32(Ref<'cell, QueryBuffersMut<'data, i32>>),
-    Int64(Ref<'cell, QueryBuffersMut<'data, i64>>),
-    Float32(Ref<'cell, QueryBuffersMut<'data, f32>>),
-    Float64(Ref<'cell, QueryBuffersMut<'data, f64>>),
-}
+type RefQueryBuffersMut<'cell, 'data, T> =
+    Ref<'cell, QueryBuffersMut<'data, T>>;
+typed_enum!(RefQueryBuffersMut<'cell, 'data, T> => RefTypedQueryBuffersMut);
 
 macro_rules! typed_query_buffers {
     ($($V:ident : $U:ty),+) => {
@@ -452,104 +433,9 @@ typed_query_buffers!(UInt8: u8, UInt16: u16, UInt32: u32, UInt64: u64);
 typed_query_buffers!(Int8: i8, Int16: i16, Int32: i32, Int64: i64);
 typed_query_buffers!(Float32: f32, Float64: f64);
 
-#[macro_export]
-macro_rules! typed_query_buffers_go {
-    ($expr:expr, $DT:ident, $inner:pat, $then:expr) => {
-        match $expr {
-            TypedQueryBuffers::UInt8($inner) => {
-                type $DT = u8;
-                $then
-            }
-            TypedQueryBuffers::UInt16($inner) => {
-                type $DT = u16;
-                $then
-            }
-            TypedQueryBuffers::UInt32($inner) => {
-                type $DT = u32;
-                $then
-            }
-            TypedQueryBuffers::UInt64($inner) => {
-                type $DT = u64;
-                $then
-            }
-            TypedQueryBuffers::Int8($inner) => {
-                type $DT = i8;
-                $then
-            }
-            TypedQueryBuffers::Int16($inner) => {
-                type $DT = i16;
-                $then
-            }
-            TypedQueryBuffers::Int32($inner) => {
-                type $DT = i32;
-                $then
-            }
-            TypedQueryBuffers::Int64($inner) => {
-                type $DT = i64;
-                $then
-            }
-            TypedQueryBuffers::Float32($inner) => {
-                type $DT = f32;
-                $then
-            }
-            TypedQueryBuffers::Float64($inner) => {
-                type $DT = f64;
-                $then
-            }
-        }
-    };
-}
-
-macro_rules! ref_typed_query_buffers_go {
-    ($expr:expr, $DT:ident, $inner:pat, $then:expr) => {
-        match $expr {
-            RefTypedQueryBuffersMut::UInt8($inner) => {
-                type $DT = u8;
-                $then
-            }
-            RefTypedQueryBuffersMut::UInt16($inner) => {
-                type $DT = u16;
-                $then
-            }
-            RefTypedQueryBuffersMut::UInt32($inner) => {
-                type $DT = u32;
-                $then
-            }
-            RefTypedQueryBuffersMut::UInt64($inner) => {
-                type $DT = u64;
-                $then
-            }
-            RefTypedQueryBuffersMut::Int8($inner) => {
-                type $DT = i8;
-                $then
-            }
-            RefTypedQueryBuffersMut::Int16($inner) => {
-                type $DT = i16;
-                $then
-            }
-            RefTypedQueryBuffersMut::Int32($inner) => {
-                type $DT = i32;
-                $then
-            }
-            RefTypedQueryBuffersMut::Int64($inner) => {
-                type $DT = i64;
-                $then
-            }
-            RefTypedQueryBuffersMut::Float32($inner) => {
-                type $DT = f32;
-                $then
-            }
-            RefTypedQueryBuffersMut::Float64($inner) => {
-                type $DT = f64;
-                $then
-            }
-        }
-    };
-}
-
 impl<'cell, 'data> RefTypedQueryBuffersMut<'cell, 'data> {
     pub fn as_shared(&'cell self) -> TypedQueryBuffers<'cell> {
-        ref_typed_query_buffers_go!(self, _DT, qb, {
+        ref_typed_query_buffers_mut_go!(self, _DT, qb, {
             TypedQueryBuffers::from(qb.as_shared())
         })
     }

--- a/tiledb/api/src/query/read/output/arrow.rs
+++ b/tiledb/api/src/query/read/output/arrow.rs
@@ -10,10 +10,11 @@ use crate::array::CellValNum;
 use crate::datatype::arrow::ArrowPrimitiveTypeNative;
 use crate::error::{DatatypeErrorKind, Error};
 use crate::query::buffer::{
-    Buffer, CellStructure, QueryBuffers, TypedQueryBuffers,
+    typed_query_buffers_go, Buffer, CellStructure, QueryBuffers,
+    TypedQueryBuffers,
 };
 use crate::query::read::output::{RawReadOutput, TypedRawReadOutput};
-use crate::{typed_query_buffers_go, Result as TileDBResult};
+use crate::Result as TileDBResult;
 
 impl<'data, C> TryFrom<RawReadOutput<'data, C>>
     for PrimitiveArray<<C as ArrowPrimitiveTypeNative>::ArrowPrimitiveType>

--- a/tiledb/api/src/query/read/output/mod.rs
+++ b/tiledb/api/src/query/read/output/mod.rs
@@ -9,11 +9,11 @@ use crate::array::CellValNum;
 use crate::datatype::PhysicalType;
 use crate::error::{DatatypeErrorKind, Error};
 use crate::query::buffer::{
-    Buffer, BufferMut, CellStructure, CellStructureMut, QueryBuffers,
-    QueryBuffersMut, TypedQueryBuffers,
+    typed_query_buffers_go, Buffer, BufferMut, CellStructure, CellStructureMut,
+    QueryBuffers, QueryBuffersMut, TypedQueryBuffers,
 };
+use crate::Datatype;
 use crate::Result as TileDBResult;
-use crate::{typed_query_buffers_go, Datatype};
 
 #[cfg(feature = "arrow")]
 pub mod arrow;

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -13,6 +13,8 @@ use proptest::test_runner::TestRunner;
 use super::*;
 use crate::array::{ArrayType, CellValNum, SchemaData};
 use crate::datatype::LogicalType;
+use crate::fn_typed;
+use crate::query::buffer::typed_query_buffers_go;
 use crate::query::read::output::{
     FixedDataIterator, RawReadOutput, TypedRawReadOutput, VarDataIterator,
 };
@@ -20,7 +22,6 @@ use crate::query::read::{
     CallbackVarArgReadBuilder, FieldMetadata, ManagedBuffer, RawReadHandle,
     ReadCallbackVarArg, TypedReadHandle,
 };
-use crate::{fn_typed, typed_query_buffers_go};
 
 /// Represents the write query input for a single field.
 /// For each variant, the outer Vec is the collection of records, and the interior is value in the
@@ -88,7 +89,8 @@ impl From<Vec<String>> for FieldData {
 
 impl From<&TypedRawReadOutput<'_>> for FieldData {
     fn from(value: &TypedRawReadOutput) -> Self {
-        typed_query_buffers_go!(value.buffers, DT, ref handle, {
+        typed_query_buffers_go!(value.buffers, LT, ref handle, {
+            type DT = <LT as LogicalType>::PhysicalType;
             let rr = RawReadOutput {
                 ncells: value.ncells,
                 input: handle.borrow(),


### PR DESCRIPTION
We have `metadata::Value`, `TypedQueryBuffers`, and something with ranges... and maybe more?

This pull request brings that pattern into a common core of a new macro `typed_enum!` which expands into an `enum` definition with one variant per logical type, and also into a new macro definition which matches on the enum and then brings the logical type into context for an expression block (like `fn_typed`).

The choice of using logical type rather than physical type for variation was motivated by what I'm doing with arrow.