### PR TITLE
Update Arrow dependencies

### DIFF
--- a/tiledb/api/Cargo.toml
+++ b/tiledb/api/Cargo.toml
@@ -9,8 +9,8 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-arrow = { version = "50.0.0", features = ["prettyprint"], optional = true }
-arrow-schema = { version = "50.0.0", default-features = false, optional = true }
+arrow = { version = "51.0.0", features = ["prettyprint"], optional = true }
+arrow-schema = { version = "51.0.0", default-features = false, optional = true }
 itertools = "0"
 num-traits = { version = "0.2", optional = true }
 paste = "1.0"


### PR DESCRIPTION
This is to match a change to datafusion 37 in the tables repo.