### PR TITLE
FillData::data is not json but instead metadata::Value

### DIFF
--- a/tiledb/api/src/array/attribute/strategy.rs
+++ b/tiledb/api/src/array/attribute/strategy.rs
@@ -1,7 +1,6 @@
 use std::rc::Rc;
 
 use proptest::prelude::*;
-use serde_json::json;
 
 use crate::array::{
     attribute::FillData, ArrayType, AttributeData, CellValNum, DomainData,
@@ -123,7 +122,7 @@ fn prop_attribute_for_datatype(
                                 nullability: Some(nullable),
                                 cell_val_num: Some(cell_val_num),
                                 fill: Some(FillData {
-                                    data: json!(fill),
+                                    data: fill.into(),
                                     nullability: Some(
                                         nullable && fill_nullable,
                                     ),

--- a/tiledb/api/src/metadata.rs
+++ b/tiledb/api/src/metadata.rs
@@ -5,7 +5,10 @@ use crate::Result as TileDBResult;
 use core::slice;
 use std::convert::From;
 
-#[derive(Debug, PartialEq)]
+use serde::{Deserialize, Serialize};
+use util::option::OptionSubset;
+
+#[derive(Clone, Debug, Deserialize, OptionSubset, PartialEq, Serialize)]
 pub enum Value {
     UInt8Value(Vec<u8>),
     UInt16Value(Vec<u16>),
@@ -28,8 +31,10 @@ fn get_value_vec<T>(vec: &[T]) -> (*const std::ffi::c_void, usize) {
     (vec_ptr, vec_size)
 }
 
+#[macro_export]
 macro_rules! value_typed {
-    ($valuetype:expr, $typename:ident, $vec:ident, $then: expr) => {
+    ($valuetype:expr, $typename:ident, $vec:ident, $then: expr) => {{
+        use $crate::metadata::Value;
         match $valuetype {
             Value::Int8Value(ref $vec) => {
                 type $typename = i8;
@@ -72,8 +77,9 @@ macro_rules! value_typed {
                 $then
             }
         }
-    };
+    }};
 }
+pub use value_typed;
 
 impl Value {
     pub fn c_vec(&self) -> (*const std::ffi::c_void, usize) {


### PR DESCRIPTION
When a proptest fails with schema data, we would really like to be able to copy/paste the `Debug` output into a unit test so we can step through the execution of the minimum failing input with ease.

At present there are a number of alterations required in order to copy/paste.  Attribute fill data, for example, looks like:
```
fill: Some(
                    FillData {
                        data: Array [
                            Number(52),
                            Number(78),
                            Number(56),
                            Number(57),
                            Number(-6),
                            Number(-81),
                            Number(-89),
                            Number(23),
                            Number(108),
                            Number(36),
                        ],
                        nullability: Some(
                            false,
                        ),
                    },
                )
```
This can probably be copy/pasteable by doing `use serde_json::Value::*` or something along those lines.  But we'd probably rather see something like `data: UInt64([52, 78, 56, 57, -6, -81, -89, 23, 108, 36])`.

This change also is a step towards removing `serde_json` as a dependency for our `api` crate, if we determine we would prefer that.