### PR TITLE
Proptest for checking correctness of a single sparse write

### DIFF
--- a/tiledb/api/src/array/dimension/strategy.rs
+++ b/tiledb/api/src/array/dimension/strategy.rs
@@ -39,7 +39,8 @@ impl Default for Requirements {
 }
 
 pub fn prop_dimension_name() -> impl Strategy<Value = String> {
-    proptest::string::string_regex("[a-zA-Z0-9_]*")
+    // SC-48077: bug with "" for dimension name, prevent for now
+    proptest::string::string_regex("[a-zA-Z0-9_]+")
         .expect("Error creating dimension name strategy")
 }
 

--- a/tiledb/api/src/array/dimension/strategy.rs
+++ b/tiledb/api/src/array/dimension/strategy.rs
@@ -24,6 +24,7 @@ pub struct Requirements {
     pub array_type: Option<ArrayType>,
     pub datatype: Option<Datatype>,
     pub extent_limit: usize,
+    pub filters: Option<Rc<FilterRequirements>>,
 }
 
 impl Default for Requirements {
@@ -32,6 +33,7 @@ impl Default for Requirements {
             array_type: None,
             datatype: None,
             extent_limit: 1024 * 16,
+            filters: None,
         }
     }
 }
@@ -200,11 +202,16 @@ fn prop_dimension_for_datatype(
         } else {
             Just(None).boxed()
         };
-        let filters = any_with::<FilterListData>(Rc::new(FilterRequirements {
+        let filter_req = FilterRequirements {
             input_datatype: Some(datatype),
             context: Some(FilterContext::Dimension(datatype, cell_val_num)),
-            ..Default::default()
-        }));
+            ..params
+                .filters
+                .as_ref()
+                .map(|rc| rc.as_ref().clone())
+                .unwrap_or_default()
+        };
+        let filters = any_with::<FilterListData>(Rc::new(filter_req));
         (name, range_and_extent, filters)
             .prop_map(move |(name, values, filters)| {
                 let constraints = match values {

--- a/tiledb/api/src/array/domain/mod.rs
+++ b/tiledb/api/src/array/domain/mod.rs
@@ -278,6 +278,20 @@ pub struct DomainData {
     pub dimension: Vec<DimensionData>,
 }
 
+impl DomainData {
+    /// Returns the total number of cells spanned by all dimensions,
+    /// or `None` if:
+    /// - any dimension is not constrained into a domain; or
+    /// - the total number of cells exceeds `usize::MAX`.
+    pub fn num_cells(&self) -> Option<usize> {
+        let mut total = 1u128;
+        for d in self.dimension.iter() {
+            total = total.checked_mul(d.constraints.num_cells()?)?;
+        }
+        usize::try_from(total).ok()
+    }
+}
+
 impl Display for DomainData {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         write!(f, "{}", json!(*self))

--- a/tiledb/api/src/array/domain/strategy.rs
+++ b/tiledb/api/src/array/domain/strategy.rs
@@ -12,6 +12,7 @@ pub struct Requirements {
     pub array_type: Option<ArrayType>,
     pub num_dimensions: std::ops::RangeInclusive<usize>,
     pub cells_per_tile_limit: usize,
+    pub dimension: Option<DimensionRequirements>,
 }
 
 impl Requirements {
@@ -28,6 +29,7 @@ impl Default for Requirements {
             num_dimensions: Self::DEFAULT_MIN_DIMENSIONS
                 ..=Self::DEFAULT_MAX_DIMENSIONS,
             cells_per_tile_limit: Self::DEFAULT_CELLS_PER_TILE_LIMIT,
+            dimension: None,
         }
     }
 }
@@ -36,6 +38,8 @@ fn prop_domain_for_array_type(
     array_type: ArrayType,
     params: &Requirements,
 ) -> impl Strategy<Value = DomainData> {
+    let dimension_params = params.dimension.clone().unwrap_or_default();
+
     match array_type {
         ArrayType::Dense => {
             let cells_per_tile_limit = params.cells_per_tile_limit;
@@ -63,7 +67,7 @@ fn prop_domain_for_array_type(
                                 ) as usize
                                     + 1 // round up, probably won't hurt, might prevent problems
                             },
-                            ..Default::default()
+                            ..dimension_params.clone()
                         };
                         proptest::collection::vec(
                             any_with::<DimensionData>(dimension_params),
@@ -76,7 +80,7 @@ fn prop_domain_for_array_type(
         ArrayType::Sparse => {
             let dimension_params = DimensionRequirements {
                 array_type: Some(ArrayType::Sparse),
-                ..Default::default()
+                ..dimension_params
             };
             proptest::collection::vec(
                 any_with::<DimensionData>(dimension_params),

--- a/tiledb/api/src/array/schema/arrow.rs
+++ b/tiledb/api/src/array/schema/arrow.rs
@@ -30,7 +30,6 @@ pub type SchemaFromArrowResult =
 #[derive(Deserialize, Serialize)]
 pub struct SchemaMetadata {
     array_type: ArrayType,
-    version: i64,
     capacity: u64,
     allows_duplicates: bool,
     cell_order: CellOrder,
@@ -48,7 +47,6 @@ impl SchemaMetadata {
     pub fn new(schema: &Schema) -> TileDBResult<Self> {
         Ok(SchemaMetadata {
             array_type: schema.array_type()?,
-            version: schema.version()?,
             capacity: schema.capacity()?,
             allows_duplicates: schema.allows_duplicates()?,
             cell_order: schema.cell_order()?,

--- a/tiledb/api/src/array/schema/mod.rs
+++ b/tiledb/api/src/array/schema/mod.rs
@@ -390,18 +390,14 @@ impl Schema {
         Ok(Schema::new(context, RawSchema::Owned(c_schema)))
     }
 
-    pub fn version(&self) -> TileDBResult<i64> {
+    pub fn version(&self) -> TileDBResult<u32> {
         let c_schema = self.capi();
-        let mut c_version: std::os::raw::c_int = out_ptr!();
+        let mut c_version: u32 = out_ptr!();
         self.capi_call(|ctx| unsafe {
-            ffi::tiledb_array_schema_get_allows_dups(
-                ctx,
-                c_schema,
-                &mut c_version,
-            )
+            ffi::tiledb_array_schema_get_version(ctx, c_schema, &mut c_version)
         })?;
 
-        Ok(c_version as i64)
+        Ok(c_version)
     }
 
     pub fn array_type(&self) -> TileDBResult<ArrayType> {
@@ -1013,7 +1009,12 @@ mod tests {
         .unwrap();
 
         let s: Schema = b.build().unwrap();
-        assert_eq!(0, s.version().unwrap());
+
+        let schema_version = s.version().unwrap();
+
+        // it's a little awkward to use a constant here but this does
+        // not appear to be tied to the library version
+        assert_eq!(schema_version, 21);
     }
 
     #[test]

--- a/tiledb/api/src/array/schema/mod.rs
+++ b/tiledb/api/src/array/schema/mod.rs
@@ -180,6 +180,14 @@ pub enum Field {
 }
 
 impl Field {
+    pub fn is_attribute(&self) -> bool {
+        matches!(self, Self::Attribute(_))
+    }
+
+    pub fn is_dimension(&self) -> bool {
+        matches!(self, Self::Dimension(_))
+    }
+
     pub fn name(&self) -> TileDBResult<String> {
         match self {
             Field::Dimension(ref d) => d.name(),
@@ -234,6 +242,14 @@ pub enum FieldData {
 }
 
 impl FieldData {
+    pub fn is_attribute(&self) -> bool {
+        matches!(self, Self::Attribute(_))
+    }
+
+    pub fn is_dimension(&self) -> bool {
+        matches!(self, Self::Dimension(_))
+    }
+
     pub fn name(&self) -> &str {
         match self {
             Self::Dimension(d) => &d.name,

--- a/tiledb/api/src/array/schema/mod.rs
+++ b/tiledb/api/src/array/schema/mod.rs
@@ -1634,7 +1634,7 @@ mod tests {
         assert_eq!(10000, dense_schema.capacity().unwrap());
         assert_eq!(CellOrder::RowMajor, dense_schema.cell_order().unwrap());
         assert_eq!(TileOrder::RowMajor, dense_schema.tile_order().unwrap());
-        assert_eq!(false, dense_schema.allows_duplicates().unwrap());
+        assert!(!dense_schema.allows_duplicates().unwrap());
 
         let sparse_spec = SchemaData {
             array_type: ArrayType::Sparse,
@@ -1663,6 +1663,6 @@ mod tests {
         assert_eq!(10000, sparse_schema.capacity().unwrap());
         assert_eq!(CellOrder::RowMajor, sparse_schema.cell_order().unwrap());
         assert_eq!(TileOrder::RowMajor, sparse_schema.tile_order().unwrap());
-        assert_eq!(false, sparse_schema.allows_duplicates().unwrap());
+        assert!(!sparse_schema.allows_duplicates().unwrap());
     }
 }

--- a/tiledb/api/src/datatype/physical.rs
+++ b/tiledb/api/src/datatype/physical.rs
@@ -124,7 +124,9 @@ pub trait PhysicalType:
 {
 }
 
-macro_rules! native_type_eq {
+pub trait IntegralType: Eq + Ord + PhysicalType {}
+
+macro_rules! integral_type_impls {
     ($($T:ty: $datatype:expr),+) => {
         sealed!($($T),+);
 
@@ -142,12 +144,14 @@ macro_rules! native_type_eq {
             }
 
             impl PhysicalType for $T {}
+
+            impl IntegralType for $T {}
         )+
     }
 }
 
-native_type_eq!(u8: Datatype::UInt8, u16: Datatype::UInt16, u32: Datatype::UInt32, u64: Datatype::UInt64);
-native_type_eq!(i8: Datatype::Int8, i16: Datatype::Int16, i32: Datatype::Int32, i64: Datatype::Int64);
+integral_type_impls!(u8: Datatype::UInt8, u16: Datatype::UInt16, u32: Datatype::UInt32, u64: Datatype::UInt64);
+integral_type_impls!(i8: Datatype::Int8, i16: Datatype::Int16, i32: Datatype::Int32, i64: Datatype::Int64);
 
 impl crate::private::Sealed for f32 {}
 impl crate::private::Sealed for f64 {}

--- a/tiledb/api/src/query/read/callback.rs
+++ b/tiledb/api/src/query/read/callback.rs
@@ -210,6 +210,135 @@ fn_mut_adapter_tuple!(ReadCallback2Arg, A1: Unit1, A2: Unit2);
 fn_mut_adapter_tuple!(ReadCallback3Arg, A1: Unit1, A2: Unit2, A3: Unit3);
 fn_mut_adapter_tuple!(ReadCallback4Arg, A1: Unit1, A2: Unit2, A3: Unit3, A4: Unit4);
 
+pub struct MapIntermediate<S, F> {
+    callback: S,
+    transform: F,
+}
+
+impl<S, F, O> ReadCallbackVarArg for MapIntermediate<S, F>
+where
+    S: ReadCallbackVarArg,
+    F: FnMut(<S as ReadCallbackVarArg>::Intermediate) -> O,
+{
+    type Intermediate = O;
+    type Final = <S as ReadCallbackVarArg>::Final;
+    type Error = <S as ReadCallbackVarArg>::Error;
+
+    fn intermediate_result(
+        &mut self,
+        args: Vec<TypedRawReadOutput>,
+    ) -> Result<Self::Intermediate, Self::Error> {
+        Ok((self.transform)(self.callback.intermediate_result(args)?))
+    }
+
+    fn final_result(
+        self,
+        args: Vec<TypedRawReadOutput>,
+    ) -> Result<Self::Final, Self::Error> {
+        self.callback.final_result(args)
+    }
+}
+
+pub struct MapFinal<S, F> {
+    callback: S,
+    transform: F,
+}
+
+impl<S, F, O> ReadCallbackVarArg for MapFinal<S, F>
+where
+    S: ReadCallbackVarArg,
+    F: FnMut(<S as ReadCallbackVarArg>::Final) -> O,
+{
+    type Intermediate = <S as ReadCallbackVarArg>::Intermediate;
+    type Final = O;
+    type Error = <S as ReadCallbackVarArg>::Error;
+
+    fn intermediate_result(
+        &mut self,
+        args: Vec<TypedRawReadOutput>,
+    ) -> Result<Self::Intermediate, Self::Error> {
+        self.callback.intermediate_result(args)
+    }
+
+    fn final_result(
+        mut self,
+        args: Vec<TypedRawReadOutput>,
+    ) -> Result<Self::Final, Self::Error> {
+        Ok((self.transform)(self.callback.final_result(args)?))
+    }
+}
+
+macro_rules! map_impls {
+    ($callback:ident, $($A:ident: $U:ident),+) => {
+        impl<S, F, O> $callback for MapIntermediate<S, F> where S: $callback, F: FnMut(<S as $callback>::Intermediate) -> O {
+            $(
+                type $U = <S as $callback>::$U;
+            )+
+            type Intermediate = O;
+            type Final = <S as $callback>::Final;
+            type Error = <S as $callback>::Error;
+
+            paste! {
+                fn intermediate_result(
+                    &mut self,
+                    $(
+                        [< $A:snake >]: RawReadOutput<Self::$U>
+                    ),+
+                ) -> Result<Self::Intermediate, Self::Error>
+                {
+                    Ok((self.transform)(self.callback.intermediate_result($([< $A:snake >]),+)?))
+                }
+
+                fn final_result(
+                    self,
+                    $(
+                        [< $A:snake >]: RawReadOutput<Self::$U>
+                    ),+
+                ) -> Result<Self::Final, Self::Error>
+                {
+                    self.callback.final_result($([< $A:snake >]),+)
+                }
+            }
+        }
+
+        impl<S, F, O> $callback for MapFinal<S, F> where S: $callback, F: FnMut(<S as $callback>::Final) -> O {
+            $(
+                type $U = <S as $callback>::$U;
+            )+
+            type Intermediate = <S as $callback>::Intermediate;
+            type Final = O;
+            type Error = <S as $callback>::Error;
+
+            paste! {
+                fn intermediate_result(
+                    &mut self,
+                    $(
+                        [< $A:snake >]: RawReadOutput<Self::$U>
+                    ),+
+                ) -> Result<Self::Intermediate, Self::Error>
+                {
+                    self.callback.intermediate_result($([< $A:snake >]),+)
+                }
+
+                fn final_result(
+                    mut self,
+                    $(
+                        [< $A:snake >]: RawReadOutput<Self::$U>
+                    ),+
+                ) -> Result<Self::Final, Self::Error>
+                {
+                    Ok((self.transform)(self.callback.final_result($([< $A:snake >]),+)?))
+                }
+            }
+        }
+    };
+}
+
+map_impls!(ReadCallback, A1: Unit);
+map_impls!(ReadCallback2Arg, A1: Unit1, A2: Unit2);
+map_impls!(ReadCallback3Arg, A1: Unit1, A2: Unit2, A3: Unit3);
+map_impls!(ReadCallback4Arg, A1: Unit1, A2: Unit2, A3: Unit3, A4: Unit4);
+
 mod impls {
     use super::*;
     use crate::query::read::output::VarDataIterator;
@@ -389,6 +518,36 @@ macro_rules! query_read_callback {
                 ),+
             }
 
+            impl<'data, T, Q> $query<'data, T, Q> where T: $callback {
+                pub fn map_intermediate<F, O>(self, transform: F) -> $query<'data, MapIntermediate<T, F>, Q>
+                where F: FnMut(T::Intermediate) -> O {
+                    $query {
+                        callback: self.callback.map(|callback| MapIntermediate {
+                            callback,
+                            transform
+                        }),
+                        base: self.base,
+                        $(
+                            [< arg_ $U:snake >]: self.[< arg_ $U:snake >]
+                        ),+
+                    }
+                }
+
+                pub fn map_final<F, O>(self, transform: F) -> $query<'data, MapFinal<T, F>, Q>
+                where F: FnMut(T::Final) -> O {
+                    $query {
+                        callback: self.callback.map(|callback| MapFinal {
+                            callback,
+                            transform
+                        }),
+                        base: self.base,
+                        $(
+                            [< arg_ $U:snake >]: self.[< arg_ $U:snake >]
+                        ),+
+                    }
+                }
+            }
+
             impl<'data, T, Q> ContextBound for $query<'data, T, Q>
             where
                 T: $callback,
@@ -536,6 +695,40 @@ macro_rules! query_read_callback {
                 ),+
             }
 
+            impl<'data, T, B> $Builder<'data, T, B> where T: $callback {
+                pub fn map_intermediate<F, O>(
+                    self, transform: F
+                ) -> $Builder<'data, MapIntermediate<T, F>, B>
+                where F: FnMut(T::Intermediate) -> O {
+                    $Builder {
+                        callback: MapIntermediate {
+                            callback: self.callback,
+                            transform
+                        },
+                        base: self.base,
+                        $(
+                            [< arg_ $U:snake >]: self.[< arg_ $U:snake >]
+                        ),+
+                    }
+                }
+
+                pub fn map_final<F, O>(
+                    self, transform: F
+                ) -> $Builder<'data, MapFinal<T, F>, B>
+                where F: FnMut(T::Final) -> O {
+                    $Builder {
+                        callback: MapFinal {
+                            callback: self.callback,
+                            transform
+                        },
+                        base: self.base,
+                        $(
+                            [< arg_ $U:snake >]: self.[< arg_ $U:snake >]
+                        ),+
+                    }
+                }
+            }
+
             impl<'data, T, B> QueryBuilder for $Builder <'data, T, B>
             where T: $callback,
                   B: QueryBuilder,
@@ -604,6 +797,43 @@ query_read_callback!(
 pub struct CallbackVarArgReadQuery<'data, T, Q> {
     pub(crate) callback: Option<T>,
     pub(crate) base: VarRawReadQuery<'data, Q>,
+}
+
+impl<'data, T, Q> CallbackVarArgReadQuery<'data, T, Q>
+where
+    T: ReadCallbackVarArg,
+{
+    pub fn map_intermediate<F, O>(
+        self,
+        transform: F,
+    ) -> CallbackVarArgReadQuery<'data, MapIntermediate<T, F>, Q>
+    where
+        F: FnMut(T::Intermediate) -> O,
+    {
+        CallbackVarArgReadQuery {
+            callback: self.callback.map(|callback| MapIntermediate {
+                callback,
+                transform,
+            }),
+            base: self.base,
+        }
+    }
+
+    pub fn map_final<F, O>(
+        self,
+        transform: F,
+    ) -> CallbackVarArgReadQuery<'data, MapFinal<T, F>, Q>
+    where
+        F: FnMut(T::Final) -> O,
+    {
+        CallbackVarArgReadQuery {
+            callback: self.callback.map(|callback| MapFinal {
+                callback,
+                transform,
+            }),
+            base: self.base,
+        }
+    }
 }
 
 impl<'data, T, Q> ContextBound for CallbackVarArgReadQuery<'data, T, Q>
@@ -723,6 +953,43 @@ where
 pub struct CallbackVarArgReadBuilder<'data, T, B> {
     pub(crate) callback: T,
     pub(crate) base: VarRawReadBuilder<'data, B>,
+}
+
+impl<'data, T, B> CallbackVarArgReadBuilder<'data, T, B>
+where
+    T: ReadCallbackVarArg,
+{
+    pub fn map_intermediate<F, O>(
+        self,
+        transform: F,
+    ) -> CallbackVarArgReadBuilder<'data, MapIntermediate<T, F>, B>
+    where
+        F: FnMut(T::Intermediate) -> O,
+    {
+        CallbackVarArgReadBuilder {
+            callback: MapIntermediate {
+                callback: self.callback,
+                transform,
+            },
+            base: self.base,
+        }
+    }
+
+    pub fn map_final<F, O>(
+        self,
+        transform: F,
+    ) -> CallbackVarArgReadBuilder<'data, MapFinal<T, F>, B>
+    where
+        F: FnMut(T::Final) -> O,
+    {
+        CallbackVarArgReadBuilder {
+            callback: MapFinal {
+                callback: self.callback,
+                transform,
+            },
+            base: self.base,
+        }
+    }
 }
 
 impl<'data, T, B> ContextBound for CallbackVarArgReadBuilder<'data, T, B>

--- a/tiledb/api/src/query/read/mod.rs
+++ b/tiledb/api/src/query/read/mod.rs
@@ -443,16 +443,14 @@ impl<I, F> Iterator for ReadQueryIterator<I, F> {
     type Item = TileDBResult<ReadStepOutput<I, F>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(q) = self.query.as_mut() {
-            Some(q.step().map(|r| {
-                if r.is_final() {
-                    self.query = None;
+        self.query.take().map(|mut q| {
+            q.step().map(|r| {
+                if !r.is_final() {
+                    self.query = Some(q);
                 }
                 r
-            }))
-        } else {
-            None
-        }
+            })
+        })
     }
 }
 

--- a/tiledb/api/src/query/read/mod.rs
+++ b/tiledb/api/src/query/read/mod.rs
@@ -201,6 +201,17 @@ pub trait ReadQuery: Query {
             }
         })
     }
+
+    /// Convert this query into an iterator which yields an item
+    /// for each step of the query.
+    fn into_iter(self) -> ReadQueryIterator<Self::Intermediate, Self::Final>
+    where
+        Self: Sized + 'static,
+    {
+        ReadQueryIterator {
+            query: Some(Box::new(self)),
+        }
+    }
 }
 
 macro_rules! fn_register_callback {
@@ -423,3 +434,26 @@ impl QueryBuilder for ReadBuilder {
 }
 
 impl<'data> ReadQueryBuilder<'data> for ReadBuilder {}
+
+pub struct ReadQueryIterator<I, F> {
+    query: Option<Box<dyn ReadQuery<Intermediate = I, Final = F>>>,
+}
+
+impl<I, F> Iterator for ReadQueryIterator<I, F> {
+    type Item = TileDBResult<ReadStepOutput<I, F>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(q) = self.query.as_mut() {
+            Some(q.step().map(|r| {
+                if r.is_final() {
+                    self.query = None;
+                }
+                r
+            }))
+        } else {
+            None
+        }
+    }
+}
+
+impl<I, F> std::iter::FusedIterator for ReadQueryIterator<I, F> {}

--- a/tiledb/api/src/query/strategy.rs
+++ b/tiledb/api/src/query/strategy.rs
@@ -733,6 +733,7 @@ impl ReadCallbackVarArg for RawResultCallback {
 
 /// Query callback which accumulates results from each step into `Cells`
 /// and returns the `Cells` as the final result.
+#[derive(Default)]
 pub struct CellsConstructor {
     cells: Option<Cells>,
 }

--- a/tiledb/api/src/query/strategy.rs
+++ b/tiledb/api/src/query/strategy.rs
@@ -1558,9 +1558,7 @@ impl CellsStrategy {
                         .domain
                         .dimension
                         .iter()
-                        .map(|d| d.constraints.num_cells())
-                        .filter(|n| n.is_some())
-                        .map(|n| n.unwrap())
+                        .filter_map(|d| d.constraints.num_cells())
                         .min()?,
                 )
                 .ok();

--- a/tiledb/api/src/query/strategy.rs
+++ b/tiledb/api/src/query/strategy.rs
@@ -14,7 +14,7 @@ use proptest::test_runner::TestRunner;
 
 use crate::array::schema::FieldData as SchemaField;
 use crate::array::{ArrayType, CellValNum, SchemaData};
-use crate::datatype::physical::{BitsEq, BitsOrd};
+use crate::datatype::physical::{BitsEq, BitsOrd, IntegralType};
 use crate::datatype::LogicalType;
 use crate::query::read::output::{
     CellStructureSingleIterator, FixedDataIterator, RawReadOutput,
@@ -147,88 +147,91 @@ macro_rules! typed_field_data_go {
     ($field:expr, $data:pat, $then:expr) => {
         typed_field_data_go!($field, _DT, $data, $then, $then)
     };
-    ($field:expr, $DT:ident, $data:pat, $fixed:expr, $var:expr) => {{
+    ($field:expr, $DT:ident, $data:pat, $fixed:expr, $var:expr) => {
+        typed_field_data_go!($field, $DT, $data, $fixed, $var, $fixed, $var)
+    };
+    ($field:expr, $DT:ident, $data:pat, $integral_fixed:expr, $integral_var:expr, $float_fixed:expr, $float_var:expr) => {{
         use $crate::query::strategy::FieldData;
         match $field {
             FieldData::UInt8($data) => {
                 type $DT = u8;
-                $fixed
+                $integral_fixed
             }
             FieldData::UInt16($data) => {
                 type $DT = u16;
-                $fixed
+                $integral_fixed
             }
             FieldData::UInt32($data) => {
                 type $DT = u32;
-                $fixed
+                $integral_fixed
             }
             FieldData::UInt64($data) => {
                 type $DT = u64;
-                $fixed
+                $integral_fixed
             }
             FieldData::Int8($data) => {
                 type $DT = i8;
-                $fixed
+                $integral_fixed
             }
             FieldData::Int16($data) => {
                 type $DT = i16;
-                $fixed
+                $integral_fixed
             }
             FieldData::Int32($data) => {
                 type $DT = i32;
-                $fixed
+                $integral_fixed
             }
             FieldData::Int64($data) => {
                 type $DT = i64;
-                $fixed
+                $integral_fixed
             }
             FieldData::Float32($data) => {
                 type $DT = f32;
-                $fixed
+                $float_fixed
             }
             FieldData::Float64($data) => {
                 type $DT = f64;
-                $fixed
+                $float_fixed
             }
             FieldData::VecUInt8($data) => {
                 type $DT = u8;
-                $var
+                $integral_var
             }
             FieldData::VecUInt16($data) => {
                 type $DT = u16;
-                $var
+                $integral_var
             }
             FieldData::VecUInt32($data) => {
                 type $DT = u32;
-                $var
+                $integral_var
             }
             FieldData::VecUInt64($data) => {
                 type $DT = u64;
-                $var
+                $integral_var
             }
             FieldData::VecInt8($data) => {
                 type $DT = i8;
-                $var
+                $integral_var
             }
             FieldData::VecInt16($data) => {
                 type $DT = i16;
-                $var
+                $integral_var
             }
             FieldData::VecInt32($data) => {
                 type $DT = i32;
-                $var
+                $integral_var
             }
             FieldData::VecInt64($data) => {
                 type $DT = i64;
-                $var
+                $integral_var
             }
             FieldData::VecFloat32($data) => {
                 type $DT = f32;
-                $var
+                $float_var
             }
             FieldData::VecFloat64($data) => {
                 type $DT = f64;
-                $var
+                $float_var
             }
         }
     }};
@@ -456,20 +459,149 @@ field_value_strategy!(Float32 : f32, Float64 : f64);
 
 #[derive(Clone, Debug)]
 pub struct FieldDataParameters {
-    pub nrecords: Option<SizeRange>,
+    pub nrecords: SizeRange,
     pub datatype: Option<FieldStrategyDatatype>,
     pub value_min_var_size: usize,
     pub value_max_var_size: usize,
+    pub unique: bool,
+}
+
+impl FieldDataParameters {
+    pub fn require_unique_cells(&self) -> bool {
+        self.unique
+            || matches!(
+                self.datatype,
+                Some(FieldStrategyDatatype::SchemaField(
+                    SchemaField::Dimension(_)
+                ))
+            )
+    }
 }
 
 impl Default for FieldDataParameters {
     fn default() -> Self {
         FieldDataParameters {
-            nrecords: None,
+            nrecords: (0..=1024).into(),
             datatype: None,
             value_min_var_size: 0,
             value_max_var_size: 8, /* TODO */
+            unique: false,
         }
+    }
+}
+
+trait ArbitraryFieldData: Sized {
+    fn arbitrary(
+        params: FieldDataParameters,
+        cell_val_num: CellValNum,
+        value_strat: BoxedStrategy<Self>,
+    ) -> BoxedStrategy<FieldData>;
+}
+
+impl<DT> ArbitraryFieldData for DT
+where
+    DT: IntegralType,
+    FieldData: From<Vec<DT>> + From<Vec<Vec<DT>>>,
+{
+    fn arbitrary(
+        params: FieldDataParameters,
+        cell_val_num: CellValNum,
+        value_strat: BoxedStrategy<Self>,
+    ) -> BoxedStrategy<FieldData> {
+        if cell_val_num == 1u32 {
+            if params.require_unique_cells() {
+                proptest::collection::btree_set(value_strat, params.nrecords)
+                    .prop_flat_map(|cell_set| {
+                        Just(cell_set.into_iter().collect::<Vec<_>>())
+                            .prop_shuffle()
+                            .prop_map(FieldData::from)
+                    })
+                    .boxed()
+            } else {
+                proptest::collection::vec(value_strat, params.nrecords)
+                    .prop_map(FieldData::from)
+                    .boxed()
+            }
+        } else {
+            let (min, max) = if cell_val_num.is_var_sized() {
+                (params.value_min_var_size, params.value_max_var_size)
+            } else {
+                let fixed_bound = Into::<u32>::into(cell_val_num) as usize;
+                (fixed_bound, fixed_bound)
+            };
+
+            let cell_strat = proptest::collection::vec(value_strat, min..=max);
+
+            if params.require_unique_cells() {
+                proptest::collection::btree_set(cell_strat, params.nrecords)
+                    .prop_flat_map(|cell_set| {
+                        Just(cell_set.into_iter().collect::<Vec<_>>())
+                            .prop_shuffle()
+                            .prop_map(FieldData::from)
+                    })
+                    .boxed()
+            } else {
+                proptest::collection::vec(cell_strat, params.nrecords)
+                    .prop_map(FieldData::from)
+                    .boxed()
+            }
+        }
+    }
+}
+
+impl ArbitraryFieldData for f32 {
+    fn arbitrary(
+        params: FieldDataParameters,
+        cell_val_num: CellValNum,
+        value_strat: BoxedStrategy<Self>,
+    ) -> BoxedStrategy<FieldData> {
+        let value_strat = value_strat.prop_map(|float| float.to_bits()).boxed();
+
+        fn transform(v: Vec<u32>) -> Vec<f32> {
+            v.into_iter().map(f32::from_bits).collect::<Vec<f32>>()
+        }
+
+        <u32 as ArbitraryFieldData>::arbitrary(
+            params,
+            cell_val_num,
+            value_strat,
+        )
+        .prop_map(|field_data| match field_data {
+            FieldData::UInt32(values) => FieldData::Float32(transform(values)),
+            FieldData::VecUInt32(values) => FieldData::VecFloat32(
+                values.into_iter().map(transform).collect::<Vec<Vec<f32>>>(),
+            ),
+            _ => unreachable!(),
+        })
+        .boxed()
+    }
+}
+
+impl ArbitraryFieldData for f64 {
+    fn arbitrary(
+        params: FieldDataParameters,
+        cell_val_num: CellValNum,
+        value_strat: BoxedStrategy<Self>,
+    ) -> BoxedStrategy<FieldData> {
+        let value_strat = value_strat.prop_map(|float| float.to_bits()).boxed();
+
+        fn transform(v: Vec<u64>) -> Vec<f64> {
+            v.into_iter().map(f64::from_bits).collect::<Vec<f64>>()
+        }
+
+        <u64 as ArbitraryFieldData>::arbitrary(
+            params,
+            cell_val_num,
+            value_strat,
+        )
+        .prop_map(|field_data| match field_data {
+            FieldData::UInt64(values) => FieldData::Float64(transform(values)),
+            FieldData::VecUInt64(values) => FieldData::VecFloat64(
+                values.into_iter().map(transform).collect::<Vec<Vec<f64>>>(),
+            ),
+            _ => unreachable!(),
+        })
+        .boxed()
     }
 }
 
@@ -478,41 +610,6 @@ impl Arbitrary for FieldData {
     type Parameters = FieldDataParameters;
 
     fn arbitrary_with(params: Self::Parameters) -> Self::Strategy {
-        fn body<DT: Debug + 'static>(
-            params: FieldDataParameters,
-            value_strat: BoxedStrategy<DT>,
-            cell_val_num: CellValNum,
-        ) -> BoxedStrategy<FieldData>
-        where
-            FieldData: From<Vec<DT>> + From<Vec<Vec<DT>>>,
-        {
-            let nrecords = if let Some(nrecords) = params.nrecords {
-                nrecords
-            } else {
-                (0..=1024).into() /* TODO: configure */
-            };
-
-            if cell_val_num == 1u32 {
-                proptest::collection::vec(value_strat, nrecords)
-                    .prop_map(FieldData::from)
-                    .boxed()
-            } else {
-                let (min, max) = if cell_val_num.is_var_sized() {
-                    (params.value_min_var_size, params.value_max_var_size)
-                } else {
-                    let fixed_bound = Into::<u32>::into(cell_val_num) as usize;
-                    (fixed_bound, fixed_bound)
-                };
-
-                let cell_strat =
-                    proptest::collection::vec(value_strat, min..=max);
-
-                proptest::collection::vec(cell_strat, nrecords)
-                    .prop_map(FieldData::from)
-                    .boxed()
-            }
-        }
-
         match params.datatype.clone() {
             Some(FieldStrategyDatatype::SchemaField(
                 SchemaField::Dimension(d),
@@ -521,23 +618,41 @@ impl Arbitrary for FieldData {
                 let cell_val_num =
                     d.cell_val_num.unwrap_or(CellValNum::single());
 
+                /* if unique values are required then the request may not be satisfiable */
+                if params.require_unique_cells()
+                    && !matches!(d.cell_val_num, Some(CellValNum::Var))
+                {
+                    let CellValNum::Fixed(nz) =
+                        d.cell_val_num.unwrap_or(CellValNum::single())
+                    else {
+                        unreachable!()
+                    };
+
+                    if let Some(num_cells) = d.constraints.num_cells() {
+                        let num_cell_values = num_cells * nz.get() as u128;
+                        if num_cell_values < params.nrecords.start() as u128 {
+                            panic!("Uniqueness is not satisfiable for strategy parameters: nrecords = {:?}, num_cells = {:?}, dimension = {:?}", params.nrecords, num_cells, d);
+                        }
+                    }
+                }
+
                 dimension_constraints_go!(
                     d.constraints,
                     DT,
                     ref domain,
                     _,
                     {
-                        body::<DT>(
+                        <DT as ArbitraryFieldData>::arbitrary(
                             params,
-                            value_strat.try_into().unwrap(),
                             cell_val_num,
+                            value_strat.try_into().unwrap(),
                         )
                     },
                     {
-                        body::<u8>(
+                        <u8 as ArbitraryFieldData>::arbitrary(
                             params,
-                            value_strat.try_into().unwrap(),
                             cell_val_num,
+                            value_strat.try_into().unwrap(),
                         )
                     }
                 )
@@ -551,10 +666,10 @@ impl Arbitrary for FieldData {
 
                 fn_typed!(a.datatype, LT, {
                     type DT = <LT as LogicalType>::PhysicalType;
-                    body::<DT>(
+                    <DT as ArbitraryFieldData>::arbitrary(
                         params,
-                        value_strat.try_into().unwrap(),
                         cell_val_num,
+                        value_strat.try_into().unwrap(),
                     )
                 })
             }
@@ -562,7 +677,11 @@ impl Arbitrary for FieldData {
                 fn_typed!(datatype, LT, {
                     type DT = <LT as LogicalType>::PhysicalType;
                     let value_strat = any::<DT>().boxed();
-                    body::<DT>(params, value_strat, cell_val_num)
+                    <DT as ArbitraryFieldData>::arbitrary(
+                        params,
+                        cell_val_num,
+                        value_strat,
+                    )
                 })
             }
             None => (any::<Datatype>(), any::<CellValNum>())
@@ -570,7 +689,11 @@ impl Arbitrary for FieldData {
                     fn_typed!(datatype, LT, {
                         type DT = <LT as LogicalType>::PhysicalType;
                         let value_strat = any::<DT>().boxed();
-                        body::<DT>(params.clone(), value_strat, cell_val_num)
+                        <DT as ArbitraryFieldData>::arbitrary(
+                            params.clone(),
+                            cell_val_num,
+                            value_strat,
+                        )
                     })
                 })
                 .boxed(),
@@ -1276,7 +1399,7 @@ impl CellsStrategySchema {
                     .map(|(field, (mask, (datatype, cell_val_num)))| {
                         let field_data = if mask.is_included() {
                             let params = FieldDataParameters {
-                                nrecords: Some((nrecords..=nrecords).into()),
+                                nrecords: (nrecords..=nrecords).into(),
                                 datatype: Some(
                                     FieldStrategyDatatype::Datatype(
                                         *datatype,
@@ -1341,7 +1464,7 @@ impl CellsStrategySchema {
                         let field_name = field.name().to_string();
                         let field_data = if mask.is_included() {
                             let params = FieldDataParameters {
-                                nrecords: Some(nrecords.into()),
+                                nrecords: nrecords.into(),
                                 datatype: Some(
                                     FieldStrategyDatatype::SchemaField(field),
                                 ),
@@ -1450,6 +1573,63 @@ impl Arbitrary for Cells {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
+
+    fn do_field_data_unique(data: FieldData) {
+        typed_field_data_go!(
+            data,
+            _DT,
+            values,
+            {
+                let num_cells = values.len();
+                let num_unique_cells =
+                    values.clone().into_iter().collect::<HashSet<_>>().len();
+                assert_eq!(
+                    num_cells, num_unique_cells,
+                    "values = {:?}",
+                    values
+                );
+            },
+            {
+                let num_cells = values.len();
+                let num_unique_cells =
+                    values.clone().into_iter().collect::<HashSet<_>>().len();
+                assert_eq!(
+                    num_cells, num_unique_cells,
+                    "values = {:?}",
+                    values
+                );
+            },
+            {
+                let values =
+                    values.into_iter().map(|f| f.to_bits()).collect::<Vec<_>>();
+                let num_cells = values.len();
+                let num_unique_cells =
+                    values.clone().into_iter().collect::<HashSet<_>>().len();
+                assert_eq!(
+                    num_cells, num_unique_cells,
+                    "values.to_bits = {:?}",
+                    values
+                );
+            },
+            {
+                let values = values
+                    .into_iter()
+                    .map(|v| {
+                        v.into_iter().map(|f| f.to_bits()).collect::<Vec<_>>()
+                    })
+                    .collect::<Vec<Vec<_>>>();
+                let num_cells = values.len();
+                let num_unique_cells =
+                    values.clone().into_iter().collect::<HashSet<_>>().len();
+                assert_eq!(
+                    num_cells, num_unique_cells,
+                    "values.to_bits = {:?}",
+                    values
+                );
+            }
+        )
+    }
 
     fn do_field_data_extend(dst: FieldData, src: FieldData) {
         let orig_dst = dst.clone();
@@ -1682,6 +1862,12 @@ mod tests {
     }
 
     proptest! {
+        #[test]
+        fn field_data_unique(data in any_with::<FieldData>(FieldDataParameters { unique: true, ..Default::default() }))
+        {
+            do_field_data_unique(data)
+        }
+
         #[test]
         fn field_data_extend((dst, src) in (any::<Datatype>(), any::<CellValNum>()).prop_flat_map(|(dt, cvn)| {
             let params = FieldDataParameters {

--- a/tiledb/api/src/query/strategy.rs
+++ b/tiledb/api/src/query/strategy.rs
@@ -129,6 +129,9 @@ impl From<&TypedRawReadOutput<'_>> for FieldData {
 /// The first form of this macro applies the same expression to all variants.
 /// The second form enables applying a different expression to the forms
 /// with an interior `Vec<DT>` versus `Vec<Vec<DT>>`.
+/// The third form enables applying a different expression to the forms
+/// with an interior `Vec<DT>` versus `Vec<FT>` versus `Vec<Vec<DT>>` versus `Vec<Vec<FT>>`,
+/// where `DT` is an integral type and `FT` is a floating-point type.
 ///
 /// # Examples
 /// ```

--- a/tiledb/api/src/query/strategy.rs
+++ b/tiledb/api/src/query/strategy.rs
@@ -338,6 +338,10 @@ impl FieldData {
         typed_field_data_go!(self, v, v.len())
     }
 
+    pub fn is_cell_single(&self) -> bool {
+        typed_field_data_go!(self, _DT, _, true, false)
+    }
+
     pub fn slice(&self, start: usize, len: usize) -> FieldData {
         typed_field_data_go!(self, ref values, {
             FieldData::from(values[start..start + len].to_vec().clone())

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -413,6 +413,7 @@ impl Arbitrary for DenseWriteInput {
                     validity_filters: Some(Rc::new(
                         query_write_filter_requirements(),
                     )),
+                    ..Default::default()
                 };
                 any_with::<SchemaData>(Rc::new(schema_req))
                     .prop_map(Rc::new)
@@ -944,6 +945,7 @@ mod tests {
             attribute_filters: Some(Rc::new(query_write_filter_requirements())),
             offsets_filters: Some(Rc::new(query_write_filter_requirements())),
             validity_filters: Some(Rc::new(query_write_filter_requirements())),
+            ..Default::default()
         };
 
         let strategy = any_with::<SchemaData>(Rc::new(requirements))

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -944,7 +944,7 @@ mod tests {
 
                 let write_ranges = if let Some(ranges) = write.ranges() {
                     let generic_ranges = ranges
-                        .into_iter()
+                        .iter()
                         .cloned()
                         .map(|svr| vec![crate::range::Range::Single(svr)])
                         .collect::<Vec<Vec<crate::range::Range>>>();


### PR DESCRIPTION
This is the follow-up to #98 , extending the proptest to also work correctly for sparse writes.

Things this pull request had to deal with:
- filters on schema coordinates and dimensions because those can be Float types now
- generating unique values for dimensions when required

There are a few notable tools used to accomplish these goals.

As we've been building out the API we've had more and more reasons to separate handling of floating-point types from integral types for the various enums that can hold both. This pull request encounters yet another, and so we add the `crate::datatype::Integral` trait as a helper for writing generic code over u8, u16, u32, etc.

Another tool added here is an analog of `Iterator::map` for the query callback adapters. We add `map_intermediate`, `map_final`, and `map` functions for transforming the result of a callback into something else.