### PR TITLE
Fix nightly CI config

### DIFF
--- a/.github/workflows/nigthtly-ci.yml
+++ b/.github/workflows/nigthtly-ci.yml
@@ -30,7 +30,10 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -Dwarnings
       - name: Lint
         if: ${{ matrix.version == 'nightly' }}
-        run: cargo clippy --all-targets --all-features -- --cfg ci_nightly -Dwarnings
+        # The nightly complier/clippy complain about the proptest derive
+        # macros. Originally I disabled via `--cfg` but now a new lint warns
+        # on that approach. So I'm just disabling the particular lint globally.
+        run: cargo clippy --all-targets --all-features -- --allow non_local_definitions -Dwarnings
       - name: Build
         run: cargo build --all-targets --all-features
       - name: Test

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -1,7 +1,3 @@
-// This is for the derive(proptest::Arbitrary) macro which triggers this
-// lint on nightly.
-#![cfg_attr(ci_nightly, allow(non_local_definitions))]
-
 use std::convert::TryFrom;
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use std::ops::Deref;


### PR DESCRIPTION
I forgot to set the `ci_nightly` config attribute and clippy has started complaining. Easy fix is easy.