### PR TITLE
Implement query input traits for Arrow data

### DIFF
--- a/tiledb/api/src/array/attribute/mod.rs
+++ b/tiledb/api/src/array/attribute/mod.rs
@@ -127,7 +127,7 @@ impl Attribute {
 
         if !self.datatype()?.is_compatible_type::<F::PhysicalType>() {
             return Err(Error::Datatype(DatatypeErrorKind::TypeMismatch {
-                user_type: std::any::type_name::<F::PhysicalType>(),
+                user_type: std::any::type_name::<F::PhysicalType>().to_owned(),
                 tiledb_type: self.datatype()?,
             }));
         }
@@ -158,7 +158,7 @@ impl Attribute {
     ) -> TileDBResult<(F, bool)> {
         if !self.datatype()?.is_compatible_type::<F::PhysicalType>() {
             return Err(Error::Datatype(DatatypeErrorKind::TypeMismatch {
-                user_type: std::any::type_name::<F::PhysicalType>(),
+                user_type: std::any::type_name::<F::PhysicalType>().to_owned(),
                 tiledb_type: self.datatype()?,
             }));
         }
@@ -354,7 +354,7 @@ impl Builder {
             .is_compatible_type::<F::PhysicalType>()
         {
             return Err(Error::Datatype(DatatypeErrorKind::TypeMismatch {
-                user_type: std::any::type_name::<F::PhysicalType>(),
+                user_type: std::any::type_name::<F::PhysicalType>().to_owned(),
                 tiledb_type: self.attr.datatype()?,
             }));
         }
@@ -394,7 +394,7 @@ impl Builder {
             .is_compatible_type::<F::PhysicalType>()
         {
             return Err(Error::Datatype(DatatypeErrorKind::TypeMismatch {
-                user_type: std::any::type_name::<F::PhysicalType>(),
+                user_type: std::any::type_name::<F::PhysicalType>().to_owned(),
                 tiledb_type: self.attr.datatype()?,
             }));
         }

--- a/tiledb/api/src/array/dimension/mod.rs
+++ b/tiledb/api/src/array/dimension/mod.rs
@@ -294,7 +294,7 @@ impl DimensionConstraints {
                 if !datatype.is_compatible_type::<DT>() {
                     return Err(Error::Datatype(
                         DatatypeErrorKind::TypeMismatch {
-                            user_type: std::any::type_name::<DT>(),
+                            user_type: std::any::type_name::<DT>().to_owned(),
                             tiledb_type: datatype,
                         },
                     ));

--- a/tiledb/api/src/array/fragment_info.rs
+++ b/tiledb/api/src/array/fragment_info.rs
@@ -349,14 +349,14 @@ impl FragmentInfoInternal {
             type DT = <LT as LogicalType>::PhysicalType;
             if start_size % std::mem::size_of::<DT>() as u64 != 0 {
                 return Err(Error::Datatype(DatatypeErrorKind::TypeMismatch {
-                    user_type: std::any::type_name::<DT>(),
+                    user_type: std::any::type_name::<DT>().to_owned(),
                     tiledb_type: datatype,
                 }));
             }
 
             if end_size % std::mem::size_of::<DT>() as u64 != 0 {
                 return Err(Error::Datatype(DatatypeErrorKind::TypeMismatch {
-                    user_type: std::any::type_name::<DT>(),
+                    user_type: std::any::type_name::<DT>().to_owned(),
                     tiledb_type: datatype,
                 }));
             }
@@ -468,14 +468,14 @@ impl FragmentInfoInternal {
             type DT = <LT as LogicalType>::PhysicalType;
             if start_size % std::mem::size_of::<DT>() as u64 != 0 {
                 return Err(Error::Datatype(DatatypeErrorKind::TypeMismatch {
-                    user_type: std::any::type_name::<DT>(),
+                    user_type: std::any::type_name::<DT>().to_owned(),
                     tiledb_type: datatype,
                 }));
             }
 
             if end_size % std::mem::size_of::<DT>() as u64 != 0 {
                 return Err(Error::Datatype(DatatypeErrorKind::TypeMismatch {
-                    user_type: std::any::type_name::<DT>(),
+                    user_type: std::any::type_name::<DT>().to_owned(),
                     tiledb_type: datatype,
                 }));
             }

--- a/tiledb/api/src/error.rs
+++ b/tiledb/api/src/error.rs
@@ -30,7 +30,7 @@ impl Drop for RawError {
 pub enum DatatypeErrorKind {
     InvalidDiscriminant(u64),
     TypeMismatch {
-        user_type: &'static str,
+        user_type: String,
         tiledb_type: Datatype,
     },
     UnexpectedCellStructure {

--- a/tiledb/api/src/error.rs
+++ b/tiledb/api/src/error.rs
@@ -38,6 +38,9 @@ pub enum DatatypeErrorKind {
         found: CellValNum,
         expected: CellValNum,
     },
+    UnexpectedValidity {
+        context: Option<String>,
+    },
     InvalidDatatype {
         context: Option<String>,
         found: Datatype,
@@ -78,6 +81,13 @@ impl Display for DatatypeErrorKind {
                         "Unexpected cell val num: expected {}, found {}",
                         expected, found
                     )
+                }
+            }
+            DatatypeErrorKind::UnexpectedValidity { context } => {
+                if let Some(context) = context {
+                    write!(f, "Unexpected validity data for {}", context)
+                } else {
+                    write!(f, "Unexpected validity data")
                 }
             }
             DatatypeErrorKind::InvalidDatatype {

--- a/tiledb/api/src/metadata.rs
+++ b/tiledb/api/src/metadata.rs
@@ -128,7 +128,7 @@ impl Metadata {
         if !datatype.is_compatible_type::<T>() {
             return Err(crate::error::Error::Datatype(
                 DatatypeErrorKind::TypeMismatch {
-                    user_type: std::any::type_name::<T>(),
+                    user_type: std::any::type_name::<T>().to_owned(),
                     tiledb_type: datatype,
                 },
             ));

--- a/tiledb/api/src/query/buffer/arrow.rs
+++ b/tiledb/api/src/query/buffer/arrow.rs
@@ -74,13 +74,6 @@ where
     }
 }
 
-impl<'data> From<&'data OffsetBuffer<i64>> for Buffer<'data, u64> {
-    fn from(value: &'data OffsetBuffer<i64>) -> Self {
-        /* i64 is used but offsets are necessarily non-negative */
-        Buffer::Borrowed(value.inner().inner().typed_data::<u64>())
-    }
-}
-
 impl From<Celled<Buffer<'_, u8>>> for NullBuffer {
     fn from(value: Celled<Buffer<'_, u8>>) -> Self {
         let Celled(ncells, validity) = value;

--- a/tiledb/api/src/query/buffer/mod.rs
+++ b/tiledb/api/src/query/buffer/mod.rs
@@ -551,6 +551,10 @@ impl<'data> TypedQueryBuffers<'data> {
     pub fn cell_structure(&self) -> &CellStructure<'data> {
         crate::typed_query_buffers_go!(self, _DT, ref qb, &qb.cell_structure)
     }
+
+    pub fn validity(&self) -> Option<&Buffer<'data, u8>> {
+        crate::typed_query_buffers_go!(self, _DT, ref qb, qb.validity.as_ref())
+    }
 }
 
 pub enum RefTypedQueryBuffersMut<'cell, 'data> {

--- a/tiledb/api/src/query/buffer/mod.rs
+++ b/tiledb/api/src/query/buffer/mod.rs
@@ -548,12 +548,23 @@ pub enum TypedQueryBuffers<'data> {
 }
 
 impl<'data> TypedQueryBuffers<'data> {
+    pub fn values_capacity(&self) -> usize {
+        crate::typed_query_buffers_go!(self, _DT, ref qb, qb.data.len())
+    }
+
     pub fn cell_structure(&self) -> &CellStructure<'data> {
         crate::typed_query_buffers_go!(self, _DT, ref qb, &qb.cell_structure)
     }
 
     pub fn validity(&self) -> Option<&Buffer<'data, u8>> {
         crate::typed_query_buffers_go!(self, _DT, ref qb, qb.validity.as_ref())
+    }
+
+    pub fn borrow<'this>(&'this self) -> TypedQueryBuffers<'data>
+    where
+        'this: 'data,
+    {
+        crate::typed_query_buffers_go!(self, _DT, ref qb, qb.borrow().into())
     }
 }
 
@@ -649,6 +660,82 @@ macro_rules! typed_query_buffers_go {
             }
         }
     };
+    ($left:expr, $right:expr, $DT:ident, $lbind:pat, $rbind:pat, $then:expr) => {{
+        use $crate::query::buffer::TypedQueryBuffers;
+        match ($left, $right) {
+            (
+                TypedQueryBuffers::UInt8($lbind),
+                TypedQueryBuffers::UInt8($rbind),
+            ) => {
+                type $DT = u8;
+                $then
+            }
+            (
+                TypedQueryBuffers::UInt16($lbind),
+                TypedQueryBuffers::UInt16($rbind),
+            ) => {
+                type $DT = u16;
+                $then
+            }
+            (
+                TypedQueryBuffers::UInt32($lbind),
+                TypedQueryBuffers::UInt32($rbind),
+            ) => {
+                type $DT = u32;
+                $then
+            }
+            (
+                TypedQueryBuffers::UInt64($lbind),
+                TypedQueryBuffers::UInt64($rbind),
+            ) => {
+                type $DT = u64;
+                $then
+            }
+            (
+                TypedQueryBuffers::Int8($lbind),
+                TypedQueryBuffers::Int8($rbind),
+            ) => {
+                type $DT = i8;
+                $then
+            }
+            (
+                TypedQueryBuffers::Int16($lbind),
+                TypedQueryBuffers::Int16($rbind),
+            ) => {
+                type $DT = i16;
+                $then
+            }
+            (
+                TypedQueryBuffers::Int32($lbind),
+                TypedQueryBuffers::Int32($rbind),
+            ) => {
+                type $DT = i32;
+                $then
+            }
+            (
+                TypedQueryBuffers::Int64($lbind),
+                TypedQueryBuffers::Int64($rbind),
+            ) => {
+                type $DT = i64;
+                $then
+            }
+            (
+                TypedQueryBuffers::Float32($lbind),
+                TypedQueryBuffers::Float32($rbind),
+            ) => {
+                type $DT = f32;
+                $then
+            }
+            (
+                TypedQueryBuffers::Float64($lbind),
+                TypedQueryBuffers::Float64($rbind),
+            ) => {
+                type $DT = f64;
+                $then
+            }
+            _ => unreachable!(),
+        }
+    }};
 }
 
 macro_rules! ref_typed_query_buffers_go {

--- a/tiledb/api/src/query/read/output/mod.rs
+++ b/tiledb/api/src/query/read/output/mod.rs
@@ -50,7 +50,7 @@ impl<C> RawReadOutput<'_, C> {
             CellStructure::Var(ref offsets) => json!({
                 "capacity": offsets.len(),
                 "defined": self.ncells + 1,
-                "values": format!("{:?}", &offsets.as_ref()[0.. self.ncells + 1])
+                "values": format!("{:?}", &offsets.as_ref()[0.. std::cmp::min(offsets.len(), self.ncells + 1)])
             }),
         };
 

--- a/tiledb/api/src/query/read/output/strategy.rs
+++ b/tiledb/api/src/query/read/output/strategy.rs
@@ -221,11 +221,11 @@ where
                             .into_iter()
                             .take(ncells + 1)
                             .collect::<Vec<u64>>();
-                        if let Some(first) = offsets.first_mut() {
-                            *first = 0u64;
-                        }
                         if let Some(last) = offsets.last_mut() {
                             *last = nvalues as u64;
+                        }
+                        if let Some(first) = offsets.first_mut() {
+                            *first = 0u64;
                         }
                         offsets.sort();
 

--- a/tiledb/api/src/query/subarray.rs
+++ b/tiledb/api/src/query/subarray.rs
@@ -297,7 +297,7 @@ where
         let dtype = dim.datatype()?;
         if dtype.is_compatible_type::<T>() {
             return Err(Error::Datatype(DatatypeErrorKind::TypeMismatch {
-                user_type: std::any::type_name::<T>(),
+                user_type: std::any::type_name::<T>().to_owned(),
                 tiledb_type: dtype,
             }));
         }

--- a/tiledb/api/src/query/write/input/arrow.rs
+++ b/tiledb/api/src/query/write/input/arrow.rs
@@ -68,14 +68,13 @@ fn cell_structure_fixed(
         ),
         CellValNum::Fixed(nz) => Ok(CellStructure::Fixed(nz)),
         CellValNum::Var => {
-            let offsets = Buffer::Owned(
-                std::iter::repeat(fixed_len as usize)
-                    .take(ncells)
-                    .enumerate()
-                    .map(|(i, len)| (i * len) as u64)
-                    .collect::<Vec<u64>>()
-                    .into_boxed_slice(),
-            );
+            let offsets = Buffer::Owned({
+                let mut offsets = vec![0; ncells];
+                for (i, o) in offsets.iter_mut().enumerate() {
+                    *o = i as u64 * fixed_len as u64;
+                }
+                offsets.into_boxed_slice()
+            });
             Ok(CellStructure::Var(offsets))
         }
     }

--- a/tiledb/api/src/query/write/input/arrow.rs
+++ b/tiledb/api/src/query/write/input/arrow.rs
@@ -15,7 +15,7 @@ where
 {
     type Unit = <A as ArrowPrimitiveType>::Native;
 
-    fn as_tiledb_input(
+    fn query_buffers(
         &self,
         cell_val_num: CellValNum,
         is_nullable: bool,

--- a/tiledb/api/src/query/write/input/arrow.rs
+++ b/tiledb/api/src/query/write/input/arrow.rs
@@ -1,11 +1,22 @@
-use arrow::array::{Array as ArrowArray, PrimitiveArray};
-use arrow::datatypes::ArrowPrimitiveType;
+use std::rc::Rc;
+use std::sync::Arc;
 
-use crate::array::CellValNum;
+use arrow::array::{
+    Array as ArrowArray, FixedSizeBinaryArray, FixedSizeListArray,
+    GenericListArray, LargeBinaryArray, LargeStringArray, PrimitiveArray,
+    RecordBatch,
+};
+use arrow::datatypes::{ArrowPrimitiveType, Field};
+
+use crate::array::{CellValNum, Schema};
 use crate::datatype::PhysicalType;
 use crate::error::{DatatypeErrorKind, Error};
-use crate::query::buffer::{Buffer, CellStructure, QueryBuffers};
-use crate::query::write::input::DataProvider;
+use crate::query::buffer::{
+    Buffer, CellStructure, QueryBuffers, TypedQueryBuffers,
+};
+use crate::query::write::input::{
+    DataProvider, RecordProvider, TypedDataProvider,
+};
 use crate::Result as TileDBResult;
 
 impl<A> DataProvider for PrimitiveArray<A>
@@ -83,6 +94,260 @@ where
                     expected: CellValNum::single(),
                 },
             )),
+        }
+    }
+}
+
+impl DataProvider for FixedSizeBinaryArray {
+    type Unit = u8;
+
+    fn query_buffers(
+        &self,
+        cell_val_num: CellValNum,
+        is_nullable: bool,
+    ) -> TileDBResult<QueryBuffers<Self::Unit>> {
+        todo!()
+    }
+}
+
+impl DataProvider for LargeBinaryArray {
+    type Unit = u8;
+
+    fn query_buffers(
+        &self,
+        cell_val_num: CellValNum,
+        is_nullable: bool,
+    ) -> TileDBResult<QueryBuffers<Self::Unit>> {
+        todo!()
+    }
+}
+
+impl DataProvider for LargeStringArray {
+    type Unit = u8;
+
+    fn query_buffers(
+        &self,
+        cell_val_num: CellValNum,
+        is_nullable: bool,
+    ) -> TileDBResult<QueryBuffers<Self::Unit>> {
+        todo!()
+    }
+}
+
+impl TypedDataProvider for FixedSizeListArray {
+    fn typed_query_buffers(
+        &self,
+        cell_val_num: CellValNum,
+        is_nullable: bool,
+    ) -> TileDBResult<TypedQueryBuffers> {
+        todo!()
+    }
+}
+
+impl TypedDataProvider for GenericListArray<i64> {
+    fn typed_query_buffers(
+        &self,
+        cell_val_num: CellValNum,
+        is_nullable: bool,
+    ) -> TileDBResult<TypedQueryBuffers> {
+        todo!()
+    }
+}
+
+impl TypedDataProvider for dyn ArrowArray {
+    fn typed_query_buffers(
+        &self,
+        cell_val_num: CellValNum,
+        is_nullable: bool,
+    ) -> TileDBResult<TypedQueryBuffers> {
+        let c = cell_val_num;
+        let n = is_nullable;
+
+        use arrow::array::AsArray;
+        use arrow::datatypes::{DataType as ADT, *};
+        match self.data_type() {
+            ADT::Null => unimplemented!(),
+            ADT::Boolean => unimplemented!(),
+            ADT::Float16 => unimplemented!(),
+            ADT::Duration(_) => unimplemented!(), /* possible but bit width is not specified */
+            ADT::Interval(_) => unimplemented!(), /* possible but bit width is not specified */
+            ADT::Binary => unimplemented!(),      /* offset is 32-bit */
+            ADT::Utf8 => unimplemented!(),        /* offset is 32-bit */
+            ADT::BinaryView => unimplemented!(),
+            ADT::Utf8View => unimplemented!(),
+            ADT::List(_) => unimplemented!(), /* 32 bit offsets */
+            ADT::ListView(_) => todo!(),
+            ADT::LargeListView(_) => todo!(),
+            ADT::Struct(_) => todo!(),
+            ADT::Union(_, _) => todo!(),
+            ADT::Dictionary(_, _) => todo!(),
+            ADT::Decimal128(_, _) => todo!(),
+            ADT::Decimal256(_, _) => todo!(),
+            ADT::Map(_, _) => todo!(),
+            ADT::RunEndEncoded(_, _) => todo!(),
+            ADT::UInt8 => {
+                self.as_primitive::<UInt8Type>().typed_query_buffers(c, n)
+            }
+            ADT::UInt16 => {
+                self.as_primitive::<UInt16Type>().typed_query_buffers(c, n)
+            }
+            ADT::UInt32 => {
+                self.as_primitive::<UInt32Type>().typed_query_buffers(c, n)
+            }
+            ADT::UInt64 => {
+                self.as_primitive::<UInt64Type>().typed_query_buffers(c, n)
+            }
+            ADT::Int8 => {
+                self.as_primitive::<Int8Type>().typed_query_buffers(c, n)
+            }
+            ADT::Int16 => {
+                self.as_primitive::<Int16Type>().typed_query_buffers(c, n)
+            }
+            ADT::Int32 => {
+                self.as_primitive::<Int32Type>().typed_query_buffers(c, n)
+            }
+            ADT::Int64 => {
+                self.as_primitive::<Int64Type>().typed_query_buffers(c, n)
+            }
+            ADT::Float32 => {
+                self.as_primitive::<Float32Type>().typed_query_buffers(c, n)
+            }
+            ADT::Float64 => {
+                self.as_primitive::<Float64Type>().typed_query_buffers(c, n)
+            }
+            ADT::Timestamp(TimeUnit::Second, _) => self
+                .as_primitive::<TimestampSecondType>()
+                .typed_query_buffers(c, n),
+            ADT::Timestamp(TimeUnit::Millisecond, _) => self
+                .as_primitive::<TimestampMillisecondType>()
+                .typed_query_buffers(c, n),
+            ADT::Timestamp(TimeUnit::Microsecond, _) => self
+                .as_primitive::<TimestampMicrosecondType>()
+                .typed_query_buffers(c, n),
+            ADT::Timestamp(TimeUnit::Nanosecond, _) => self
+                .as_primitive::<TimestampNanosecondType>()
+                .typed_query_buffers(c, n),
+            ADT::Date32 => {
+                self.as_primitive::<Date32Type>().typed_query_buffers(c, n)
+            }
+            ADT::Date64 => {
+                self.as_primitive::<Date64Type>().typed_query_buffers(c, n)
+            }
+            ADT::Time32(TimeUnit::Second) => self
+                .as_primitive::<Time32SecondType>()
+                .typed_query_buffers(c, n),
+            ADT::Time32(TimeUnit::Millisecond) => self
+                .as_primitive::<Time32MillisecondType>()
+                .typed_query_buffers(c, n),
+            ADT::Time32(_) => unreachable!(),
+            ADT::Time64(TimeUnit::Microsecond) => self
+                .as_primitive::<Time64MicrosecondType>()
+                .typed_query_buffers(c, n),
+            ADT::Time64(TimeUnit::Nanosecond) => self
+                .as_primitive::<Time64NanosecondType>()
+                .typed_query_buffers(c, n),
+            ADT::Time64(_) => unreachable!(),
+            ADT::FixedSizeBinary(_) => {
+                self.as_fixed_size_binary().typed_query_buffers(c, n)
+            }
+            ADT::LargeBinary => {
+                self.as_binary::<i64>().typed_query_buffers(c, n)
+            }
+            ADT::LargeUtf8 => self.as_string::<i64>().typed_query_buffers(c, n),
+            ADT::FixedSizeList(_, _) => {
+                self.as_fixed_size_list().typed_query_buffers(c, n)
+            }
+            ADT::LargeList(_) => {
+                self.as_list::<i64>().typed_query_buffers(c, n)
+            }
+        }
+    }
+}
+
+impl<'data> RecordProvider<'data> for RecordBatch {
+    type Iter = RecordBatchTileDBInputs<'data>;
+
+    fn tiledb_inputs(
+        &'data self,
+        schema: Rc<Schema>,
+    ) -> RecordBatchTileDBInputs<'data> {
+        RecordBatchTileDBInputs::new(self, schema)
+    }
+}
+
+pub struct RecordBatchTileDBInputs<'data> {
+    schema: Rc<Schema>,
+    fields: core::slice::Iter<'data, Arc<Field>>,
+    columns: core::slice::Iter<'data, Arc<dyn ArrowArray>>,
+}
+
+impl<'data> RecordBatchTileDBInputs<'data> {
+    pub fn new(batch: &'data RecordBatch, schema: Rc<Schema>) -> Self {
+        RecordBatchTileDBInputs {
+            schema,
+            fields: batch.schema_ref().fields.iter(),
+            columns: batch.columns().iter(),
+        }
+    }
+}
+
+impl<'data> Iterator for RecordBatchTileDBInputs<'data> {
+    type Item = TileDBResult<(String, TypedQueryBuffers<'data>)>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match (self.fields.next(), self.columns.next()) {
+            (None, None) => None,
+            (Some(f), Some(c)) => {
+                let Some((datatype, cell_val_num)) =
+                    crate::datatype::arrow::from_arrow(f.data_type()).ok()
+                else {
+                    /* TODO: error */
+                    unimplemented!()
+                };
+
+                let tiledb_field = match self.schema.field(f.name()) {
+                    Ok(field) => field,
+                    Err(e) => return Some(Err(e)),
+                };
+                let field_datatype = match tiledb_field.datatype() {
+                    Ok(datatype) => datatype,
+                    Err(e) => return Some(Err(e)),
+                };
+                if datatype != field_datatype {
+                    return Some(Err(Error::Datatype(
+                        DatatypeErrorKind::InvalidDatatype {
+                            context: Some(f.name().clone()),
+                            found: datatype,
+                            expected: field_datatype,
+                        },
+                    )));
+                }
+                let field_cell_val_num = match tiledb_field.cell_val_num() {
+                    Ok(cvn) => cvn,
+                    Err(e) => return Some(Err(e)),
+                };
+                if cell_val_num != field_cell_val_num {
+                    /* TODO: we can be more flexible, e.g. fixed size list can go to Var */
+                    return Some(Err(Error::Datatype(
+                        DatatypeErrorKind::UnexpectedCellStructure {
+                            context: Some(f.name().clone()),
+                            found: cell_val_num,
+                            expected: field_cell_val_num,
+                        },
+                    )));
+                }
+                let field_is_nullable = match tiledb_field.nullability() {
+                    Ok(is_nullable) => is_nullable,
+                    Err(e) => return Some(Err(e)),
+                };
+                Some(
+                    c.typed_query_buffers(cell_val_num, field_is_nullable)
+                        .map(|qb| (f.name().clone(), qb)),
+                )
+            }
+            _ => {
+                /* arrow documentation asserts they have the same length */
+                unreachable!()
+            }
         }
     }
 }

--- a/tiledb/api/src/query/write/input/arrow.rs
+++ b/tiledb/api/src/query/write/input/arrow.rs
@@ -37,13 +37,7 @@ where
             CellValNum::Fixed(nz) if nz.get() == 1 => {
                 let validity = if let Some(nulls) = self.nulls() {
                     if is_nullable {
-                        Some(
-                            nulls
-                                .iter()
-                                .map(|v| if v { 1 } else { 0 })
-                                .collect::<Vec<u8>>()
-                                .into(),
-                        )
+                        Some(Buffer::<'_, u8>::from(nulls))
                     } else if nulls.null_count() == 0 {
                         None
                     } else {

--- a/tiledb/api/src/query/write/input/arrow.rs
+++ b/tiledb/api/src/query/write/input/arrow.rs
@@ -1,0 +1,88 @@
+use arrow::array::{Array as ArrowArray, PrimitiveArray};
+use arrow::datatypes::ArrowPrimitiveType;
+
+use crate::array::CellValNum;
+use crate::datatype::PhysicalType;
+use crate::error::{DatatypeErrorKind, Error};
+use crate::query::buffer::{Buffer, CellStructure, QueryBuffers};
+use crate::query::write::input::DataProvider;
+use crate::Result as TileDBResult;
+
+impl<A> DataProvider for PrimitiveArray<A>
+where
+    A: ArrowPrimitiveType,
+    <A as ArrowPrimitiveType>::Native: PhysicalType,
+{
+    type Unit = <A as ArrowPrimitiveType>::Native;
+
+    fn as_tiledb_input(
+        &self,
+        cell_val_num: CellValNum,
+        is_nullable: bool,
+    ) -> TileDBResult<QueryBuffers<Self::Unit>> {
+        let data = Buffer::Borrowed(self.values().as_ref());
+
+        match cell_val_num {
+            CellValNum::Fixed(nz) if nz.get() == 1 => {
+                let validity = if let Some(nulls) = self.nulls() {
+                    if is_nullable {
+                        Some(
+                            nulls
+                                .iter()
+                                .map(|v| if v { 1 } else { 0 })
+                                .collect::<Vec<u8>>()
+                                .into(),
+                        )
+                    } else if nulls.null_count() == 0 {
+                        None
+                    } else {
+                        /* TODO: error out, we have nulls but they are not expected */
+                        unimplemented!()
+                    }
+                } else {
+                    if is_nullable {
+                        Some(vec![1u8; self.values().len()].into())
+                    } else {
+                        None
+                    }
+                };
+
+                Ok(QueryBuffers {
+                    data,
+                    cell_structure: CellStructure::single(),
+                    validity,
+                })
+            }
+            CellValNum::Fixed(nz) => {
+                /* TODO: also check nulls */
+                if self.values().len() % nz.get() as usize == 0 {
+                    return Err(Error::Datatype(
+                        DatatypeErrorKind::UnexpectedCellStructure {
+                            context: None,
+                            found: CellValNum::Fixed(nz),
+                            expected: CellValNum::single(),
+                        },
+                    ));
+                }
+
+                if self.nulls().map(|n| n.null_count() > 0).unwrap_or(false) {
+                    /* TODO: error out, no way to represent this */
+                    unimplemented!()
+                }
+
+                Ok(QueryBuffers {
+                    data,
+                    cell_structure: CellStructure::Fixed(nz),
+                    validity: None,
+                })
+            }
+            CellValNum::Var => Err(Error::Datatype(
+                DatatypeErrorKind::UnexpectedCellStructure {
+                    context: None,
+                    found: CellValNum::Var,
+                    expected: CellValNum::single(),
+                },
+            )),
+        }
+    }
+}

--- a/tiledb/api/src/query/write/input/mod.rs
+++ b/tiledb/api/src/query/write/input/mod.rs
@@ -8,6 +8,9 @@ use crate::query::buffer::{
 };
 use crate::Result as TileDBResult;
 
+#[cfg(feature = "arrow")]
+pub mod arrow;
+
 pub trait DataProvider {
     type Unit: PhysicalType;
 

--- a/tiledb/api/src/query/write/input/mod.rs
+++ b/tiledb/api/src/query/write/input/mod.rs
@@ -1,10 +1,11 @@
 use std::num::NonZeroU32;
+use std::rc::Rc;
 
-use crate::array::CellValNum;
+use crate::array::{CellValNum, Schema};
 use crate::datatype::PhysicalType;
 use crate::error::{DatatypeErrorKind, Error};
 use crate::query::buffer::{
-    Buffer, CellStructure, QueryBuffers, QueryBuffersMut,
+    Buffer, CellStructure, QueryBuffers, QueryBuffersMut, TypedQueryBuffers,
 };
 use crate::Result as TileDBResult;
 
@@ -284,6 +285,12 @@ impl DataProvider for Vec<String> {
             validity,
         })
     }
+}
+
+pub trait RecordProvider<'data> {
+    type Iter: Iterator<Item = TileDBResult<(String, TypedQueryBuffers<'data>)>>;
+
+    fn tiledb_inputs(&'data self, schema: Rc<Schema>) -> Self::Iter;
 }
 
 #[cfg(test)]

--- a/tiledb/api/src/query/write/mod.rs
+++ b/tiledb/api/src/query/write/mod.rs
@@ -162,7 +162,7 @@ impl<'data> WriteBuilder<'data> {
             _data_size: data_size,
             _offsets_size: offsets_size,
             _validity_size: validity_size,
-            _input: input.into(),
+            _input: input,
         };
 
         self.inputs.insert(field_name, raw_write_input);

--- a/tiledb/api/src/query/write/mod.rs
+++ b/tiledb/api/src/query/write/mod.rs
@@ -2,9 +2,11 @@ use super::*;
 
 use std::collections::HashMap;
 use std::pin::Pin;
+use std::rc::Rc;
 
 use crate::query::buffer::{CellStructure, QueryBuffers, TypedQueryBuffers};
-use crate::query::write::input::DataProvider;
+use crate::query::write::input::{DataProvider, RecordProvider};
+use crate::typed_query_buffers_go;
 
 pub mod input;
 
@@ -80,34 +82,27 @@ impl<'data> WriteBuilder<'data> {
         })
     }
 
-    pub fn data_typed<S, T>(
+    pub fn buffers<S>(
         mut self,
         field: S,
-        data: &'data T,
+        input: TypedQueryBuffers<'data>,
     ) -> TileDBResult<Self>
     where
         S: AsRef<str>,
-        T: DataProvider,
-        QueryBuffers<'data, <T as DataProvider>::Unit>:
-            Into<TypedQueryBuffers<'data>>,
     {
         let field_name = field.as_ref().to_string();
-
-        let input = {
-            let schema = self.base().array().schema()?;
-            let schema_field = schema.field(field_name.clone())?;
-            data.as_tiledb_input(
-                schema_field.cell_val_num()?,
-                schema_field.nullability()?,
-            )?
-        };
 
         let c_query = **self.base().cquery();
         let c_name = cstring!(field_name.clone());
 
-        let mut data_size = Box::pin(input.data.size() as u64);
+        let (c_bufptr, mut data_size) =
+            typed_query_buffers_go!(input, _DT, ref qb, {
+                let c_bufptr =
+                    qb.data.as_ref().as_ptr() as *mut std::ffi::c_void;
+                let data_size = Box::pin(qb.data.size() as u64);
+                (c_bufptr, data_size)
+            });
 
-        let c_bufptr = input.data.as_ref().as_ptr() as *mut std::ffi::c_void;
         let c_sizeptr = data_size.as_mut().get_mut() as *mut u64;
 
         self.capi_call(|ctx| unsafe {
@@ -121,7 +116,7 @@ impl<'data> WriteBuilder<'data> {
         })?;
 
         let offsets_size = if let CellStructure::Var(offsets) =
-            input.cell_structure.borrow()
+            input.cell_structure().borrow()
         {
             let mut offsets_size = Box::pin(offsets.size() as u64);
 
@@ -143,11 +138,11 @@ impl<'data> WriteBuilder<'data> {
         };
 
         let mut validity_size =
-            input.validity.as_ref().map(|b| Box::pin(b.size() as u64));
+            input.validity().map(|b| Box::pin(b.size() as u64));
 
         if let Some(ref mut validity_size) = validity_size.as_mut() {
             let c_validityptr =
-                input.validity.as_ref().unwrap().as_ref().as_ptr() as *mut u8;
+                input.validity().unwrap().as_ref().as_ptr() as *mut u8;
             let c_sizeptr = validity_size.as_mut().get_mut() as *mut u64;
 
             self.capi_call(|ctx| unsafe {
@@ -171,6 +166,46 @@ impl<'data> WriteBuilder<'data> {
         self.inputs.insert(field_name, raw_write_input);
 
         Ok(self)
+    }
+
+    pub fn data_typed<S, T>(
+        self,
+        field: S,
+        data: &'data T,
+    ) -> TileDBResult<Self>
+    where
+        S: AsRef<str>,
+        T: DataProvider,
+        QueryBuffers<'data, <T as DataProvider>::Unit>:
+            Into<TypedQueryBuffers<'data>>,
+    {
+        let field_name = field.as_ref();
+
+        let input = {
+            let schema = self.base().array().schema()?;
+            let schema_field = schema.field(field_name)?;
+            data.as_tiledb_input(
+                schema_field.cell_val_num()?,
+                schema_field.nullability()?,
+            )?
+        };
+
+        self.buffers(field, input.into())
+    }
+
+    pub fn records<R>(self, data: &'data R) -> TileDBResult<Self>
+    where
+        R: RecordProvider<'data>,
+    {
+        let schema = Rc::new(self.base().array().schema()?);
+
+        let mut b = self;
+        for try_input in data.tiledb_inputs(Rc::clone(&schema)) {
+            let (field, input_data) = try_input?;
+            b = b.buffers(field, input_data)?;
+        }
+
+        Ok(b)
     }
 }
 

--- a/tiledb/api/src/range.rs
+++ b/tiledb/api/src/range.rs
@@ -18,7 +18,7 @@ macro_rules! check_datatype_inner {
     ($ty:ty, $dtype:expr) => {
         if !$dtype.is_compatible_type::<$ty>() {
             return Err(Error::Datatype(DatatypeErrorKind::TypeMismatch {
-                user_type: std::any::type_name::<$ty>(),
+                user_type: std::any::type_name::<$ty>().to_owned(),
                 tiledb_type: $dtype,
             }));
         }


### PR DESCRIPTION
Previous work turned query read output into arrow data.  This pull request flips that, turning arrow data into query input.

This involves several implementations of `DataProvider` for arrow array types, as well as introducing a similar `TypedDataProvider` which we need to do `impl TypedDataProvider for dyn ArrowArray`.  `DataProvider` has an object create `QueryBuffers` and `TypedDataProvider` has an object return `TypedQueryBuffers`.  These implementations are tested by taking something resembling tiledb query output, turning it into arrow, and then turning the arrow back into the tiledb format.

We also add a new trait `RecordProvider` which we implement for `RecordBatch`, adding a set of named fields to a write query.  This is not tested yet and probably won't be while the write test strategy is still pending.