### PR TITLE
Replace TempDir with TestArrayUri

### DIFF
--- a/tiledb/api/src/array/fragment_info.rs
+++ b/tiledb/api/src/array/fragment_info.rs
@@ -744,18 +744,17 @@ impl Builder {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use tempfile::TempDir;
-
     use crate::array::*;
     use crate::config::Config;
     use crate::query::{QueryBuilder, WriteBuilder};
+    use crate::test_util::{self, TestArrayUri};
     use crate::Datatype;
 
     #[test]
     fn test_set_config() -> TileDBResult<()> {
         let ctx = Context::new().unwrap();
-        let tmp_dir = TempDir::new().unwrap();
-        let array_uri = create_dense_array(&ctx, &tmp_dir).unwrap();
+        let test_uri = test_util::get_uri_generator()?;
+        let array_uri = create_dense_array(&ctx, &test_uri)?;
 
         let config = Config::new()?;
         let frag_infos =
@@ -769,8 +768,8 @@ pub mod tests {
     #[test]
     fn test_get_config() -> TileDBResult<()> {
         let ctx = Context::new().unwrap();
-        let tmp_dir = TempDir::new().unwrap();
-        let array_uri = create_dense_array(&ctx, &tmp_dir).unwrap();
+        let test_uri = test_util::get_uri_generator()?;
+        let array_uri = create_dense_array(&ctx, &test_uri)?;
         let frag_infos = Builder::new(&ctx, array_uri)?.build()?;
 
         assert!(frag_infos.config().is_ok());
@@ -781,8 +780,8 @@ pub mod tests {
     #[test]
     fn test_load_infos() -> TileDBResult<()> {
         let ctx = Context::new().unwrap();
-        let tmp_dir = TempDir::new().unwrap();
-        let array_uri = create_dense_array(&ctx, &tmp_dir).unwrap();
+        let test_uri = test_util::get_uri_generator()?;
+        let array_uri = create_dense_array(&ctx, &test_uri)?;
         let frag_infos = Builder::new(&ctx, array_uri)?.build_without_loading();
 
         assert!(frag_infos.load().is_ok());
@@ -793,8 +792,8 @@ pub mod tests {
     #[test]
     fn test_unconsolidated_metadata_num() -> TileDBResult<()> {
         let ctx = Context::new().unwrap();
-        let tmp_dir = TempDir::new().unwrap();
-        let array_uri = create_dense_array(&ctx, &tmp_dir).unwrap();
+        let test_uri = test_util::get_uri_generator()?;
+        let array_uri = create_dense_array(&ctx, &test_uri)?;
         let frag_infos = Builder::new(&ctx, array_uri)?.build()?;
 
         assert!(frag_infos.unconsolidated_metadata_num().is_ok());
@@ -805,8 +804,8 @@ pub mod tests {
     #[test]
     fn test_num_to_vacuum() -> TileDBResult<()> {
         let ctx = Context::new().unwrap();
-        let tmp_dir = TempDir::new().unwrap();
-        let array_uri = create_dense_array(&ctx, &tmp_dir).unwrap();
+        let test_uri = test_util::get_uri_generator()?;
+        let array_uri = create_dense_array(&ctx, &test_uri)?;
         let frag_infos = Builder::new(&ctx, array_uri)?.build()?;
 
         assert!(frag_infos.num_to_vacuum().is_ok());
@@ -817,8 +816,8 @@ pub mod tests {
     #[test]
     fn test_total_cell_count() -> TileDBResult<()> {
         let ctx = Context::new().unwrap();
-        let tmp_dir = TempDir::new().unwrap();
-        let array_uri = create_dense_array(&ctx, &tmp_dir).unwrap();
+        let test_uri = test_util::get_uri_generator()?;
+        let array_uri = create_dense_array(&ctx, &test_uri)?;
         let frag_infos = Builder::new(&ctx, array_uri)?.build()?;
 
         let cell_count = frag_infos.total_cell_count()?;
@@ -830,8 +829,8 @@ pub mod tests {
     #[test]
     fn test_num_fragments() -> TileDBResult<()> {
         let ctx = Context::new().unwrap();
-        let tmp_dir = TempDir::new().unwrap();
-        let array_uri = create_dense_array(&ctx, &tmp_dir).unwrap();
+        let test_uri = test_util::get_uri_generator()?;
+        let array_uri = create_dense_array(&ctx, &test_uri)?;
         let frag_infos = Builder::new(&ctx, array_uri)?.build()?;
 
         let num_frags = frag_infos.num_fragments()?;
@@ -843,8 +842,8 @@ pub mod tests {
     #[test]
     fn test_get_fragment() -> TileDBResult<()> {
         let ctx = Context::new().unwrap();
-        let tmp_dir = TempDir::new().unwrap();
-        let array_uri = create_dense_array(&ctx, &tmp_dir).unwrap();
+        let test_uri = test_util::get_uri_generator()?;
+        let array_uri = create_dense_array(&ctx, &test_uri)?;
         let frag_infos = Builder::new(&ctx, array_uri)?.build()?;
 
         assert!(frag_infos.get_fragment(0).is_ok());
@@ -855,8 +854,8 @@ pub mod tests {
     #[test]
     fn test_get_fragment_failure() -> TileDBResult<()> {
         let ctx = Context::new().unwrap();
-        let tmp_dir = TempDir::new().unwrap();
-        let array_uri = create_dense_array(&ctx, &tmp_dir).unwrap();
+        let test_uri = test_util::get_uri_generator()?;
+        let array_uri = create_dense_array(&ctx, &test_uri)?;
         let frag_infos = Builder::new(&ctx, array_uri)?.build()?;
 
         assert!(frag_infos.get_fragment(3).is_err());
@@ -867,8 +866,8 @@ pub mod tests {
     #[test]
     fn test_iter_fragments() -> TileDBResult<()> {
         let ctx = Context::new().unwrap();
-        let tmp_dir = TempDir::new().unwrap();
-        let array_uri = create_dense_array(&ctx, &tmp_dir).unwrap();
+        let test_uri = test_util::get_uri_generator()?;
+        let array_uri = create_dense_array(&ctx, &test_uri)?;
         let frag_infos = Builder::new(&ctx, array_uri)?.build()?;
 
         let mut num_frags = 0;
@@ -884,9 +883,9 @@ pub mod tests {
     #[test]
     fn test_fragment_info_apis() -> TileDBResult<()> {
         let ctx = Context::new().unwrap();
-        let tmp_dir = TempDir::new().unwrap();
-        let dense_array_uri = create_dense_array(&ctx, &tmp_dir).unwrap();
-        let sparse_array_uri = create_sparse_array(&ctx, &tmp_dir).unwrap();
+        let test_uri = test_util::get_uri_generator()?;
+        let dense_array_uri = create_dense_array(&ctx, &test_uri)?;
+        let sparse_array_uri = create_sparse_array(&ctx, &test_uri)?;
 
         check_fragment_info_apis(&ctx, &dense_array_uri, FragmentType::Dense)?;
         check_fragment_info_apis(
@@ -928,10 +927,9 @@ pub mod tests {
     /// Create a simple dense test array with a couple fragments to inspect.
     pub fn create_dense_array(
         ctx: &Context,
-        dir: &TempDir,
+        test_uri: &dyn TestArrayUri,
     ) -> TileDBResult<String> {
-        let array_dir = dir.path().join("fragment_info_test_dense");
-        let array_uri = String::from(array_dir.to_str().unwrap());
+        let array_uri = test_uri.with_path("fragment_info_test_dense")?;
 
         let domain = {
             let rows = DimensionBuilder::new(
@@ -972,10 +970,9 @@ pub mod tests {
     /// Create a simple sparse test array with a couple fragments to inspect.
     pub fn create_sparse_array(
         ctx: &Context,
-        dir: &TempDir,
+        test_uri: &dyn TestArrayUri,
     ) -> TileDBResult<String> {
-        let array_dir = dir.path().join("fragment_info_test_sparse");
-        let array_uri = String::from(array_dir.to_str().unwrap());
+        let array_uri = test_uri.with_path("fragment_info_test_sparse")?;
 
         let domain = {
             let rows = DimensionBuilder::new(

--- a/tiledb/api/src/array/schema/mod.rs
+++ b/tiledb/api/src/array/schema/mod.rs
@@ -934,15 +934,13 @@ pub mod strategy;
 
 #[cfg(test)]
 mod tests {
-    use std::io;
-    use tempfile::TempDir;
-
     use super::*;
     use crate::array::tests::create_quickstart_dense;
     use crate::array::{AttributeBuilder, DimensionBuilder, DomainBuilder};
     use crate::filter::{
         CompressionData, CompressionType, FilterData, FilterListBuilder,
     };
+    use crate::test_util::{self, TestArrayUri};
 
     fn sample_attribute(c: &Context) -> Attribute {
         AttributeBuilder::new(c, "a1", Datatype::Int32)
@@ -1089,15 +1087,16 @@ mod tests {
     }
 
     #[test]
-    fn test_load() -> io::Result<()> {
-        let tmp_dir = TempDir::new()?;
+    fn test_load() -> TileDBResult<()> {
+        let test_uri = test_util::get_uri_generator()?;
 
         let c: Context = Context::new().unwrap();
 
-        let r = create_quickstart_dense(&tmp_dir, &c);
+        let r = create_quickstart_dense(&test_uri, &c);
         assert!(r.is_ok());
+        let uri = r.ok().unwrap();
 
-        let schema = Schema::load(&c, r.unwrap())
+        let schema = Schema::load(&c, uri)
             .expect("Could not open quickstart_dense schema");
 
         let domain = schema.domain().expect("Error reading domain");
@@ -1119,9 +1118,7 @@ mod tests {
         assert_eq!(cols_domain[1], 4);
 
         // Make sure we can remove the array we created.
-        tmp_dir.close()?;
-
-        Ok(())
+        test_uri.close()
     }
 
     #[test]

--- a/tiledb/api/src/array/strategy.rs
+++ b/tiledb/api/src/array/strategy.rs
@@ -1,13 +1,13 @@
 #[cfg(test)]
 mod tests {
     use proptest::prelude::*;
-    use tempfile::TempDir;
     use util::assert_option_subset;
     use util::option::OptionSubset;
 
     use crate::array::schema::SchemaData;
     use crate::array::{Array, Schema};
     use crate::context::Context;
+    use crate::test_util::{self, TestArrayUri};
     use crate::Factory;
 
     #[test]
@@ -18,8 +18,8 @@ mod tests {
             let schema_in = schema_spec.create(&ctx)
                 .expect("Error constructing arbitrary schema");
 
-            let tempdir = TempDir::new().expect("Error creating temp dir");
-            let uri = String::from("file:///") + tempdir.path().join("array").to_str().unwrap();
+            let test_uri = test_util::get_uri_generator()?;
+            let uri = test_uri.with_path("array")?;
 
             Array::create(&ctx, &uri, schema_in)
                 .expect("Error creating array");

--- a/tiledb/api/src/lib.rs
+++ b/tiledb/api/src/lib.rs
@@ -57,6 +57,9 @@ pub mod stats;
 pub mod string;
 pub mod vfs;
 
+#[cfg(test)]
+pub mod test_util;
+
 #[cfg(feature = "arrow")]
 pub mod arrow;
 

--- a/tiledb/api/src/test_util.rs
+++ b/tiledb/api/src/test_util.rs
@@ -1,0 +1,81 @@
+use tempfile::TempDir;
+
+use crate::error::Error;
+use crate::Result as TileDBResult;
+
+pub trait TestArrayUri {
+    fn base_dir(&self) -> TileDBResult<String>;
+    fn with_path(&self, path: &str) -> TileDBResult<String>;
+    fn with_paths(&self, paths: &[&str]) -> TileDBResult<String>;
+    fn close(self) -> TileDBResult<()>;
+}
+
+pub fn get_uri_generator() -> TileDBResult<impl TestArrayUri> {
+    // TODO: Eventually this will check an environment variable to decide
+    // whether we should return a TestDirectory or a new struct called something
+    // like TestRestServer to run our test suite against the cloud service.
+    TestDirectory::new()
+}
+
+pub struct TestDirectory {
+    base_dir: TempDir,
+}
+
+impl TestDirectory {
+    pub fn new() -> TileDBResult<Self> {
+        Ok(Self {
+            base_dir: TempDir::new().map_err(|e| {
+                Error::Other(format!(
+                    "Error creating temporary directory: {}",
+                    e
+                ))
+            })?,
+        })
+    }
+
+    pub fn base_dir(&self) -> TileDBResult<String> {
+        let path =
+            self.base_dir.path().to_str().map(|s| s.to_string()).ok_or(
+                Error::Other("Error creating test array URI".to_string()),
+            )?;
+        Ok("file://".to_string() + &path)
+    }
+
+    pub fn with_path(&self, path: &str) -> TileDBResult<String> {
+        self.with_paths(&[path])
+    }
+
+    pub fn with_paths(&self, paths: &[&str]) -> TileDBResult<String> {
+        let path = self.base_dir.path().to_path_buf();
+        let path = paths.iter().fold(path, |path, part| path.join(part));
+        let path = path
+            .to_str()
+            .map(|p| p.to_string())
+            .ok_or(Error::Other("Error creating temporary URI".to_string()))?;
+        Ok("file://".to_string() + &path)
+    }
+
+    pub fn close(self) -> TileDBResult<()> {
+        self.base_dir.close().map_err(|e| {
+            Error::Other(format!("Error closing temporary directory: {}", e))
+        })
+    }
+}
+
+impl TestArrayUri for TestDirectory {
+    fn base_dir(&self) -> TileDBResult<String> {
+        self.base_dir()
+    }
+
+    fn with_path(&self, path: &str) -> TileDBResult<String> {
+        self.with_path(path)
+    }
+
+    fn with_paths(&self, paths: &[&str]) -> TileDBResult<String> {
+        self.with_paths(paths)
+    }
+
+    fn close(self) -> TileDBResult<()> {
+        self.close()
+    }
+}


### PR DESCRIPTION
This removes our usage of the TempDir for tests and instead uses a new TestArrayUri trait. Eventually this will allow us to dynamically change whether tests run against a local file system or a remote cloud service instance.

This does not yet support actually running against the cloud service as that will take more infra setup to get going. However, it should be as simple as creating a new TestCloudUri struct which then implements the TestArrayUri trait. Then the `test_util::get_uri_generator` can return either trait implementation at runtime based on an environment variable or whatever is easiest in CI.