### PR TITLE
Remove QueryCondition struct, user just provides enum

### DIFF
--- a/tiledb/api/examples/query_condition_dense.rs
+++ b/tiledb/api/examples/query_condition_dense.rs
@@ -31,33 +31,33 @@ fn main() -> TileDBResult<()> {
 
     println!("Reading: a is null");
     let qc = QC::field("a").is_null();
-    read_array(&ctx, Some(&qc))?;
+    read_array(&ctx, Some(qc))?;
 
     println!("Reading: b < \"eve\"");
     let qc = QC::field("b").lt("eve");
-    read_array(&ctx, Some(&qc))?;
+    read_array(&ctx, Some(qc))?;
 
     println!("Reading: c >= 1");
     let qc = QC::field("c").ge(1i32);
-    read_array(&ctx, Some(&qc))?;
+    read_array(&ctx, Some(qc))?;
 
     println!("Reading: 3.0 <= d <= 4.0");
     let qc = QC::field("d").ge(3.0f32) & QC::field("d").le(4.0f32);
-    read_array(&ctx, Some(&qc))?;
+    read_array(&ctx, Some(qc))?;
 
     println!("Reading: (a is not null) && (b < \"eve\") && (3.0 <= d <= 4.0)");
     let qc = QC::field("a").not_null()
         & QC::field("b").lt("eve")
         & QC::field("d").ge(3.0f32)
         & QC::field("d").le(4.0f32);
-    read_array(&ctx, Some(&qc))?;
+    read_array(&ctx, Some(qc))?;
 
     Ok(())
 }
 
 /// Read the array with the optional query condition and print the results
 /// to stdout.
-fn read_array(ctx: &Context, qc: Option<&QC>) -> TileDBResult<()> {
+fn read_array(ctx: &Context, qc: Option<QC>) -> TileDBResult<()> {
     let array = tiledb::Array::open(ctx, ARRAY_URI, tiledb::array::Mode::Read)?;
     let mut query = ReadBuilder::new(array)?
         .layout(tiledb::query::QueryLayout::RowMajor)?
@@ -74,7 +74,7 @@ fn read_array(ctx: &Context, qc: Option<&QC>) -> TileDBResult<()> {
         .finish_subarray()?;
 
     query = if let Some(qc) = qc {
-        query.query_condition(qc.build(ctx)?)?
+        query.query_condition(qc)?
     } else {
         query
     };

--- a/tiledb/api/examples/query_condition_sparse.rs
+++ b/tiledb/api/examples/query_condition_sparse.rs
@@ -31,33 +31,33 @@ fn main() -> TileDBResult<()> {
 
     println!("Reading: a is null");
     let qc = QC::field("a").is_null();
-    read_array(&ctx, Some(&qc))?;
+    read_array(&ctx, Some(qc))?;
 
     println!("Reading: b < \"eve\"");
     let qc = QC::field("b").lt("eve");
-    read_array(&ctx, Some(&qc))?;
+    read_array(&ctx, Some(qc))?;
 
     println!("Reading: c >= 1");
     let qc = QC::field("c").ge(1i32);
-    read_array(&ctx, Some(&qc))?;
+    read_array(&ctx, Some(qc))?;
 
     println!("Reading: 3.0 <= d <= 4.0");
     let qc = QC::field("d").ge(3.0f32) & QC::field("d").le(4.0f32);
-    read_array(&ctx, Some(&qc))?;
+    read_array(&ctx, Some(qc))?;
 
     println!("Reading: (a is not null) && (b < \"eve\") && (3.0 <= d <= 4.0)");
     let qc = QC::field("a").not_null()
         & QC::field("b").lt("eve")
         & QC::field("d").ge(3.0f32)
         & QC::field("d").le(4.0f32);
-    read_array(&ctx, Some(&qc))?;
+    read_array(&ctx, Some(qc))?;
 
     Ok(())
 }
 
 /// Read the array with the optional query condition and print the results
 /// to stdout.
-fn read_array(ctx: &Context, qc: Option<&QC>) -> TileDBResult<()> {
+fn read_array(ctx: &Context, qc: Option<QC>) -> TileDBResult<()> {
     let array = tiledb::Array::open(ctx, ARRAY_URI, tiledb::array::Mode::Read)?;
     let mut query = ReadBuilder::new(array)?
         .layout(tiledb::query::QueryLayout::RowMajor)?
@@ -74,7 +74,7 @@ fn read_array(ctx: &Context, qc: Option<&QC>) -> TileDBResult<()> {
         .finish_subarray()?;
 
     query = if let Some(qc) = qc {
-        query.query_condition(qc.build(ctx)?)?
+        query.query_condition(qc)?
     } else {
         query
     };

--- a/tiledb/api/src/query/mod.rs
+++ b/tiledb/api/src/query/mod.rs
@@ -10,7 +10,7 @@ pub mod read;
 pub mod subarray;
 pub mod write;
 
-pub use self::conditions::{QueryCondition, QueryConditionExpr};
+pub use self::conditions::QueryConditionExpr;
 pub use self::read::{
     ReadBuilder, ReadQuery, ReadQueryBuilder, ReadStepOutput, TypedReadBuilder,
 };
@@ -197,9 +197,10 @@ pub trait QueryBuilder<'ctx>: Sized {
         SubarrayBuilder::for_query(self)
     }
 
-    fn query_condition(self, qc: QueryCondition<'ctx>) -> TileDBResult<Self> {
+    fn query_condition(self, qc: QueryConditionExpr) -> TileDBResult<Self> {
+        let raw = qc.build(self.base().context())?;
         let c_query = **self.base().cquery();
-        let c_cond = qc.capi();
+        let c_cond = *raw;
         self.base().capi_call(|ctx| unsafe {
             ffi::tiledb_query_set_condition(ctx, c_query, c_cond)
         })?;


### PR DESCRIPTION
This is a minor tweak to the query condition API which simplifies the experience for users a bit.  The `struct QueryCondition` is only ever build and then immediately passed to the query builder API.  Any manipulations will be done by the enum.  Given that, why should the user need to build a `struct QueryCondition` at all? Let's just have the query do it.  That's what this PR implements.