### PR TITLE
Fix FixedDataIterator and VarDataIterator soundness

### DIFF
--- a/tiledb/api/src/query/buffer/mod.rs
+++ b/tiledb/api/src/query/buffer/mod.rs
@@ -457,12 +457,13 @@ macro_rules! query_buffers_proof_impls {
         )+
     }
 }
+pub(crate) use query_buffers_proof_impls;
 
 /// A set of `QueryBuffers` which is known to have `cell_structure: CellStructure::Fixed(1)`.
 pub struct QueryBuffersCellStructureSingle<'data, C>(QueryBuffers<'data, C>);
 
 impl<'data, C> QueryBuffersCellStructureSingle<'data, C> {
-    fn accept(value: &QueryBuffers<'data, C>) -> bool {
+    pub fn accept(value: &QueryBuffers<'data, C>) -> bool {
         value.cell_structure.is_single()
     }
 }
@@ -472,7 +473,7 @@ impl<'data, C> QueryBuffersCellStructureSingle<'data, C> {
 pub struct QueryBuffersCellStructureFixed<'data, C>(QueryBuffers<'data, C>);
 
 impl<'data, C> QueryBuffersCellStructureFixed<'data, C> {
-    fn accept(value: &QueryBuffers<'data, C>) -> bool {
+    pub fn accept(value: &QueryBuffers<'data, C>) -> bool {
         matches!(&value.cell_structure, CellStructure::Fixed(ref nz) if nz.get() != 1)
     }
 }
@@ -481,7 +482,7 @@ impl<'data, C> QueryBuffersCellStructureFixed<'data, C> {
 pub struct QueryBuffersCellStructureVar<'data, C>(QueryBuffers<'data, C>);
 
 impl<'data, C> QueryBuffersCellStructureVar<'data, C> {
-    fn accept(value: &QueryBuffers<'data, C>) -> bool {
+    pub fn accept(value: &QueryBuffers<'data, C>) -> bool {
         value.cell_structure.is_var()
     }
 }

--- a/tiledb/api/src/query/buffer/mod.rs
+++ b/tiledb/api/src/query/buffer/mod.rs
@@ -418,41 +418,52 @@ impl<'data, T> QueryBuffersMut<'data, T> {
     }
 }
 
+/// Generates a set of `impl`s for a "query buffer proof", which we
+/// use to mean a type which wraps a `QueryBuffers` if the wrapped buffers
+/// satisfies some property. Code which accesses the wrapped buffers may
+/// safely assume the property is satisfied, which is useful for things
+/// like `unwrap` and `unsafe`.
+///
+/// Usage of this macro for a type requires a method `fn accept` which
+/// returns whether a `QueryBuffers` satisfies the property desired by the type.
+macro_rules! query_buffers_proof_impls {
+    ($($Q:ident),+) => {
+        $(
+            impl<'data, C> $Q<'data, C> {
+                pub fn into_inner(self) -> QueryBuffers<'data, C> {
+                    self.0
+                }
+            }
+
+            impl<'data, C> AsRef<QueryBuffers<'data, C>> for $Q<'data, C>
+            {
+                fn as_ref(&self) -> &QueryBuffers<'data, C> {
+                    &self.0
+                }
+            }
+
+            impl<'data, C> TryFrom<QueryBuffers<'data, C>> for $Q<'data, C>
+            {
+                type Error = QueryBuffers<'data, C>;
+
+                fn try_from(value: QueryBuffers<'data, C>) -> Result<Self, Self::Error> {
+                    if Self::accept(&value) {
+                        Ok(Self(value))
+                    } else {
+                        Err(value)
+                    }
+                }
+            }
+        )+
+    }
+}
+
 /// A set of `QueryBuffers` which is known to have `cell_structure: CellStructure::Fixed(1)`.
 pub struct QueryBuffersCellStructureSingle<'data, C>(QueryBuffers<'data, C>);
 
 impl<'data, C> QueryBuffersCellStructureSingle<'data, C> {
-    pub fn into_inner(self) -> QueryBuffers<'data, C> {
-        self.0
-    }
-}
-
-impl<'data, C> TryFrom<QueryBuffers<'data, C>>
-    for QueryBuffersCellStructureSingle<'data, C>
-{
-    type Error = QueryBuffers<'data, C>;
-    fn try_from(value: QueryBuffers<'data, C>) -> Result<Self, Self::Error> {
-        if value.cell_structure.is_single() {
-            Ok(Self(value))
-        } else {
-            Err(value)
-        }
-    }
-}
-
-impl<'data, C> AsRef<QueryBuffers<'data, C>>
-    for QueryBuffersCellStructureSingle<'data, C>
-{
-    fn as_ref(&self) -> &QueryBuffers<'data, C> {
-        &self.0
-    }
-}
-
-impl<'data, C> AsMut<QueryBuffers<'data, C>>
-    for QueryBuffersCellStructureSingle<'data, C>
-{
-    fn as_mut(&mut self) -> &mut QueryBuffers<'data, C> {
-        &mut self.0
+    fn accept(value: &QueryBuffers<'data, C>) -> bool {
+        value.cell_structure.is_single()
     }
 }
 
@@ -461,38 +472,8 @@ impl<'data, C> AsMut<QueryBuffers<'data, C>>
 pub struct QueryBuffersCellStructureFixed<'data, C>(QueryBuffers<'data, C>);
 
 impl<'data, C> QueryBuffersCellStructureFixed<'data, C> {
-    pub fn into_inner(self) -> QueryBuffers<'data, C> {
-        self.0
-    }
-}
-
-impl<'data, C> TryFrom<QueryBuffers<'data, C>>
-    for QueryBuffersCellStructureFixed<'data, C>
-{
-    type Error = QueryBuffers<'data, C>;
-    fn try_from(value: QueryBuffers<'data, C>) -> Result<Self, Self::Error> {
-        if matches!(&value.cell_structure, CellStructure::Fixed(ref nz) if nz.get() != 1)
-        {
-            Ok(Self(value))
-        } else {
-            Err(value)
-        }
-    }
-}
-
-impl<'data, C> AsRef<QueryBuffers<'data, C>>
-    for QueryBuffersCellStructureFixed<'data, C>
-{
-    fn as_ref(&self) -> &QueryBuffers<'data, C> {
-        &self.0
-    }
-}
-
-impl<'data, C> AsMut<QueryBuffers<'data, C>>
-    for QueryBuffersCellStructureFixed<'data, C>
-{
-    fn as_mut(&mut self) -> &mut QueryBuffers<'data, C> {
-        &mut self.0
+    fn accept(value: &QueryBuffers<'data, C>) -> bool {
+        matches!(&value.cell_structure, CellStructure::Fixed(ref nz) if nz.get() != 1)
     }
 }
 
@@ -500,39 +481,16 @@ impl<'data, C> AsMut<QueryBuffers<'data, C>>
 pub struct QueryBuffersCellStructureVar<'data, C>(QueryBuffers<'data, C>);
 
 impl<'data, C> QueryBuffersCellStructureVar<'data, C> {
-    pub fn into_inner(self) -> QueryBuffers<'data, C> {
-        self.0
+    fn accept(value: &QueryBuffers<'data, C>) -> bool {
+        value.cell_structure.is_var()
     }
 }
 
-impl<'data, C> TryFrom<QueryBuffers<'data, C>>
-    for QueryBuffersCellStructureVar<'data, C>
-{
-    type Error = QueryBuffers<'data, C>;
-    fn try_from(value: QueryBuffers<'data, C>) -> Result<Self, Self::Error> {
-        if value.cell_structure.is_var() {
-            Ok(Self(value))
-        } else {
-            Err(value)
-        }
-    }
-}
-
-impl<'data, C> AsRef<QueryBuffers<'data, C>>
-    for QueryBuffersCellStructureVar<'data, C>
-{
-    fn as_ref(&self) -> &QueryBuffers<'data, C> {
-        &self.0
-    }
-}
-
-impl<'data, C> AsMut<QueryBuffers<'data, C>>
-    for QueryBuffersCellStructureVar<'data, C>
-{
-    fn as_mut(&mut self) -> &mut QueryBuffers<'data, C> {
-        &mut self.0
-    }
-}
+query_buffers_proof_impls!(
+    QueryBuffersCellStructureSingle,
+    QueryBuffersCellStructureFixed,
+    QueryBuffersCellStructureVar
+);
 
 pub enum TypedQueryBuffers<'data> {
     UInt8(QueryBuffers<'data, u8>),

--- a/tiledb/api/src/query/read/output/mod.rs
+++ b/tiledb/api/src/query/read/output/mod.rs
@@ -658,6 +658,32 @@ impl<'data, C> TryFrom<RawReadOutput<'data, C>>
     }
 }
 
+/// A set of `QueryBuffers` which can be correctly used by `FixedDataIterator`.
+/// The `QueryBuffers` which is known to have `cell_structure: CellStructure::Fixed(nz)`
+/// for some `1 < nz < u32::MAX`, and also must not own any of the underlying buffers.
+pub struct QueryBuffersFixedDataIterable<'data, C>(QueryBuffers<'data, C>);
+
+impl<'data, C> QueryBuffersFixedDataIterable<'data, C> {
+    pub fn accept(value: &QueryBuffers<'data, C>) -> bool {
+        QueryBuffersCellStructureFixed::accept(value)
+            && !matches!(value.data, Buffer::Owned(_))
+    }
+}
+
+pub struct QueryBuffersVarDataIterable<'data, C>(QueryBuffers<'data, C>);
+
+impl<'data, C> QueryBuffersVarDataIterable<'data, C> {
+    fn accept(value: &QueryBuffers<'data, C>) -> bool {
+        QueryBuffersCellStructureVar::accept(value)
+            && !matches!(value.data, Buffer::Owned(_))
+    }
+}
+
+query_buffers_proof_impls!(
+    QueryBuffersFixedDataIterable,
+    QueryBuffersVarDataIterable
+);
+
 pub struct FixedDataIterator<'data, C> {
     ncells: usize,
     index: usize,
@@ -667,7 +693,7 @@ pub struct FixedDataIterator<'data, C> {
 impl<'data, C> FixedDataIterator<'data, C> {
     pub fn new(
         ncells: usize,
-        input: QueryBuffersCellStructureFixed<'data, C>,
+        input: QueryBuffersFixedDataIterable<'data, C>,
     ) -> Self {
         FixedDataIterator {
             ncells,
@@ -680,16 +706,22 @@ impl<'data, C> FixedDataIterator<'data, C> {
         ncells: usize,
         input: QueryBuffers<'data, C>,
     ) -> TileDBResult<Self> {
-        match QueryBuffersCellStructureFixed::try_from(input) {
+        match QueryBuffersFixedDataIterable::try_from(input) {
             Ok(qb) => Ok(Self::new(ncells, qb)),
-            Err(qb) => {
-                Err(Error::Datatype(
-                    DatatypeErrorKind::UnexpectedCellStructure {
-                        context: None,
-                        expected: CellValNum::single(), /* TODO: this is not really accurate, any Fixed */
-                        found: qb.cell_structure.as_cell_val_num(),
-                    },
-                ))
+            Err(input) => {
+                if matches!(input.data, Buffer::Owned(_)) {
+                    Err(Error::InvalidArgument(anyhow!(
+                            "FixedDataIterator cannot take ownership of data inside QueryBuffers")))
+                } else {
+                    assert!(!QueryBuffersCellStructureFixed::accept(&input));
+                    Err(Error::Datatype(
+                        DatatypeErrorKind::UnexpectedCellStructure {
+                            context: None,
+                            expected: CellValNum::single(), /* TODO: this is not really accurate, any Fixed */
+                            found: input.cell_structure.as_cell_val_num(),
+                        },
+                    ))
+                }
             }
         }
     }
@@ -742,7 +774,7 @@ pub struct VarDataIterator<'data, C> {
 impl<'data, C> VarDataIterator<'data, C> {
     pub fn new(
         ncells: usize,
-        location: QueryBuffersCellStructureVar<'data, C>,
+        location: QueryBuffersVarDataIterable<'data, C>,
     ) -> Self {
         VarDataIterator {
             ncells,
@@ -755,15 +787,23 @@ impl<'data, C> VarDataIterator<'data, C> {
         ncells: usize,
         location: QueryBuffers<'data, C>,
     ) -> TileDBResult<Self> {
-        match QueryBuffersCellStructureVar::try_from(location) {
+        match QueryBuffersVarDataIterable::try_from(location) {
             Ok(qb) => Ok(Self::new(ncells, qb)),
-            Err(qb) => Err(Error::Datatype(
-                DatatypeErrorKind::UnexpectedCellStructure {
-                    context: None,
-                    expected: CellValNum::Var,
-                    found: qb.cell_structure.as_cell_val_num(),
-                },
-            )),
+            Err(input) => {
+                if matches!(input.data, Buffer::Owned(_)) {
+                    Err(Error::InvalidArgument(anyhow!(
+                                "VarDataIterator cannot take ownership of data inside QueryBuffers")))
+                } else {
+                    assert!(!QueryBuffersCellStructureVar::accept(&input));
+                    Err(Error::Datatype(
+                        DatatypeErrorKind::UnexpectedCellStructure {
+                            context: None,
+                            expected: CellValNum::Var,
+                            found: input.cell_structure.as_cell_val_num(),
+                        },
+                    ))
+                }
+            }
         }
     }
 }
@@ -792,13 +832,16 @@ impl<'data, C> Iterator for VarDataIterator<'data, C> {
         let data_buffer: &'data [C] = unsafe {
             /*
              * If `self.location.data` is `Buffer::Owned`, then the underlying
-             * data will be dropped when `self` is.
-             * TODO: this actually is unsafe and `test_var_data_iterator_lifetime`
-             * demonstrates that.
+             * data will be dropped when `self` is. The 'data item could live
+             * longer, but would have been dropped. This is undefined behavior.
              *
              * If `self.location.data` is `Buffer::Borrowed`, then the underlying
              * data will be dropped when 'data expires, are returned items
-             * are guaranteed to live at least that long.  Hence this is safe.
+             * are guaranteed to live in the 'data lifetime. This is safe.
+             *
+             * The constructor requires `QueryBuffersVarDataIterable` which
+             * requires `Buffer::Borrowed` for each buffer.
+             * We will never see `Buffer::Owned` here, hence this is safe.
              */
             &*(self.location.data.as_ref() as *const [C]) as &'data [C]
         };
@@ -934,67 +977,49 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_fixed_data_iterator_lifetime() {
         let data = vec![0u8, 1, 2, 3, 4, 5, 6, 7];
 
         let mut databuf = Buffer::Borrowed(&data);
 
-        let item = {
-            let _ = std::mem::replace(
-                &mut databuf,
-                Buffer::Owned(vec![1u8; 16].into_boxed_slice()),
-            );
+        let _ = std::mem::replace(
+            &mut databuf,
+            Buffer::Owned(vec![1u8; 16].into_boxed_slice()),
+        );
 
-            FixedDataIterator::try_new(
-                2,
-                QueryBuffers {
-                    data: databuf,
-                    cell_structure: CellStructure::from(
-                        NonZeroU32::new(4).unwrap(),
-                    ),
-                    validity: None,
-                },
-            )
-            .unwrap()
-            .next()
-        }
-        .unwrap();
-
-        // this is a use after free which passes if you're lucky. valgrind catches it
-        // SC-46534
-        assert_eq!(item, vec![0, 1, 2, 3].as_slice());
+        let try_new = FixedDataIterator::try_new(
+            2,
+            QueryBuffers {
+                data: databuf,
+                cell_structure: CellStructure::from(
+                    NonZeroU32::new(4).unwrap(),
+                ),
+                validity: None,
+            },
+        );
+        assert!(matches!(try_new, Err(Error::InvalidArgument(_))));
     }
 
     #[test]
-    #[ignore]
     fn test_var_data_iterator_lifetime() {
         let data = vec![0u8; 16]; // not important
         let offsets = vec![0u64, 4, 8, 12, data.len() as u64];
 
         let mut databuf = Buffer::Borrowed(&data);
 
-        let item = {
-            let _ = std::mem::replace(
-                &mut databuf,
-                Buffer::Owned(vec![1u8; 16].into_boxed_slice()),
-            );
+        let _ = std::mem::replace(
+            &mut databuf,
+            Buffer::Owned(vec![1u8; 16].into_boxed_slice()),
+        );
 
-            VarDataIterator::try_new(
-                offsets.len(),
-                QueryBuffers {
-                    data: databuf,
-                    cell_structure: CellStructure::Var(offsets.into()),
-                    validity: None,
-                },
-            )
-            .unwrap()
-            .next()
-        }
-        .unwrap();
-
-        // this is a use after free which passes if you're lucky. valgrind catches it
-        // SC-46534
-        assert_eq!(item, vec![1u8; 4]);
+        let try_new = VarDataIterator::try_new(
+            offsets.len(),
+            QueryBuffers {
+                data: databuf,
+                cell_structure: CellStructure::Var(offsets.into()),
+                validity: None,
+            },
+        );
+        assert!(matches!(try_new, Err(Error::InvalidArgument(_))));
     }
 }

--- a/tiledb/api/src/query/read/output/mod.rs
+++ b/tiledb/api/src/query/read/output/mod.rs
@@ -659,8 +659,9 @@ impl<'data, C> TryFrom<RawReadOutput<'data, C>>
 }
 
 /// A set of `QueryBuffers` which can be correctly used by `FixedDataIterator`.
-/// The `QueryBuffers` which is known to have `cell_structure: CellStructure::Fixed(nz)`
-/// for some `1 < nz < u32::MAX`, and also must not own any of the underlying buffers.
+/// A `QueryBuffers` instance can be wrapped this way if it has
+/// `cell_structure: CellStructure::Fixed(nz)` for some `1 < nz < u32::MAX`,
+/// and also does not own the `data` buffer.
 pub struct QueryBuffersFixedDataIterable<'data, C>(QueryBuffers<'data, C>);
 
 impl<'data, C> QueryBuffersFixedDataIterable<'data, C> {
@@ -670,6 +671,10 @@ impl<'data, C> QueryBuffersFixedDataIterable<'data, C> {
     }
 }
 
+/// A set of `QueryBuffers` which can be correctly used by `VarDataIterator`.
+/// A `QueryBuffers` instance can be wrapped this way if it has
+/// `cell_structure: CellStructure::Var(_)`
+/// and also does not own the `data` buffer.
 pub struct QueryBuffersVarDataIterable<'data, C>(QueryBuffers<'data, C>);
 
 impl<'data, C> QueryBuffersVarDataIterable<'data, C> {


### PR DESCRIPTION
We have tests `test_fixed_data_iterator_lifetime` and `test_var_data_iterator_lifetime` which demonstrate unsoundness of an `unsafe` block inside `FixedDataIterator` and `VarDataIterator` respectively.  This unsoundness arises when there is a transfer of ownership of the values data into the iterator, potentially resulting in a situation where an item yielded lives longer than the iterator does.

This pull request fixes that unsoundness by adding a type-level proof that the data passed to the iterator is *borrowed*, not owned.  The user cannot construct an iterator which satisfies the conditions for unsoundness.