### PR TITLE
feat: [sc-48511] Fix sparse array write strategy "too many local rejects"

### DIFF
--- a/tiledb/api/src/datatype/physical.rs
+++ b/tiledb/api/src/datatype/physical.rs
@@ -104,6 +104,13 @@ where
     }
 }
 
+/// Trait for hashing based on value bits.
+/// This exists to work around float types, which do not implement `Hash`.
+/// That makes generic programming on all physical types more challenging.
+///
+/// Types implementing `BitsHash` can be hashed by an instance of `Hasher`
+/// using `BitsKeyAdapter` which adapts `Self::bits_hash` into an implementation
+/// of the `Hash` trait.
 pub trait BitsHash {
     fn bits_hash<H>(&self, state: &mut H)
     where

--- a/tiledb/api/src/datatype/physical.rs
+++ b/tiledb/api/src/datatype/physical.rs
@@ -1,4 +1,6 @@
+use std::cmp::Ordering;
 use std::fmt::Debug;
+use std::hash::{Hash, Hasher};
 
 use serde::{Deserialize, Serialize};
 
@@ -13,6 +15,10 @@ pub trait BitsEq {
     /// This is often the same as `PartialEq::eq`, but is not in the case
     /// of floats where `NaN != NaN`.
     fn bits_eq(&self, other: &Self) -> bool;
+
+    fn bits_ne(&self, other: &Self) -> bool {
+        !self.bits_eq(other)
+    }
 }
 
 impl<T> BitsEq for [T]
@@ -50,7 +56,7 @@ where
 pub trait BitsOrd {
     /// Return the ordering between `self` and `other`.
     /// This function defines a total order for all values of `Self`.
-    fn bits_cmp(&self, other: &Self) -> std::cmp::Ordering;
+    fn bits_cmp(&self, other: &Self) -> Ordering;
 
     /// Restrict a value to a certain interval, using `bits_cmp` as
     /// the ordering function. See `std::cmp::Ord::clamp`.
@@ -58,8 +64,6 @@ pub trait BitsOrd {
     where
         Self: Sized,
     {
-        use std::cmp::Ordering;
-
         assert_eq!(min.bits_cmp(&max), Ordering::Less);
 
         if matches!(self.bits_cmp(&min), Ordering::Less) {
@@ -77,9 +81,7 @@ impl<T> BitsOrd for [T]
 where
     T: BitsOrd,
 {
-    fn bits_cmp(&self, other: &Self) -> std::cmp::Ordering {
-        use std::cmp::Ordering;
-
+    fn bits_cmp(&self, other: &Self) -> Ordering {
         for (l, r) in self.iter().zip(other.iter()) {
             match l.bits_cmp(r) {
                 Ordering::Less => return Ordering::Less,
@@ -97,8 +99,39 @@ impl<T> BitsOrd for Vec<T>
 where
     T: BitsOrd,
 {
-    fn bits_cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn bits_cmp(&self, other: &Self) -> Ordering {
         self.as_slice().bits_cmp(other.as_slice())
+    }
+}
+
+pub trait BitsHash {
+    fn bits_hash<H>(&self, state: &mut H)
+    where
+        H: Hasher;
+}
+
+impl<T> BitsHash for &T
+where
+    T: BitsHash,
+{
+    fn bits_hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        (**self).bits_hash(state)
+    }
+}
+
+impl<T> BitsHash for Vec<T>
+where
+    T: BitsHash,
+{
+    fn bits_hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        let adapted = self.iter().map(BitsKeyAdapter).collect::<Vec<_>>();
+        adapted.hash(state)
     }
 }
 
@@ -109,6 +142,7 @@ where
 /// in Rust and TileDB.
 pub trait PhysicalType:
     BitsEq
+    + BitsHash
     + BitsOrd
     + Copy
     + Debug
@@ -138,8 +172,14 @@ macro_rules! integral_type_impls {
             }
 
             impl BitsOrd for $T {
-                fn bits_cmp(&self, other: &Self) -> std::cmp::Ordering {
+                fn bits_cmp(&self, other: &Self) -> Ordering {
                     <Self as Ord>::cmp(self, other)
+                }
+            }
+
+            impl BitsHash for $T {
+                fn bits_hash<H>(&self, state: &mut H) where H: Hasher {
+                    <Self as Hash>::hash(self, state)
                 }
             }
 
@@ -163,8 +203,17 @@ impl BitsEq for f32 {
 }
 
 impl BitsOrd for f32 {
-    fn bits_cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn bits_cmp(&self, other: &Self) -> Ordering {
         self.total_cmp(other)
+    }
+}
+
+impl BitsHash for f32 {
+    fn bits_hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.to_bits().bits_hash(state)
     }
 }
 
@@ -177,9 +226,62 @@ impl BitsEq for f64 {
 }
 
 impl BitsOrd for f64 {
-    fn bits_cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn bits_cmp(&self, other: &Self) -> Ordering {
         self.total_cmp(other)
     }
 }
 
+impl BitsHash for f64 {
+    fn bits_hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.to_bits().bits_hash(state)
+    }
+}
 impl PhysicalType for f64 {}
+
+/// Adapts a generic type to use as a key in `std` collections via
+/// the `BitsEq`, `BitsOrd`, or `BitsHash` traits.
+pub struct BitsKeyAdapter<T>(pub T);
+
+impl<T> PartialEq for BitsKeyAdapter<T>
+where
+    T: BitsEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.0.bits_eq(&other.0)
+    }
+}
+
+impl<T> Eq for BitsKeyAdapter<T> where T: BitsEq {}
+
+impl<T> Hash for BitsKeyAdapter<T>
+where
+    T: BitsHash,
+{
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.0.bits_hash(state)
+    }
+}
+
+impl<T> PartialOrd for BitsKeyAdapter<T>
+where
+    T: BitsEq + BitsOrd,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.0.bits_cmp(&other.0))
+    }
+}
+
+impl<T> Ord for BitsKeyAdapter<T>
+where
+    T: BitsEq + BitsOrd,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.bits_cmp(&other.0)
+    }
+}

--- a/tiledb/api/src/datatype/physical.rs
+++ b/tiledb/api/src/datatype/physical.rs
@@ -21,6 +21,15 @@ pub trait BitsEq {
     }
 }
 
+impl<T> BitsEq for &T
+where
+    T: BitsEq,
+{
+    fn bits_eq(&self, other: &Self) -> bool {
+        (**self).bits_eq(*other)
+    }
+}
+
 impl<T> BitsEq for [T]
 where
     T: BitsEq,
@@ -73,6 +82,15 @@ pub trait BitsOrd {
         } else {
             max
         }
+    }
+}
+
+impl<T> BitsOrd for &T
+where
+    T: BitsOrd,
+{
+    fn bits_cmp(&self, other: &Self) -> Ordering {
+        (**self).bits_cmp(*other)
     }
 }
 
@@ -280,7 +298,7 @@ where
     T: BitsEq + BitsOrd,
 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.0.bits_cmp(&other.0))
+        Some(Ord::cmp(self, other))
     }
 }
 

--- a/tiledb/api/src/query/strategy.rs
+++ b/tiledb/api/src/query/strategy.rs
@@ -994,7 +994,7 @@ impl Cells {
             return self.clone();
         }
 
-        let mut idx = (0..self.len()).into_iter().collect::<Vec<usize>>();
+        let mut idx = (0..self.len()).collect::<Vec<usize>>();
 
         let idx_comparator = self.index_comparator(keys);
         idx.sort_by(idx_comparator);
@@ -2036,16 +2036,16 @@ mod tests {
                                     let mut unique = HashMap::new();
 
                                     for r in 0..ki_cells.len() {
-                                        let values = match unique.entry(
-                                            BitsKeyAdapter(ki_cells[r].clone()),
-                                        ) {
+                                        let values = match unique
+                                            .entry(BitsKeyAdapter(&ki_cells[r]))
+                                        {
                                             Entry::Vacant(v) => {
                                                 v.insert(HashSet::new())
                                             }
                                             Entry::Occupied(o) => o.into_mut(),
                                         };
                                         values.insert(BitsKeyAdapter(
-                                            kj_cells[r].clone(),
+                                            &kj_cells[r],
                                         ));
                                     }
 

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -928,6 +928,11 @@ mod tests {
         let mut accumulated_domain: Option<Vec<Range>> = None;
         let mut accumulated_write: Option<Cells> = None;
 
+        let sort_keys = schema_spec
+            .fields()
+            .map(|f| f.name().to_owned())
+            .collect::<Vec<String>>();
+
         for write in write_sequence {
             /* write data and preserve ranges for sanity check */
             let write_ranges = {
@@ -983,8 +988,8 @@ mod tests {
 
                 /* `cells` should match the write */
                 {
-                    let write_sorted = write.cells().sorted();
-                    cells.sort();
+                    let write_sorted = write.cells().sorted(&sort_keys);
+                    cells.sort(&sort_keys);
                     assert_eq!(write_sorted, cells);
                 }
 

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -928,6 +928,10 @@ mod tests {
         let mut accumulated_domain: Option<Vec<Range>> = None;
         let mut accumulated_write: Option<Cells> = None;
 
+        /*
+         * Results do not come back in a defined order, so we must sort and
+         * compare. Writes currently have to write all fields.
+         */
         let sort_keys = match write_sequence {
             WriteSequence::Dense(_) => schema_spec
                 .attributes

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -928,10 +928,17 @@ mod tests {
         let mut accumulated_domain: Option<Vec<Range>> = None;
         let mut accumulated_write: Option<Cells> = None;
 
-        let sort_keys = schema_spec
-            .fields()
-            .map(|f| f.name().to_owned())
-            .collect::<Vec<String>>();
+        let sort_keys = match write_sequence {
+            WriteSequence::Dense(_) => schema_spec
+                .attributes
+                .iter()
+                .map(|f| f.name.clone())
+                .collect::<Vec<String>>(),
+            WriteSequence::Sparse(_) => schema_spec
+                .fields()
+                .map(|f| f.name().to_owned())
+                .collect::<Vec<String>>(),
+        };
 
         for write in write_sequence {
             /* write data and preserve ranges for sanity check */


### PR DESCRIPTION
Story details: https://app.shortcut.com/tiledb-inc/story/48511


> Generating a write input for a sparse array may require generating unique coordinates.
>
> The current strategy generates coordinates which are unique for each dimension individually. If a single dimension is constrained to the domain 0.. 10, for example, then the strategy cannot possibly produce more than 10 records of input, no matter how many other dimensions there are.
> 
> This means that the test generator will never cover the whole space of a sparse dimension.
> 
> The implementation of choosing the unique values within a dimension also is not very smart. It uses proptest::collection::btree_set, which generates a bunch of values and then throws the whole thing away to try again if it is below the requested number of records. The probability of rejection increases a lot as the dimension gets more and more constrained, and we have seen in the occasional run that proptest eventually gives up if it cannot satisfy the minimum number of records.
>
> For all of the above we must change our strategy to choose unique values across all dimensions instead.


This pull request fixes the issue by modifying the `Cells` strategy to first generate the maximum number of records for the dimensions, then deduplicate the coordinates.  Then we generate the rest of the attributes to write using the new number of records.