### PR TITLE
Remove restrictions on datatypes for proptest strategies

### DIFF
--- a/tiledb/api/src/array/attribute/arrow.rs
+++ b/tiledb/api/src/array/attribute/arrow.rs
@@ -34,7 +34,7 @@ impl AttributeMetadata {
             fill_value: fn_typed!(attr.datatype()?, LT, {
                 type DT = <LT as LogicalType>::PhysicalType;
                 let (fill_value, fill_nullable) =
-                    attr.fill_value_nullable::<DT>()?;
+                    attr.fill_value_nullable::<&[DT]>()?;
                 FillValueMetadata {
                     data: json!(fill_value),
                     nullable: fill_nullable,
@@ -57,7 +57,7 @@ impl AttributeMetadata {
         fn_typed!(builder.datatype()?, LT, {
             type DT = <LT as LogicalType>::PhysicalType;
             let fill_value =
-                serde_json::from_value::<DT>(self.fill_value.data.clone())
+                serde_json::from_value::<Vec<DT>>(self.fill_value.data.clone())
                     .map_err(|e| {
                         Error::Deserialization(
                             String::from("attribute fill value"),

--- a/tiledb/api/src/array/attribute/mod.rs
+++ b/tiledb/api/src/array/attribute/mod.rs
@@ -2,6 +2,7 @@ extern crate tiledb_sys as ffi;
 
 use std::borrow::Borrow;
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
+use std::num::NonZeroU32;
 use std::ops::Deref;
 
 use anyhow::anyhow;
@@ -11,6 +12,7 @@ use util::option::OptionSubset;
 
 use crate::array::CellValNum;
 use crate::context::{CApiInterface, Context, ContextBound};
+use crate::datatype::physical::BitsEq;
 use crate::datatype::{LogicalType, PhysicalType};
 use crate::error::{DatatypeErrorKind, Error};
 use crate::filter::list::{FilterList, FilterListData, RawFilterList};
@@ -111,10 +113,17 @@ impl<'ctx> Attribute<'ctx> {
         Ok(c_size as u64)
     }
 
-    pub fn fill_value<T: PhysicalType>(&self) -> TileDBResult<T> {
+    pub fn fill_value<'a, F: FromFillValue<'a>>(&'a self) -> TileDBResult<F> {
         let c_attr = *self.raw;
         let mut c_ptr: *const std::ffi::c_void = out_ptr!();
         let mut c_size: u64 = 0;
+
+        if !self.datatype()?.is_compatible_type::<F::PhysicalType>() {
+            return Err(Error::Datatype(DatatypeErrorKind::TypeMismatch {
+                user_type: std::any::type_name::<F::PhysicalType>(),
+                tiledb_type: self.datatype()?,
+            }));
+        }
 
         self.capi_call(|ctx| unsafe {
             ffi::tiledb_attribute_get_fill_value(
@@ -125,19 +134,27 @@ impl<'ctx> Attribute<'ctx> {
             )
         })?;
 
-        if c_size != std::mem::size_of::<T>() as u64 {
+        assert!(c_size % std::mem::size_of::<F::PhysicalType>() as u64 == 0,
+            "Unexpected fill value size for compatible type {}: expected multiple of {}, found {}",
+            std::any::type_name::<F::PhysicalType>(),
+            std::mem::size_of::<F::PhysicalType>(), c_size);
+
+        let len = c_size as usize / std::mem::size_of::<F::PhysicalType>();
+        let slice: &[F::PhysicalType] = unsafe {
+            std::slice::from_raw_parts(c_ptr as *const F::PhysicalType, len)
+        };
+        F::from_raw(slice)
+    }
+
+    pub fn fill_value_nullable<'a, F: FromFillValue<'a>>(
+        &'a self,
+    ) -> TileDBResult<(F, bool)> {
+        if !self.datatype()?.is_compatible_type::<F::PhysicalType>() {
             return Err(Error::Datatype(DatatypeErrorKind::TypeMismatch {
-                user_type: std::any::type_name::<T>(),
+                user_type: std::any::type_name::<F::PhysicalType>(),
                 tiledb_type: self.datatype()?,
             }));
         }
-
-        Ok(unsafe { *c_ptr.cast::<T>() })
-    }
-
-    pub fn fill_value_nullable<T: PhysicalType>(
-        &self,
-    ) -> TileDBResult<(T, bool)> {
         if !self.is_nullable()? {
             /* see comment in Builder::fill_value_nullability */
             return Ok((self.fill_value()?, false));
@@ -158,16 +175,18 @@ impl<'ctx> Attribute<'ctx> {
             )
         })?;
 
-        if c_size != std::mem::size_of::<T>() as u64 {
-            return Err(Error::Datatype(DatatypeErrorKind::TypeMismatch {
-                user_type: std::any::type_name::<T>(),
-                tiledb_type: self.datatype()?,
-            }));
-        }
+        assert!(c_size % std::mem::size_of::<F::PhysicalType>() as u64 == 0,
+            "Unexpected fill value size for compatible type {}: expected multiple of {}, found {}",
+            std::any::type_name::<F::PhysicalType>(),
+            std::mem::size_of::<F::PhysicalType>(), c_size);
+
+        let len = c_size as usize / std::mem::size_of::<F::PhysicalType>();
+        let slice: &[F::PhysicalType] = unsafe {
+            std::slice::from_raw_parts(c_ptr as *const F::PhysicalType, len)
+        };
 
         let is_valid = c_validity != 0;
-        let value = unsafe { *c_ptr.cast::<T>() };
-        Ok((value, is_valid))
+        Ok((F::from_raw(slice)?, is_valid))
     }
 }
 
@@ -228,8 +247,8 @@ impl<'c1, 'c2> PartialEq<Attribute<'c2>> for Attribute<'c1> {
             fn_typed!(self.datatype().unwrap(), LT, {
                 type DT = <LT as LogicalType>::PhysicalType;
                 match (
-                    self.fill_value_nullable::<DT>(),
-                    other.fill_value_nullable::<DT>(),
+                    self.fill_value_nullable::<&[DT]>(),
+                    other.fill_value_nullable::<&[DT]>(),
                 ) {
                     (
                         Ok((mine_value, mine_nullable)),
@@ -244,7 +263,8 @@ impl<'c1, 'c2> PartialEq<Attribute<'c2>> for Attribute<'c1> {
         } else {
             fn_typed!(self.datatype().unwrap(), LT, {
                 type DT = <LT as LogicalType>::PhysicalType;
-                match (self.fill_value::<DT>(), other.fill_value::<DT>()) {
+                match (self.fill_value::<&[DT]>(), other.fill_value::<&[DT]>())
+                {
                     (Ok(mine), Ok(theirs)) => mine.bits_eq(&theirs),
                     _ => false,
                 }
@@ -320,34 +340,34 @@ impl<'ctx> Builder<'ctx> {
         Ok(self)
     }
 
-    // This currently does not support setting multi-value cells.
-    pub fn fill_value<T: PhysicalType>(self, value: T) -> TileDBResult<Self> {
-        if !self.attr.datatype()?.is_compatible_type::<T>() {
+    pub fn fill_value<F: IntoFillValue>(self, value: F) -> TileDBResult<Self> {
+        if !self
+            .attr
+            .datatype()?
+            .is_compatible_type::<F::PhysicalType>()
+        {
             return Err(Error::Datatype(DatatypeErrorKind::TypeMismatch {
-                user_type: std::any::type_name::<T>(),
+                user_type: std::any::type_name::<F::PhysicalType>(),
                 tiledb_type: self.attr.datatype()?,
             }));
         }
 
+        let fill: &[F::PhysicalType] = value.to_raw();
+
         let c_attr = *self.attr.raw;
-        let c_value = &value as *const T as *const std::ffi::c_void;
+        let c_value = fill.as_ptr() as *const std::ffi::c_void;
+        let c_size = std::mem::size_of_val(fill) as u64;
 
         self.capi_call(|ctx| unsafe {
-            ffi::tiledb_attribute_set_fill_value(
-                ctx,
-                c_attr,
-                c_value,
-                std::mem::size_of::<T>() as u64,
-            )
+            ffi::tiledb_attribute_set_fill_value(ctx, c_attr, c_value, c_size)
         })?;
 
         Ok(self)
     }
 
-    // This currently does not support setting multi-value cells.
-    pub fn fill_value_nullability<T: PhysicalType>(
+    pub fn fill_value_nullability<F: IntoFillValue>(
         self,
-        value: T,
+        value: F,
         nullable: bool,
     ) -> TileDBResult<Self> {
         if !self.attr.is_nullable()? && !nullable {
@@ -361,24 +381,27 @@ impl<'ctx> Builder<'ctx> {
             return self.fill_value(value);
         }
 
-        if !self.attr.datatype()?.is_compatible_type::<T>() {
+        if !self
+            .attr
+            .datatype()?
+            .is_compatible_type::<F::PhysicalType>()
+        {
             return Err(Error::Datatype(DatatypeErrorKind::TypeMismatch {
-                user_type: std::any::type_name::<T>(),
+                user_type: std::any::type_name::<F::PhysicalType>(),
                 tiledb_type: self.attr.datatype()?,
             }));
         }
 
+        let fill: &[F::PhysicalType] = value.to_raw();
+
         let c_attr = *self.attr.raw;
-        let c_value = &value as *const T as *const std::ffi::c_void;
+        let c_value = fill.as_ptr() as *const std::ffi::c_void;
+        let c_size = std::mem::size_of_val(fill) as u64;
         let c_nullable: u8 = if nullable { 1 } else { 0 };
 
         self.capi_call(|ctx| unsafe {
             ffi::tiledb_attribute_set_fill_value_nullable(
-                ctx,
-                c_attr,
-                c_value,
-                std::mem::size_of::<T>() as u64,
-                c_nullable,
+                ctx, c_attr, c_value, c_size, c_nullable,
             )
         })?;
 
@@ -403,6 +426,155 @@ impl<'ctx> Builder<'ctx> {
 
     pub fn build(self) -> Attribute<'ctx> {
         self.attr
+    }
+}
+
+/// Trait for data which can be used as a fill value for an attribute.
+pub trait IntoFillValue {
+    type PhysicalType: PhysicalType;
+
+    /// Get a reference to the raw fill value data.
+    /// The returned slice will be copied into the tiledb core.
+    fn to_raw(&self) -> &[Self::PhysicalType];
+}
+
+pub trait FromFillValue<'a>: IntoFillValue + Sized {
+    /// Construct a value of this type from a raw fill value.
+    fn from_raw(raw: &'a [Self::PhysicalType]) -> TileDBResult<Self>;
+}
+
+impl<T> IntoFillValue for T
+where
+    T: PhysicalType,
+{
+    type PhysicalType = Self;
+
+    fn to_raw(&self) -> &[Self::PhysicalType] {
+        std::slice::from_ref(self)
+    }
+}
+
+impl<T> FromFillValue<'_> for T
+where
+    T: PhysicalType,
+{
+    fn from_raw<'a>(raw: &'a [Self::PhysicalType]) -> TileDBResult<Self> {
+        if raw.len() == 1 {
+            Ok(raw[0])
+        } else {
+            Err(Error::Datatype(DatatypeErrorKind::UnexpectedCellStructure {
+                context: None,
+                found: CellValNum::try_from(raw.len() as u32)
+                    /* this should be safe because core forbids zero-length fill value */
+                    .unwrap(),
+                expected: CellValNum::single()
+            }))
+        }
+    }
+}
+
+impl<T, const K: usize> IntoFillValue for [T; K]
+where
+    T: PhysicalType,
+{
+    type PhysicalType = T;
+
+    fn to_raw(&self) -> &[Self::PhysicalType] {
+        self
+    }
+}
+
+impl<'a, T, const K: usize> FromFillValue<'a> for [T; K]
+where
+    T: PhysicalType,
+{
+    fn from_raw(raw: &'a [Self::PhysicalType]) -> TileDBResult<Self> {
+        Self::try_from(raw).map_err(|_|
+            Error::Datatype(DatatypeErrorKind::UnexpectedCellStructure {
+                context: None,
+                found: CellValNum::try_from(raw.len() as u32)
+                    /* this should be safe because core forbids zero-length fill value */
+                    .unwrap(),
+                expected: {
+                    /* unfortunately no clear way to bound `0 < K < u32::MAX` for a trait impl */
+                    let nz = u32::try_from(K).ok().and_then(NonZeroU32::new)
+                        .expect("`impl FillValue for [T; K] requires 0 < K < u32::MAX");
+                    CellValNum::Fixed(nz)
+                }
+            }))
+    }
+}
+
+impl<T> IntoFillValue for &[T]
+where
+    T: PhysicalType,
+{
+    type PhysicalType = T;
+
+    fn to_raw(&self) -> &[Self::PhysicalType] {
+        self
+    }
+}
+
+impl<'a, T> FromFillValue<'a> for &'a [T]
+where
+    T: PhysicalType,
+{
+    fn from_raw(raw: &'a [Self::PhysicalType]) -> TileDBResult<Self> {
+        Ok(raw)
+    }
+}
+
+impl<T> IntoFillValue for Vec<T>
+where
+    T: PhysicalType,
+{
+    type PhysicalType = T;
+
+    fn to_raw(&self) -> &[Self::PhysicalType] {
+        self.as_slice()
+    }
+}
+
+impl<T> FromFillValue<'_> for Vec<T>
+where
+    T: PhysicalType,
+{
+    fn from_raw(raw: &[Self::PhysicalType]) -> TileDBResult<Self> {
+        Ok(raw.to_vec())
+    }
+}
+
+impl IntoFillValue for &str {
+    type PhysicalType = u8;
+
+    fn to_raw(&self) -> &[Self::PhysicalType] {
+        self.as_bytes()
+    }
+}
+
+impl<'a> FromFillValue<'a> for &'a str {
+    fn from_raw(raw: &'a [Self::PhysicalType]) -> TileDBResult<Self> {
+        std::str::from_utf8(raw).map_err(|e| {
+            Error::Deserialization(
+                "Non-UTF8 fill value".to_string(),
+                anyhow!(e),
+            )
+        })
+    }
+}
+
+impl IntoFillValue for String {
+    type PhysicalType = u8;
+
+    fn to_raw(&self) -> &[Self::PhysicalType] {
+        self.as_bytes()
+    }
+}
+
+impl<'a> FromFillValue<'a> for String {
+    fn from_raw(raw: &'a [Self::PhysicalType]) -> TileDBResult<Self> {
+        <&'a str as FromFillValue<'a>>::from_raw(raw).map(|s| s.to_string())
     }
 }
 
@@ -440,7 +612,7 @@ impl<'ctx> TryFrom<&Attribute<'ctx>> for AttributeData {
         let fill = fn_typed!(datatype, LT, {
             type DT = <LT as LogicalType>::PhysicalType;
             let (fill_value, fill_value_nullability) =
-                attr.fill_value_nullable::<DT>()?;
+                attr.fill_value_nullable::<&[DT]>()?;
             FillData {
                 data: json!(fill_value),
                 nullability: Some(fill_value_nullability),
@@ -477,24 +649,26 @@ impl<'ctx> Factory<'ctx> for AttributeData {
             b = b.nullability(n)?;
         }
         if let Some(c) = self.cell_val_num {
-            b = b.cell_val_num(c)?;
+            if !matches!((self.datatype, c), (Datatype::Any, CellValNum::Var)) {
+                /* SC-46696 */
+                b = b.cell_val_num(c)?;
+            }
         }
         if let Some(ref fill) = self.fill {
             b = fn_typed!(self.datatype, LT, {
                 type DT = <LT as LogicalType>::PhysicalType;
-                let fill_value: DT = serde_json::from_value::<DT>(
-                    fill.data.clone(),
-                )
-                .map_err(|e| {
-                    Error::Deserialization(
-                        format!("attribute '{}' fill value", self.name),
-                        anyhow!(e),
-                    )
-                })?;
+                let fill_value: Vec<DT> =
+                    serde_json::from_value::<Vec<DT>>(fill.data.clone())
+                        .map_err(|e| {
+                            Error::Deserialization(
+                                format!("attribute '{}' fill value", self.name),
+                                anyhow!(e),
+                            )
+                        })?;
                 if let Some(fill_nullability) = fill.nullability {
-                    b.fill_value_nullability::<DT>(fill_value, fill_nullability)
+                    b.fill_value_nullability(fill_value, fill_nullability)
                 } else {
-                    b.fill_value::<DT>(fill_value)
+                    b.fill_value(fill_value)
                 }
             })?;
         }
@@ -722,8 +896,8 @@ mod test {
         {
             let attr = Builder::new(&ctx, "foo", Datatype::UInt32)?.build();
 
-            let val: u32 = attr.fill_value()?;
-            assert_eq!(val, u32::MAX);
+            let val: &[u32] = attr.fill_value()?;
+            assert_eq!(val, [u32::MAX]);
         }
 
         // override
@@ -732,8 +906,8 @@ mod test {
                 .fill_value(5_u32)?
                 .build();
 
-            let val: u32 = attr.fill_value()?;
-            assert_eq!(val, 5);
+            let val: &[u32] = attr.fill_value()?;
+            assert_eq!(val, [5]);
         }
 
         Ok(())
@@ -749,8 +923,8 @@ mod test {
                 .nullability(true)?
                 .build();
 
-            let (val, validity): (u32, bool) = attr.fill_value_nullable()?;
-            assert_eq!(val, u32::MAX);
+            let (val, validity): (&[u32], bool) = attr.fill_value_nullable()?;
+            assert_eq!(val, [u32::MAX]);
             assert!(!validity);
         }
 
@@ -761,8 +935,8 @@ mod test {
                 .fill_value_nullability(5_u32, true)?
                 .build();
 
-            let (val, validity): (u32, bool) = attr.fill_value_nullable()?;
-            assert_eq!(val, 5);
+            let (val, validity): (&[u32], bool) = attr.fill_value_nullable()?;
+            assert_eq!(val, [5]);
             assert!(validity);
         }
 
@@ -878,11 +1052,9 @@ mod test {
                 assert_ne!(base, other);
             }
             {
+                let new_fill_value = (base_fill_value / 2) + 1;
                 let other = default_attr()
-                    .fill_value_nullability(
-                        (base_fill_value / 2) + 1,
-                        base_fill_nullable,
-                    )
+                    .fill_value_nullability(new_fill_value, base_fill_nullable)
                     .expect("Error setting fill value")
                     .build();
                 assert_ne!(base, other);
@@ -910,12 +1082,11 @@ mod test {
                 assert!(other.is_err());
             }
             {
+                let new_fill_value = (base_fill_value / 2) + 1;
+
                 // just changing the value should also be fine
                 let other = default_attr()
-                    .fill_value_nullability(
-                        (base_fill_value / 2) + 1,
-                        base_fill_nullable,
-                    )
+                    .fill_value_nullability(new_fill_value, base_fill_nullable)
                     .expect("Error setting fill value")
                     .build();
                 assert_ne!(base, other);

--- a/tiledb/api/src/array/attribute/mod.rs
+++ b/tiledb/api/src/array/attribute/mod.rs
@@ -254,7 +254,7 @@ impl<'c1, 'c2> PartialEq<Attribute<'c2>> for Attribute<'c1> {
                         Ok((mine_value, mine_nullable)),
                         Ok((theirs_value, theirs_nullable)),
                     ) => {
-                        mine_value.bits_eq(&theirs_value)
+                        mine_value.bits_eq(theirs_value)
                             && mine_nullable == theirs_nullable
                     }
                     _ => false,
@@ -265,7 +265,7 @@ impl<'c1, 'c2> PartialEq<Attribute<'c2>> for Attribute<'c1> {
                 type DT = <LT as LogicalType>::PhysicalType;
                 match (self.fill_value::<&[DT]>(), other.fill_value::<&[DT]>())
                 {
-                    (Ok(mine), Ok(theirs)) => mine.bits_eq(&theirs),
+                    (Ok(mine), Ok(theirs)) => mine.bits_eq(theirs),
                     _ => false,
                 }
             })
@@ -458,7 +458,7 @@ impl<T> FromFillValue<'_> for T
 where
     T: PhysicalType,
 {
-    fn from_raw<'a>(raw: &'a [Self::PhysicalType]) -> TileDBResult<Self> {
+    fn from_raw(raw: &[Self::PhysicalType]) -> TileDBResult<Self> {
         if raw.len() == 1 {
             Ok(raw[0])
         } else {

--- a/tiledb/api/src/array/attribute/mod.rs
+++ b/tiledb/api/src/array/attribute/mod.rs
@@ -438,6 +438,7 @@ pub trait IntoFillValue {
     fn to_raw(&self) -> &[Self::PhysicalType];
 }
 
+/// Trait for data which can be constructed from an attribute's raw fill value.
 pub trait FromFillValue<'a>: IntoFillValue + Sized {
     /// Construct a value of this type from a raw fill value.
     fn from_raw(raw: &'a [Self::PhysicalType]) -> TileDBResult<Self>;
@@ -896,8 +897,8 @@ mod test {
         {
             let attr = Builder::new(&ctx, "foo", Datatype::UInt32)?.build();
 
-            let val: &[u32] = attr.fill_value()?;
-            assert_eq!(val, [u32::MAX]);
+            let val: u32 = attr.fill_value()?;
+            assert_eq!(val, u32::MAX);
         }
 
         // override
@@ -906,8 +907,8 @@ mod test {
                 .fill_value(5_u32)?
                 .build();
 
-            let val: &[u32] = attr.fill_value()?;
-            assert_eq!(val, [5]);
+            let val: u32 = attr.fill_value()?;
+            assert_eq!(val, 5);
         }
 
         Ok(())
@@ -923,8 +924,8 @@ mod test {
                 .nullability(true)?
                 .build();
 
-            let (val, validity): (&[u32], bool) = attr.fill_value_nullable()?;
-            assert_eq!(val, [u32::MAX]);
+            let (val, validity): (u32, bool) = attr.fill_value_nullable()?;
+            assert_eq!(val, u32::MAX);
             assert!(!validity);
         }
 
@@ -935,8 +936,8 @@ mod test {
                 .fill_value_nullability(5_u32, true)?
                 .build();
 
-            let (val, validity): (&[u32], bool) = attr.fill_value_nullable()?;
-            assert_eq!(val, [5]);
+            let (val, validity): (u32, bool) = attr.fill_value_nullable()?;
+            assert_eq!(val, 5);
             assert!(validity);
         }
 

--- a/tiledb/api/src/array/attribute/strategy.rs
+++ b/tiledb/api/src/array/attribute/strategy.rs
@@ -6,7 +6,6 @@ use serde_json::json;
 use crate::array::{
     attribute::FillData, ArrayType, AttributeData, CellValNum, DomainData,
 };
-use crate::datatype::strategy::*;
 use crate::datatype::LogicalType;
 use crate::filter::list::FilterListData;
 use crate::{fn_typed, Datatype};
@@ -34,10 +33,6 @@ pub fn prop_attribute_name() -> impl Strategy<Value = String> {
         )
 }
 
-fn prop_cell_val_num() -> impl Strategy<Value = Option<CellValNum>> {
-    Just(None)
-}
-
 fn prop_fill<T: Arbitrary>() -> impl Strategy<Value = T> {
     any::<T>()
 }
@@ -46,6 +41,7 @@ fn prop_fill<T: Arbitrary>() -> impl Strategy<Value = T> {
 /// datatype and other user requirements
 fn prop_filters(
     datatype: Datatype,
+    cell_val_num: CellValNum,
     requirements: Rc<Requirements>,
 ) -> impl Strategy<Value = FilterListData> {
     use crate::filter::strategy::{
@@ -55,10 +51,16 @@ fn prop_filters(
     let pipeline_requirements = FilterRequirements {
         context: requirements.context.as_ref().map(
             |StrategyContext::Schema(array_type, domain)| {
-                FilterContext::Attribute(datatype, *array_type, domain.clone())
+                FilterContext::Attribute(
+                    datatype,
+                    cell_val_num,
+                    *array_type,
+                    domain.clone(),
+                )
             },
         ),
         input_datatype: Some(datatype),
+        ..Default::default()
     };
 
     any_with::<FilterListData>(Rc::new(pipeline_requirements))
@@ -70,47 +72,43 @@ fn prop_attribute_for_datatype(
     datatype: Datatype,
     requirements: Rc<Requirements>,
 ) -> impl Strategy<Value = AttributeData> {
-    fn_typed!(datatype, LT, {
-        type DT = <LT as LogicalType>::PhysicalType;
-        let name = requirements
-            .name
-            .as_ref()
-            .map(|n| Just(n.clone()).boxed())
-            .unwrap_or(prop_attribute_name().boxed());
-        let nullable = requirements
-            .nullability
-            .as_ref()
-            .map(|n| Just(*n).boxed())
-            .unwrap_or(any::<bool>().boxed());
-        let cell_val_num = prop_cell_val_num();
-        let fill = prop_fill::<DT>();
-        let fill_nullable = any::<bool>();
-        let filters = prop_filters(datatype, requirements);
-        (name, nullable, cell_val_num, fill, fill_nullable, filters)
-            .prop_map(
-                move |(
-                    name,
-                    nullable,
-                    cell_val_num,
-                    fill,
-                    fill_nullable,
-                    filters,
-                )| {
-                    AttributeData {
-                        name,
-                        datatype,
-                        nullability: Some(nullable),
-                        cell_val_num,
-                        fill: Some(FillData {
-                            data: json!(fill),
-                            nullability: Some(nullable && fill_nullable),
-                        }),
-                        filters,
-                    }
+    fn_typed!(
+        datatype,
+        LT,
+        {
+            type DT = <LT as LogicalType>::PhysicalType;
+            let name = requirements
+                .name
+                .as_ref()
+                .map(|n| Just(n.clone()).boxed())
+                .unwrap_or(prop_attribute_name().boxed());
+            let nullable = requirements
+                .nullability
+                .as_ref()
+                .map(|n| Just(*n).boxed())
+                .unwrap_or(any::<bool>().boxed());
+            let cell_val_num = any::<CellValNum>();
+            let fill = prop_fill::<DT>();
+            let fill_nullable = any::<bool>();
+            (name, nullable, cell_val_num, fill, fill_nullable).prop_flat_map(
+                move |(name, nullable, cell_val_num, fill, fill_nullable)| {
+                    prop_filters(datatype, cell_val_num, requirements.clone())
+                        .prop_map(move |filters| AttributeData {
+                            name: name.clone(),
+                            datatype,
+                            nullability: Some(nullable),
+                            cell_val_num: Some(cell_val_num),
+                            fill: Some(FillData {
+                                data: json!(fill),
+                                nullability: Some(nullable && fill_nullable),
+                            }),
+                            filters,
+                        })
                 },
             )
-            .boxed()
-    })
+        }
+        .boxed()
+    )
 }
 
 pub fn prop_attribute(
@@ -119,7 +117,7 @@ pub fn prop_attribute(
     let datatype = requirements
         .datatype
         .map(|d| Just(d).boxed())
-        .unwrap_or(prop_datatype_implemented().boxed());
+        .unwrap_or(any::<Datatype>());
 
     datatype.prop_flat_map(move |datatype| {
         prop_attribute_for_datatype(datatype, requirements.clone())

--- a/tiledb/api/src/array/dimension/arrow.rs
+++ b/tiledb/api/src/array/dimension/arrow.rs
@@ -17,8 +17,8 @@ use crate::{error::Error as TileDBError, fn_typed, Result as TileDBResult};
 #[derive(Deserialize, Serialize)]
 pub struct DimensionMetadata {
     pub cell_val_num: CellValNum,
-    pub domain: [serde_json::value::Value; 2],
-    pub extent: serde_json::value::Value,
+    pub domain: Option<[serde_json::value::Value; 2]>,
+    pub extent: Option<serde_json::value::Value>,
     pub filters: FilterMetadata,
 }
 
@@ -31,8 +31,8 @@ impl DimensionMetadata {
 
             Ok(DimensionMetadata {
                 cell_val_num: dim.cell_val_num()?,
-                domain: [json!(domain[0]), json!(domain[1])],
-                extent: json!(extent),
+                domain: domain.map(|d| [json!(d[0]), json!(d[1])]),
+                extent: extent.map(|e| json!(e)),
                 filters: FilterMetadata::new(&dim.filters()?)?,
             })
         })
@@ -99,16 +99,35 @@ pub fn tiledb_dimension<'ctx>(
             })
         };
 
-        let domain = [deser(&metadata.domain[0])?, deser(&metadata.domain[1])?];
-        let extent = deser(&metadata.extent)?;
+        let domain = if let Some(d) = metadata.domain {
+            Some([deser(&d[0])?, deser(&d[1])?])
+        } else {
+            None
+        };
+        let extent = if let Some(e) = metadata.extent {
+            Some(deser(&e)?)
+        } else {
+            None
+        };
 
-        DimensionBuilder::new::<DT>(
-            context,
-            field.name(),
-            tiledb_datatype,
-            &domain,
-            &extent,
-        )
+        match (domain, extent) {
+            (Some(domain), Some(extent)) => DimensionBuilder::new::<DT>(
+                context,
+                field.name(),
+                tiledb_datatype,
+                &domain,
+                &extent,
+            ),
+            (None, None) => DimensionBuilder::new_string(
+                context,
+                field.name(),
+                tiledb_datatype,
+            ),
+            _ => {
+                /* TODO: refactor so there is only one Option such that this is actually true */
+                unreachable!()
+            }
+        }
     })?;
 
     let fl = metadata

--- a/tiledb/api/src/array/dimension/arrow.rs
+++ b/tiledb/api/src/array/dimension/arrow.rs
@@ -124,7 +124,10 @@ pub fn tiledb_dimension<'ctx>(
                 tiledb_datatype,
             ),
             _ => {
-                /* TODO: refactor so there is only one Option such that this is actually true */
+                /*
+                 * TODO: refactor so there is only one Option such that this is actually true.
+                 * Related to SC-466692
+                 */
                 unreachable!()
             }
         }

--- a/tiledb/api/src/array/dimension/mod.rs
+++ b/tiledb/api/src/array/dimension/mod.rs
@@ -93,7 +93,7 @@ impl<'ctx> Dimension<'ctx> {
             )
         })?;
 
-        if c_domain_ptr == std::ptr::null() {
+        if c_domain_ptr.is_null() {
             Ok(None)
         } else {
             let c_domain: &[T; 2] = unsafe { &*c_domain_ptr.cast::<[T; 2]>() };
@@ -114,7 +114,7 @@ impl<'ctx> Dimension<'ctx> {
             )
         })?;
 
-        if c_extent_ptr == std::ptr::null() {
+        if c_extent_ptr.is_null() {
             Ok(None)
         } else {
             Ok(Some(unsafe { *c_extent_ptr.cast::<T>() }))

--- a/tiledb/api/src/array/dimension/strategy.rs
+++ b/tiledb/api/src/array/dimension/strategy.rs
@@ -122,24 +122,38 @@ pub fn prop_dimension_for_datatype(
     fn_typed!(datatype, LT, {
         type DT = <LT as LogicalType>::PhysicalType;
         let name = prop_dimension_name();
-        let range_and_extent = prop_range_and_extent::<DT>();
+        let range_and_extent = if !datatype.is_string_type() {
+            prop_range_and_extent::<DT>().prop_map(Some).boxed()
+        } else {
+            Just(None).boxed()
+        };
         let filters = any_with::<FilterListData>(Rc::new(FilterRequirements {
             input_datatype: Some(datatype),
             context: Some(FilterContext::Dimension(datatype, cell_val_num)),
             ..Default::default()
         }));
         (name, range_and_extent, filters)
-            .prop_map(move |(name, values, filters)| DimensionData {
-                name,
-                datatype,
-                domain: Some([json!(values.0[0]), json!(values.0[1])]),
-                extent: Some(json!(values.1)),
-                cell_val_num: Some(cell_val_num),
-                filters: if filters.is_empty() {
-                    None
-                } else {
-                    Some(filters)
-                },
+            .prop_map(move |(name, values, filters)| {
+                let (domain, extent) = match values {
+                    None => (None, None),
+                    Some((domain, extent)) => (
+                        Some([json![domain[0]], json![domain[1]]]),
+                        Some(json!(extent)),
+                    ),
+                };
+
+                DimensionData {
+                    name,
+                    datatype,
+                    domain,
+                    extent,
+                    cell_val_num: Some(cell_val_num),
+                    filters: if filters.is_empty() {
+                        None
+                    } else {
+                        Some(filters)
+                    },
+                }
             })
             .boxed()
     })

--- a/tiledb/api/src/array/dimension/strategy.rs
+++ b/tiledb/api/src/array/dimension/strategy.rs
@@ -9,11 +9,13 @@ use tiledb_utils::numbers::{
     NextDirection, NextNumericValue, SmallestPositiveValue,
 };
 
-use crate::array::{ArrayType, DimensionData};
+use crate::array::{ArrayType, CellValNum, DimensionData};
 use crate::datatype::strategy::*;
 use crate::datatype::LogicalType;
 use crate::filter::list::FilterListData;
-use crate::filter::strategy::Requirements as FilterRequirements;
+use crate::filter::strategy::{
+    Requirements as FilterRequirements, StrategyContext as FilterContext,
+};
 use crate::{fn_typed, Datatype};
 
 pub fn prop_dimension_name() -> impl Strategy<Value = String> {
@@ -112,12 +114,18 @@ where
 pub fn prop_dimension_for_datatype(
     datatype: Datatype,
 ) -> impl Strategy<Value = DimensionData> {
+    let cell_val_num = if datatype.is_string_type() {
+        CellValNum::Var
+    } else {
+        CellValNum::single()
+    };
     fn_typed!(datatype, LT, {
         type DT = <LT as LogicalType>::PhysicalType;
         let name = prop_dimension_name();
         let range_and_extent = prop_range_and_extent::<DT>();
         let filters = any_with::<FilterListData>(Rc::new(FilterRequirements {
             input_datatype: Some(datatype),
+            context: Some(FilterContext::Dimension(datatype, cell_val_num)),
             ..Default::default()
         }));
         (name, range_and_extent, filters)
@@ -126,7 +134,7 @@ pub fn prop_dimension_for_datatype(
                 datatype,
                 domain: Some([json!(values.0[0]), json!(values.0[1])]),
                 extent: Some(json!(values.1)),
-                cell_val_num: None,
+                cell_val_num: Some(cell_val_num),
                 filters: if filters.is_empty() {
                     None
                 } else {
@@ -141,8 +149,12 @@ pub fn prop_dimension_for_array_type(
     array_type: ArrayType,
 ) -> impl Strategy<Value = DimensionData> {
     match array_type {
-        ArrayType::Dense => prop_datatype_for_dense_dimension().boxed(),
-        ArrayType::Sparse => prop_datatype_implemented().boxed(),
+        ArrayType::Dense => {
+            any_with::<Datatype>(DatatypeContext::DenseDimension)
+        }
+        ArrayType::Sparse => {
+            any_with::<Datatype>(DatatypeContext::SparseDimension)
+        }
     }
     .prop_flat_map(prop_dimension_for_datatype)
 }

--- a/tiledb/api/src/array/domain/strategy.rs
+++ b/tiledb/api/src/array/domain/strategy.rs
@@ -5,6 +5,7 @@ use proptest::prelude::*;
 use crate::array::dimension::strategy::*;
 use crate::array::{ArrayType, DomainData};
 use crate::datatype::strategy::*;
+use crate::Datatype;
 
 const MIN_DIMENSIONS: usize = 1;
 const MAX_DIMENSIONS: usize = 8;
@@ -18,14 +19,16 @@ fn prop_domain_for_array_type(
     array_type: ArrayType,
 ) -> impl Strategy<Value = DomainData> {
     match array_type {
-        ArrayType::Dense => prop_datatype_for_dense_dimension()
-            .prop_flat_map(|dimension_type| {
-                proptest::collection::vec(
-                    prop_dimension_for_datatype(dimension_type),
-                    MIN_DIMENSIONS..=MAX_DIMENSIONS,
-                )
-            })
-            .boxed(),
+        ArrayType::Dense => {
+            any_with::<Datatype>(DatatypeContext::DenseDimension)
+                .prop_flat_map(|dimension_type| {
+                    proptest::collection::vec(
+                        prop_dimension_for_datatype(dimension_type),
+                        MIN_DIMENSIONS..=MAX_DIMENSIONS,
+                    )
+                })
+                .boxed()
+        }
         ArrayType::Sparse => proptest::collection::vec(
             prop_dimension_for_array_type(array_type),
             MIN_DIMENSIONS..=MAX_DIMENSIONS,

--- a/tiledb/api/src/array/enumeration/strategy.rs
+++ b/tiledb/api/src/array/enumeration/strategy.rs
@@ -4,7 +4,6 @@ use proptest::collection::vec;
 use proptest::prelude::*;
 
 use crate::array::EnumerationData;
-use crate::datatype::strategy::*;
 use crate::datatype::{LogicalType, PhysicalType};
 use crate::{fn_typed, Datatype};
 
@@ -68,7 +67,7 @@ pub fn prop_enumeration_for_datatype(
 }
 
 pub fn prop_enumeration() -> impl Strategy<Value = EnumerationData> {
-    prop_datatype_implemented().prop_flat_map(prop_enumeration_for_datatype)
+    any::<Datatype>().prop_flat_map(prop_enumeration_for_datatype)
 }
 
 #[cfg(test)]

--- a/tiledb/api/src/array/schema/mod.rs
+++ b/tiledb/api/src/array/schema/mod.rs
@@ -1007,11 +1007,11 @@ mod tests {
         assert_eq!(Datatype::Int32, rows.datatype().unwrap());
         // TODO: add method to check min/max
 
-        let rows_domain = rows.domain::<i32>().unwrap();
+        let rows_domain = rows.domain::<i32>().unwrap().unwrap();
         assert_eq!(rows_domain[0], 1);
         assert_eq!(rows_domain[1], 4);
 
-        let cols_domain = cols.domain::<i32>().unwrap();
+        let cols_domain = cols.domain::<i32>().unwrap().unwrap();
         assert_eq!(cols_domain[0], 1);
         assert_eq!(cols_domain[1], 4);
 

--- a/tiledb/api/src/array/schema/strategy.rs
+++ b/tiledb/api/src/array/schema/strategy.rs
@@ -28,16 +28,21 @@ impl Arbitrary for CellValNum {
     type Parameters = Option<std::ops::Range<NonZeroU32>>;
 
     fn arbitrary_with(r: Self::Parameters) -> Self::Strategy {
-        let r = r.unwrap_or(
-            NonZeroU32::new(1).unwrap()..NonZeroU32::new(u32::MAX).unwrap(),
-        );
-
-        prop_oneof![
-            (r.start.get()..r.end.get())
-                .prop_map(|c| CellValNum::try_from(c).unwrap()),
-            Just(CellValNum::Var)
-        ]
-        .boxed()
+        if let Some(range) = r {
+            (range.start.get()..range.end.get())
+                .prop_map(|nz| CellValNum::try_from(nz).unwrap())
+                .boxed()
+        } else {
+            prop_oneof![
+                30 => Just(CellValNum::single()),
+                30 => Just(CellValNum::Var),
+                20 => (2u32..=8).prop_map(|nz| CellValNum::try_from(nz).unwrap()),
+                10 => (9u32..=16).prop_map(|nz| CellValNum::try_from(nz).unwrap()),
+                5 => (17u32..=32).prop_map(|nz| CellValNum::try_from(nz).unwrap()),
+                3 => (33u32..=64).prop_map(|nz| CellValNum::try_from(nz).unwrap()),
+                2 => (65u32..=2048).prop_map(|nz| CellValNum::try_from(nz).unwrap()),
+            ].boxed()
+        }
     }
 }
 

--- a/tiledb/api/src/datatype/arrow.rs
+++ b/tiledb/api/src/datatype/arrow.rs
@@ -208,7 +208,7 @@ pub mod strategy {
 
     pub fn prop_arrow_implemented(
     ) -> impl Strategy<Value = arrow_schema::DataType> {
-        crate::datatype::strategy::prop_datatype_implemented()
+        any::<Datatype>()
             .prop_map(|dt| arrow_type_physical(&dt)
                 .expect("Datatype claims to be implemented but does not have an arrow equivalent"))
     }
@@ -245,13 +245,6 @@ pub mod tests {
         ]
     }
 
-    pub fn prop_arrow_implemented(
-    ) -> impl Strategy<Value = arrow_schema::DataType> {
-        crate::datatype::strategy::prop_datatype_implemented()
-            .prop_map(|dt| arrow_type_physical(&dt)
-                .expect("Datatype claims to be implemented but does not have an arrow equivalent"))
-    }
-
     mod strategy {
         use super::*;
 
@@ -274,7 +267,7 @@ pub mod tests {
 
     proptest! {
         #[test]
-        fn test_physical(tdb_dt in crate::datatype::strategy::prop_datatype()) {
+        fn test_physical(tdb_dt in any::<Datatype>()) {
             if let Some(arrow_dt) = arrow_type_physical(&tdb_dt) {
                 assert!(is_same_physical_type(&tdb_dt, &arrow_dt));
                 if let Some(adt_width) = arrow_dt.primitive_width() {

--- a/tiledb/api/src/datatype/arrow.rs
+++ b/tiledb/api/src/datatype/arrow.rs
@@ -177,7 +177,6 @@ pub fn is_same_physical_type(
 
 #[cfg(any(feature = "proptest-strategies", test))]
 pub mod strategy {
-    use super::*;
     use proptest::prelude::*;
 
     /// Returns a strategy for generating any Arrow data type
@@ -208,9 +207,8 @@ pub mod strategy {
 
     pub fn prop_arrow_implemented(
     ) -> impl Strategy<Value = arrow_schema::DataType> {
-        any::<Datatype>()
-            .prop_map(|dt| arrow_type_physical(&dt)
-                .expect("Datatype claims to be implemented but does not have an arrow equivalent"))
+        /* note to the reviewer, this is going to be blasted away in short order by #87 */
+        prop_arrow_invertible()
     }
 }
 

--- a/tiledb/api/src/datatype/mod.rs
+++ b/tiledb/api/src/datatype/mod.rs
@@ -377,20 +377,24 @@ impl Datatype {
 
     /// Returns whether this type can be used as a dimension type of a sparse array
     pub fn is_allowed_dimension_type_sparse(&self) -> bool {
-        self.is_integral_type()
-            || self.is_datetime_type()
-            || self.is_time_type()
-            || matches!(
-                *self,
-                Datatype::Float32 | Datatype::Float64 | Datatype::StringAscii
-            )
+        !matches!(self, Datatype::Boolean)
+            && (self.is_integral_type()
+                || self.is_datetime_type()
+                || self.is_time_type()
+                || matches!(
+                    *self,
+                    Datatype::Float32
+                        | Datatype::Float64
+                        | Datatype::StringAscii
+                ))
     }
 
     /// Returns whether this type can be used as a dimension type of a dense array
     pub fn is_allowed_dimension_type_dense(&self) -> bool {
-        self.is_integral_type()
-            || self.is_datetime_type()
-            || self.is_time_type()
+        !matches!(self, Datatype::Boolean)
+            && (self.is_integral_type()
+                || self.is_datetime_type()
+                || self.is_time_type())
     }
 
     #[cfg(test)]

--- a/tiledb/api/src/datatype/strategy.rs
+++ b/tiledb/api/src/datatype/strategy.rs
@@ -2,7 +2,7 @@ use proptest::prelude::*;
 
 use crate::Datatype;
 
-pub fn prop_datatype() -> impl Strategy<Value = Datatype> {
+fn prop_datatype() -> impl Strategy<Value = Datatype> {
     prop_oneof![
         Just(Datatype::Int8),
         Just(Datatype::Int16),
@@ -51,10 +51,44 @@ pub fn prop_datatype() -> impl Strategy<Value = Datatype> {
     ]
 }
 
-/// Choose an arbitrary datatype which is implemented
-/// (satisfies CAPIConv, and has cases in fn_typed)
-// TODO: make sure to keep this list up to date as we add more types
-pub fn prop_datatype_implemented() -> impl Strategy<Value = Datatype> {
+fn prop_datatype_for_dense_dimension() -> impl Strategy<Value = Datatype> {
+    /* see `Datatype::is_allowed_dimension_type_dense` */
+    prop_oneof![
+        Just(Datatype::Int8),
+        Just(Datatype::Int16),
+        Just(Datatype::Int32),
+        Just(Datatype::Int64),
+        Just(Datatype::UInt8),
+        Just(Datatype::UInt16),
+        Just(Datatype::UInt32),
+        Just(Datatype::UInt64),
+        Just(Datatype::DateTimeYear),
+        Just(Datatype::DateTimeMonth),
+        Just(Datatype::DateTimeWeek),
+        Just(Datatype::DateTimeDay),
+        Just(Datatype::DateTimeHour),
+        Just(Datatype::DateTimeMinute),
+        Just(Datatype::DateTimeSecond),
+        Just(Datatype::DateTimeMillisecond),
+        Just(Datatype::DateTimeMicrosecond),
+        Just(Datatype::DateTimeNanosecond),
+        Just(Datatype::DateTimePicosecond),
+        Just(Datatype::DateTimeFemtosecond),
+        Just(Datatype::DateTimeAttosecond),
+        Just(Datatype::TimeHour),
+        Just(Datatype::TimeMinute),
+        Just(Datatype::TimeSecond),
+        Just(Datatype::TimeMillisecond),
+        Just(Datatype::TimeMicrosecond),
+        Just(Datatype::TimeNanosecond),
+        Just(Datatype::TimePicosecond),
+        Just(Datatype::TimeFemtosecond),
+        Just(Datatype::TimeAttosecond),
+    ]
+}
+
+fn prop_datatype_for_sparse_dimension() -> impl Strategy<Value = Datatype> {
+    /* see `Datatype::is_allowed_dimension_type_sparse` */
     prop_oneof![
         Just(Datatype::Int8),
         Just(Datatype::Int16),
@@ -66,14 +100,30 @@ pub fn prop_datatype_implemented() -> impl Strategy<Value = Datatype> {
         Just(Datatype::UInt64),
         Just(Datatype::Float32),
         Just(Datatype::Float64),
+        Just(Datatype::DateTimeYear),
+        Just(Datatype::DateTimeMonth),
+        Just(Datatype::DateTimeWeek),
+        Just(Datatype::DateTimeDay),
+        Just(Datatype::DateTimeHour),
+        Just(Datatype::DateTimeMinute),
+        Just(Datatype::DateTimeSecond),
+        Just(Datatype::DateTimeMillisecond),
+        Just(Datatype::DateTimeMicrosecond),
+        Just(Datatype::DateTimeNanosecond),
+        Just(Datatype::DateTimePicosecond),
+        Just(Datatype::DateTimeFemtosecond),
+        Just(Datatype::DateTimeAttosecond),
+        Just(Datatype::TimeHour),
+        Just(Datatype::TimeMinute),
+        Just(Datatype::TimeSecond),
+        Just(Datatype::TimeMillisecond),
+        Just(Datatype::TimeMicrosecond),
+        Just(Datatype::TimeNanosecond),
+        Just(Datatype::TimePicosecond),
+        Just(Datatype::TimeFemtosecond),
+        Just(Datatype::TimeAttosecond),
+        Just(Datatype::StringAscii),
     ]
-}
-
-pub fn prop_datatype_for_dense_dimension() -> impl Strategy<Value = Datatype> {
-    prop_datatype_implemented().prop_filter(
-        "Type is not a valid dimension type for dense arrays",
-        |dt| dt.is_allowed_dimension_type_dense(),
-    )
 }
 
 #[derive(Clone, Debug, Default)]
@@ -81,7 +131,7 @@ pub enum DatatypeContext {
     #[default]
     Any,
     DenseDimension,
-    Implemented,
+    SparseDimension,
 }
 
 impl Arbitrary for Datatype {
@@ -94,7 +144,26 @@ impl Arbitrary for Datatype {
             DatatypeContext::DenseDimension => {
                 prop_datatype_for_dense_dimension().boxed()
             }
-            DatatypeContext::Implemented => prop_datatype_implemented().boxed(),
+            DatatypeContext::SparseDimension => {
+                prop_datatype_for_sparse_dimension().boxed()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    proptest! {
+        #[test]
+        fn dense_dimension(dt in any_with::<Datatype>(DatatypeContext::DenseDimension)) {
+            assert!(dt.is_allowed_dimension_type_dense())
+        }
+
+        #[test]
+        fn sparse_dimension(dt in any_with::<Datatype>(DatatypeContext::SparseDimension)) {
+            assert!(dt.is_allowed_dimension_type_sparse())
         }
     }
 }

--- a/tiledb/api/src/datatype/strategy.rs
+++ b/tiledb/api/src/datatype/strategy.rs
@@ -51,79 +51,89 @@ fn prop_datatype() -> impl Strategy<Value = Datatype> {
     ]
 }
 
+const DENSE_DIMENSION_DATATYPES: [Datatype; 31] = [
+    Datatype::Int8,
+    Datatype::Int16,
+    Datatype::Int32,
+    Datatype::Int64,
+    Datatype::UInt8,
+    Datatype::UInt16,
+    Datatype::UInt32,
+    Datatype::UInt64,
+    Datatype::DateTimeYear,
+    Datatype::DateTimeMonth,
+    Datatype::DateTimeWeek,
+    Datatype::DateTimeDay,
+    Datatype::DateTimeHour,
+    Datatype::DateTimeMinute,
+    Datatype::DateTimeSecond,
+    Datatype::DateTimeMillisecond,
+    Datatype::DateTimeMicrosecond,
+    Datatype::DateTimeNanosecond,
+    Datatype::DateTimePicosecond,
+    Datatype::DateTimeFemtosecond,
+    Datatype::DateTimeAttosecond,
+    Datatype::TimeHour,
+    Datatype::TimeMinute,
+    Datatype::TimeSecond,
+    Datatype::TimeMillisecond,
+    Datatype::TimeMicrosecond,
+    Datatype::TimeNanosecond,
+    Datatype::TimePicosecond,
+    Datatype::TimeFemtosecond,
+    Datatype::TimeAttosecond,
+    Datatype::Boolean,
+];
+
+const SPARSE_DIMENSION_DATATYPES: [Datatype; 34] = [
+    Datatype::Int8,
+    Datatype::Int16,
+    Datatype::Int32,
+    Datatype::Int64,
+    Datatype::UInt8,
+    Datatype::UInt16,
+    Datatype::UInt32,
+    Datatype::UInt64,
+    Datatype::Float32,
+    Datatype::Float64,
+    Datatype::DateTimeYear,
+    Datatype::DateTimeMonth,
+    Datatype::DateTimeWeek,
+    Datatype::DateTimeDay,
+    Datatype::DateTimeHour,
+    Datatype::DateTimeMinute,
+    Datatype::DateTimeSecond,
+    Datatype::DateTimeMillisecond,
+    Datatype::DateTimeMicrosecond,
+    Datatype::DateTimeNanosecond,
+    Datatype::DateTimePicosecond,
+    Datatype::DateTimeFemtosecond,
+    Datatype::DateTimeAttosecond,
+    Datatype::TimeHour,
+    Datatype::TimeMinute,
+    Datatype::TimeSecond,
+    Datatype::TimeMillisecond,
+    Datatype::TimeMicrosecond,
+    Datatype::TimeNanosecond,
+    Datatype::TimePicosecond,
+    Datatype::TimeFemtosecond,
+    Datatype::TimeAttosecond,
+    Datatype::StringAscii,
+    Datatype::Boolean,
+];
+
 fn prop_datatype_for_dense_dimension() -> impl Strategy<Value = Datatype> {
     /* see `Datatype::is_allowed_dimension_type_dense` */
-    prop_oneof![
-        Just(Datatype::Int8),
-        Just(Datatype::Int16),
-        Just(Datatype::Int32),
-        Just(Datatype::Int64),
-        Just(Datatype::UInt8),
-        Just(Datatype::UInt16),
-        Just(Datatype::UInt32),
-        Just(Datatype::UInt64),
-        Just(Datatype::DateTimeYear),
-        Just(Datatype::DateTimeMonth),
-        Just(Datatype::DateTimeWeek),
-        Just(Datatype::DateTimeDay),
-        Just(Datatype::DateTimeHour),
-        Just(Datatype::DateTimeMinute),
-        Just(Datatype::DateTimeSecond),
-        Just(Datatype::DateTimeMillisecond),
-        Just(Datatype::DateTimeMicrosecond),
-        Just(Datatype::DateTimeNanosecond),
-        Just(Datatype::DateTimePicosecond),
-        Just(Datatype::DateTimeFemtosecond),
-        Just(Datatype::DateTimeAttosecond),
-        Just(Datatype::TimeHour),
-        Just(Datatype::TimeMinute),
-        Just(Datatype::TimeSecond),
-        Just(Datatype::TimeMillisecond),
-        Just(Datatype::TimeMicrosecond),
-        Just(Datatype::TimeNanosecond),
-        Just(Datatype::TimePicosecond),
-        Just(Datatype::TimeFemtosecond),
-        Just(Datatype::TimeAttosecond),
-    ]
+    proptest::strategy::Union::new(
+        DENSE_DIMENSION_DATATYPES.iter().map(|dt| Just(*dt)),
+    )
 }
 
 fn prop_datatype_for_sparse_dimension() -> impl Strategy<Value = Datatype> {
     /* see `Datatype::is_allowed_dimension_type_sparse` */
-    prop_oneof![
-        Just(Datatype::Int8),
-        Just(Datatype::Int16),
-        Just(Datatype::Int32),
-        Just(Datatype::Int64),
-        Just(Datatype::UInt8),
-        Just(Datatype::UInt16),
-        Just(Datatype::UInt32),
-        Just(Datatype::UInt64),
-        Just(Datatype::Float32),
-        Just(Datatype::Float64),
-        Just(Datatype::DateTimeYear),
-        Just(Datatype::DateTimeMonth),
-        Just(Datatype::DateTimeWeek),
-        Just(Datatype::DateTimeDay),
-        Just(Datatype::DateTimeHour),
-        Just(Datatype::DateTimeMinute),
-        Just(Datatype::DateTimeSecond),
-        Just(Datatype::DateTimeMillisecond),
-        Just(Datatype::DateTimeMicrosecond),
-        Just(Datatype::DateTimeNanosecond),
-        Just(Datatype::DateTimePicosecond),
-        Just(Datatype::DateTimeFemtosecond),
-        Just(Datatype::DateTimeAttosecond),
-        Just(Datatype::TimeHour),
-        Just(Datatype::TimeMinute),
-        Just(Datatype::TimeSecond),
-        Just(Datatype::TimeMillisecond),
-        Just(Datatype::TimeMicrosecond),
-        Just(Datatype::TimeNanosecond),
-        Just(Datatype::TimePicosecond),
-        Just(Datatype::TimeFemtosecond),
-        Just(Datatype::TimeAttosecond),
-        Just(Datatype::StringAscii),
-    ]
+    proptest::strategy::Union::new(
+        SPARSE_DIMENSION_DATATYPES.iter().map(|dt| Just(*dt)),
+    )
 }
 
 #[derive(Clone, Debug, Default)]
@@ -162,8 +172,26 @@ mod tests {
         }
 
         #[test]
+        fn dense_dimension_comprehensive(dt in any::<Datatype>()) {
+            if DENSE_DIMENSION_DATATYPES.contains(&dt) {
+                assert!(dt.is_allowed_dimension_type_dense());
+            } else {
+                assert!(!dt.is_allowed_dimension_type_dense());
+            }
+        }
+
+        #[test]
         fn sparse_dimension(dt in any_with::<Datatype>(DatatypeContext::SparseDimension)) {
             assert!(dt.is_allowed_dimension_type_sparse())
+        }
+
+        #[test]
+        fn sparse_dimension_comprehensive(dt in any::<Datatype>()) {
+            if SPARSE_DIMENSION_DATATYPES.contains(&dt) {
+                assert!(dt.is_allowed_dimension_type_sparse());
+            } else {
+                assert!(!dt.is_allowed_dimension_type_sparse());
+            }
         }
     }
 }

--- a/tiledb/api/src/filter/strategy.rs
+++ b/tiledb/api/src/filter/strategy.rs
@@ -1,19 +1,42 @@
-use std::collections::VecDeque;
 use std::rc::Rc;
 
 use proptest::prelude::*;
 use proptest::strategy::{NewTree, ValueTree};
 use proptest::test_runner::TestRunner;
 
-use crate::array::{ArrayType, DomainData};
-use crate::datatype::strategy::*;
+use crate::array::{ArrayType, CellValNum, DomainData};
 use crate::filter::list::FilterListData;
 use crate::filter::*;
 
 #[derive(Clone, Debug)]
 pub enum StrategyContext {
-    Attribute(Datatype, ArrayType, Rc<DomainData>),
+    Attribute(Datatype, CellValNum, ArrayType, Rc<DomainData>),
+    Dimension(Datatype, CellValNum),
     SchemaCoordinates(Rc<DomainData>),
+}
+
+impl StrategyContext {
+    /// Returns the input to the filter pipeline
+    /// (whereas `input_datatype` is the input to the current filter)
+    pub fn pipeline_input_datatypes(
+        &self,
+    ) -> Option<Vec<(Datatype, Option<CellValNum>)>> {
+        match self {
+            StrategyContext::Attribute(dt, cvn, _, _) => {
+                Some(vec![(*dt, Some(*cvn))])
+            }
+            StrategyContext::Dimension(dt, cvn) => {
+                Some(vec![(*dt, Some(*cvn))])
+            }
+            StrategyContext::SchemaCoordinates(domain) => Some(
+                domain
+                    .dimension
+                    .iter()
+                    .map(|d| (d.datatype, d.cell_val_num))
+                    .collect::<Vec<(Datatype, Option<CellValNum>)>>(),
+            ),
+        }
+    }
 }
 
 /// Defines requirements for what a generated filter must be able to accept
@@ -21,6 +44,7 @@ pub enum StrategyContext {
 pub struct Requirements {
     pub input_datatype: Option<Datatype>,
     pub context: Option<StrategyContext>,
+    pub pipeline_position: Option<usize>,
 }
 
 fn prop_bitwidthreduction() -> impl Strategy<Value = FilterData> {
@@ -41,7 +65,7 @@ fn prop_compression_delta_strategies(
 ) -> Vec<BoxedStrategy<CompressionType>> {
     if let Some(input_datatype) = input_datatype {
         if input_datatype.is_real_type() {
-            let delta = prop_datatype()
+            let delta = any::<Datatype>()
                 .prop_filter(
                     "input_datatype is floating-point, input must not be Any",
                     move |dt| {
@@ -56,7 +80,7 @@ fn prop_compression_delta_strategies(
                     reinterpret_datatype: Some(dt),
                 });
 
-            let double_delta = prop_datatype()
+            let double_delta = any::<Datatype>()
                 .prop_filter(
                     "input_datatype is floating-point, input must not be Any",
                     move |dt| {
@@ -76,14 +100,14 @@ fn prop_compression_delta_strategies(
     }
 
     /* any non-float type is allowed */
-    let delta = prop_datatype()
+    let delta = any::<Datatype>()
         .prop_filter("reinterpret_datatype cannot be floating-point", |dt| {
             !dt.is_real_type()
         })
         .prop_map(|dt| CompressionType::Delta {
             reinterpret_datatype: Some(dt),
         });
-    let double_delta = prop_datatype()
+    let double_delta = any::<Datatype>()
         .prop_filter("reinterpret_datatype cannot be floating-point", |dt| {
             !dt.is_real_type()
         })
@@ -103,12 +127,36 @@ fn prop_compression(
     // always availalble
     let compression_types = vec![
         CompressionType::Bzip2,
-        CompressionType::Dictionary,
         CompressionType::Gzip,
         CompressionType::Lz4,
-        CompressionType::Rle,
         CompressionType::Zstd,
     ];
+
+    let try_rle = if matches!(requirements.pipeline_position, Some(p) if p > 0)
+    {
+        if let Some(dts) = requirements
+            .context
+            .as_ref()
+            .and_then(|c| c.pipeline_input_datatypes())
+        {
+            let mut try_rle = true;
+            for (dt, cvn) in dts {
+                if let Some(CellValNum::Var) = cvn {
+                    if dt.is_string_type() {
+                        try_rle = false;
+                        break;
+                    }
+                }
+            }
+            try_rle
+        } else {
+            true
+        }
+    } else {
+        true
+    };
+
+    let try_dict = try_rle;
 
     let try_delta =
         if let Some(StrategyContext::SchemaCoordinates(ref domain)) =
@@ -129,19 +177,27 @@ fn prop_compression(
         } else {
             true
         };
-    let strat_kind = if try_delta {
-        let delta_strategies =
-            prop_compression_delta_strategies(requirements.input_datatype);
 
-        let strats = compression_types
+    let strat_kind = {
+        let mut strats = compression_types
             .into_iter()
             .map(|ct| Just(ct).boxed())
-            .chain(delta_strategies)
-            .collect::<Vec<_>>();
+            .collect::<Vec<BoxedStrategy<CompressionType>>>();
+        if try_rle {
+            strats.push(Just(CompressionType::Rle).boxed());
+        }
+        if try_dict {
+            strats.push(Just(CompressionType::Dictionary).boxed());
+        }
+        if try_delta {
+            for strat in
+                prop_compression_delta_strategies(requirements.input_datatype)
+            {
+                strats.push(strat);
+            }
+        }
+
         proptest::strategy::Union::new(strats).boxed()
-    } else {
-        proptest::strategy::Union::new(compression_types.into_iter().map(Just))
-            .boxed()
     };
 
     (strat_kind, MIN_COMPRESSION_LEVEL..=MAX_COMPRESSION_LEVEL).prop_map(
@@ -194,6 +250,7 @@ fn prop_webp(
 ) -> Option<impl Strategy<Value = FilterData>> {
     if let Some(StrategyContext::Attribute(
         attribute_type,
+        _,
         array_type,
         ref domain,
     )) = requirements.context.as_ref()
@@ -308,70 +365,6 @@ pub fn prop_filter(
     proptest::strategy::Union::new(filter_strategies)
 }
 
-fn prop_filter_pipeline_impl(
-    requirements: Rc<Requirements>,
-    nfilters: usize,
-) -> impl Strategy<Value = VecDeque<FilterData>> {
-    if nfilters == 0 {
-        Just(VecDeque::new()).boxed()
-    } else {
-        prop_filter(Rc::clone(&requirements))
-            .prop_flat_map(move |filter| {
-                // If the transformed datatype is None then we have a bug.
-                // Do not panic here, that will swallow what the pipeline looked like.
-                // Let the unit test fail and print the input.
-                let next = requirements
-                    .input_datatype
-                    .and_then(|dt| filter.transform_datatype(&dt));
-                let next_requirements = Requirements {
-                    input_datatype: next,
-                    ..(*requirements).clone()
-                };
-                prop_filter_pipeline_impl(
-                    Rc::new(next_requirements),
-                    nfilters - 1,
-                )
-                .boxed()
-                .prop_map(move |mut filter_vec| {
-                    filter_vec.push_front(filter.clone());
-                    filter_vec
-                })
-            })
-            .boxed()
-    }
-}
-
-fn prop_filter_pipeline(
-    requirements: Rc<Requirements>,
-) -> impl Strategy<Value = FilterListData> {
-    const MIN_FILTERS: usize = 0;
-    const MAX_FILTERS: usize = 4;
-
-    fn with_datatype(
-        requirements: Rc<Requirements>,
-    ) -> impl Strategy<Value = FilterListData> {
-        (MIN_FILTERS..=MAX_FILTERS).prop_flat_map(move |nfilters| {
-            prop_filter_pipeline_impl(Rc::clone(&requirements), nfilters)
-                .prop_map(move |filter_deque| {
-                    filter_deque.into_iter().collect::<FilterListData>()
-                })
-        })
-    }
-
-    if requirements.input_datatype.is_some() {
-        with_datatype(Rc::clone(&requirements)).boxed()
-    } else {
-        prop_datatype_implemented()
-            .prop_flat_map(move |input_datatype| {
-                with_datatype(Rc::new(Requirements {
-                    input_datatype: Some(input_datatype),
-                    ..(*requirements).clone()
-                }))
-            })
-            .boxed()
-    }
-}
-
 /// Value tree to search through the complexity space of some filter pipeline.
 /// A filter pipeline has a bit more structure than just a list of filters,
 /// because the output of each filter feeds into the next one.
@@ -437,10 +430,42 @@ impl Strategy for FilterPipelineStrategy {
     type Value = FilterListData;
 
     fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
-        let initial_pipeline =
-            prop_filter_pipeline(Rc::clone(&self.requirements))
-                .new_tree(runner)?
-                .current();
+        const MIN_FILTERS: usize = 0;
+        const MAX_FILTERS: usize = 4;
+
+        let nfilters = (MIN_FILTERS..=MAX_FILTERS).new_tree(runner)?.current();
+
+        let input_datatype = if let Some(dt) = self.requirements.input_datatype
+        {
+            dt
+        } else {
+            any::<Datatype>().new_tree(runner)?.current()
+        };
+
+        let initial_pipeline = {
+            let mut filters = vec![];
+            let mut input_datatype = Some(input_datatype);
+            for i in 0..nfilters {
+                let req = Requirements {
+                    input_datatype,
+                    context: self.requirements.context.clone(),
+                    pipeline_position: Some(i),
+                };
+
+                let f = prop_filter(Rc::new(req)).new_tree(runner)?.current();
+
+                // If the transformed datatype is None then we have a bug.
+                // Do not panic here, that will swallow what the pipeline looked like.
+                // Let the unit test fail and print the input.
+                let output_datatype =
+                    input_datatype.and_then(|dt| f.transform_datatype(&dt));
+                input_datatype = output_datatype;
+
+                filters.push(f);
+            }
+
+            filters.into_iter().collect::<FilterListData>()
+        };
 
         Ok(FilterPipelineValueTree::new(initial_pipeline))
     }
@@ -468,7 +493,7 @@ mod tests {
     fn filter_arbitrary() {
         let ctx = Context::new().expect("Error creating context");
 
-        proptest!(|(filt in prop_filter_pipeline(Default::default()))| {
+        proptest!(|(filt in any::<FilterListData>())| {
             filt.create(&ctx).expect("Error constructing arbitrary filter");
         });
     }
@@ -479,11 +504,17 @@ mod tests {
     fn filter_arbitrary_for_datatype() {
         let ctx = Context::new().expect("Error creating context");
 
-        proptest!(|((dt, filt) in prop_datatype().prop_flat_map(
-                |dt| (Just(dt), prop_filter(Rc::new(Requirements {
+        let strat = any::<Datatype>().prop_flat_map(|dt| {
+            (
+                Just(dt),
+                prop_filter(Rc::new(Requirements {
                     input_datatype: Some(dt),
                     ..Default::default()
-                })))))| {
+                })),
+            )
+        });
+
+        proptest!(|((dt, filt) in strat)| {
             let filt = filt.create(&ctx)
                 .expect("Error constructing arbitrary filter");
 
@@ -498,7 +529,7 @@ mod tests {
     fn filter_list_arbitrary() {
         let ctx = Context::new().expect("Error creating context");
 
-        proptest!(|(fl in prop_filter_pipeline(Default::default()))| {
+        proptest!(|(fl in any::<FilterListData>())| {
             fl.create(&ctx).expect("Error constructing arbitrary filter list");
         });
     }
@@ -509,11 +540,15 @@ mod tests {
     fn filter_list_arbitrary_for_datatype() {
         let ctx = Context::new().expect("Error creating context");
 
-        proptest!(|((dt, fl) in prop_datatype_implemented().prop_flat_map(
-                |dt| (Just(dt), prop_filter_pipeline(Rc::new(Requirements {
-                    input_datatype: Some(dt),
-                    ..Default::default()
-                })))))| {
+        let strat = any::<Datatype>().prop_flat_map(|dt| {
+            let req = Rc::new(Requirements {
+                input_datatype: Some(dt),
+                ..Default::default()
+            });
+            (Just(dt), any_with::<FilterListData>(req))
+        });
+
+        proptest!(|((dt, fl) in strat)| {
             let fl = fl.create(&ctx)
                 .expect("Error constructing arbitrary filter");
 
@@ -550,7 +585,7 @@ mod tests {
     fn filter_eq_reflexivity() {
         let ctx = Context::new().expect("Error creating context");
 
-        proptest!(|(pipeline in prop_filter_pipeline(Default::default()))| {
+        proptest!(|(pipeline in any::<FilterListData>())| {
             assert_eq!(pipeline, pipeline);
             assert_option_subset!(pipeline, pipeline);
 


### PR DESCRIPTION
To date, we were actually only using a few different datatypes for the proptest strategies.  And we were missing all cell val nums other than 1.

This pull request updates our strategies to use all datatypes, and consider other cell val nums as well.

There are a few issues which are revealed by those changes:
- restrictions on RLE and Dictionary filters in pipelines (fixed in this PR)
- multiple-value fill values for attributes (fixed in this PR)
- dimension domain/extent sometimes silently ignored (deferred)