### PR TITLE
Properly use cell_val_num in DataProvider impls

### DIFF
--- a/tiledb/api/src/query/buffer/mod.rs
+++ b/tiledb/api/src/query/buffer/mod.rs
@@ -51,7 +51,13 @@ impl<'data, T> Deref for Buffer<'data, T> {
 
 impl<'data, T> From<Vec<T>> for Buffer<'data, T> {
     fn from(value: Vec<T>) -> Self {
-        Buffer::Owned(value.into_boxed_slice())
+        Self::from(value.into_boxed_slice())
+    }
+}
+
+impl<'data, T> From<Box<[T]>> for Buffer<'data, T> {
+    fn from(value: Box<[T]>) -> Self {
+        Buffer::Owned(value)
     }
 }
 

--- a/tiledb/api/src/query/write/mod.rs
+++ b/tiledb/api/src/query/write/mod.rs
@@ -81,7 +81,7 @@ impl<'ctx, 'data> WriteBuilder<'ctx, 'data> {
             data.as_tiledb_input(
                 schema_field.cell_val_num()?,
                 schema_field.nullability()?,
-            )
+            )?
         };
 
         let c_query = **self.base().cquery();


### PR DESCRIPTION
This argument was tacked on in prior work, but as we turn more attention to the write side of queries it deserves some proper attention.

Different inputs may behave differently with different `cell_val_num`, or may even error out.  `DataProvider::as_tiledb_input` should return `TileDBResult`, and our existing impls should properly use `cell_val_num`.