### PR TITLE
Improvements to proptest-strategies write sequence API to enable testing in tables repo

### DIFF
--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -733,7 +733,7 @@ impl WriteInput {
     /// Returns the subarray for this write operation,
     /// if it is a dense write. Returns `None` otherwise.
     pub fn subarray(&self) -> Option<NonEmptyDomain> {
-        if let Self::Dense(ref d) = self {
+        if let Self::Dense(_) = self {
             self.domain()
         } else {
             None
@@ -813,7 +813,7 @@ impl<'a> WriteInputRef<'a> {
     /// Returns the subarray for this write operation,
     /// if it is a dense write. Returns `None` otherwise.
     pub fn subarray(&self) -> Option<NonEmptyDomain> {
-        if let Self::Dense(ref d) = self {
+        if let Self::Dense(_) = self {
             self.domain()
         } else {
             None

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -23,10 +23,16 @@ use crate::{
 
 type BoxedValueTree<T> = Box<dyn ValueTree<Value = T>>;
 
+/// Returns a base set of requirements for filters to be used
+/// in write queries. Requirements are chosen to either avoid
+/// constraints on input (e.g. positive delta filtering requires
+/// sorted input, float scale filtering is not invertible)
+/// or to avoid issues in the tiledb core library in as
+/// many scenarios as possible.
 // now that we're actually writing data we will hit the fun bugs.
 // there are several in the filter pipeline, so we must heavily
 // restrict what is allowed until the bugs are fixed.
-fn query_write_filter_requirements() -> FilterRequirements {
+pub fn query_write_filter_requirements() -> FilterRequirements {
     FilterRequirements {
         allow_bit_reduction: false,     // SC-47560
         allow_positive_delta: false,    // nothing yet to ensure sort order
@@ -39,7 +45,10 @@ fn query_write_filter_requirements() -> FilterRequirements {
     }
 }
 
-fn query_write_schema_requirements(
+/// Returns a base set of schema requirements for running a query.
+/// Requirements are chosen to either avoid constraints on write input
+/// or to avoid issues in the tiledb core library in as many scenarios as possible.
+pub fn query_write_schema_requirements(
     array_type: Option<ArrayType>,
 ) -> crate::array::schema::strategy::Requirements {
     crate::array::schema::strategy::Requirements {
@@ -112,9 +121,9 @@ impl DenseWriteInput {
 
 #[derive(Clone, Debug, Default)]
 pub struct DenseWriteParameters {
-    schema: Option<Rc<SchemaData>>,
-    layout: Option<CellOrder>,
-    memory_limit: Option<usize>,
+    pub schema: Option<Rc<SchemaData>>,
+    pub layout: Option<CellOrder>,
+    pub memory_limit: Option<usize>,
 }
 
 pub struct DenseWriteValueTree {

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -1,5 +1,5 @@
 use std::fmt::{Debug, Formatter, Result as FmtResult};
-use std::ops::RangeInclusive;
+use std::ops::{Deref, RangeInclusive};
 use std::rc::Rc;
 
 use proptest::prelude::*;
@@ -597,9 +597,10 @@ pub struct DenseWriteSequence {
     writes: Vec<DenseWriteInput>,
 }
 
-impl DenseWriteSequence {
-    pub fn iter(&self) -> <&Self as IntoIterator>::IntoIter {
-        self.into_iter()
+impl Deref for DenseWriteSequence {
+    type Target = Vec<DenseWriteInput>;
+    fn deref(&self) -> &Self::Target {
+        &self.writes
     }
 }
 
@@ -645,23 +646,15 @@ impl IntoIterator for DenseWriteSequence {
     }
 }
 
-impl<'a> IntoIterator for &'a DenseWriteSequence {
-    type Item = &'a DenseWriteInput;
-    type IntoIter = <&'a Vec<DenseWriteInput> as IntoIterator>::IntoIter;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.writes.iter()
-    }
-}
-
 #[derive(Debug)]
 pub struct SparseWriteSequence {
     writes: Vec<SparseWriteInput>,
 }
 
-impl SparseWriteSequence {
-    pub fn iter(&self) -> <&Self as IntoIterator>::IntoIter {
-        self.into_iter()
+impl Deref for SparseWriteSequence {
+    type Target = Vec<SparseWriteInput>;
+    fn deref(&self) -> &Self::Target {
+        &self.writes
     }
 }
 
@@ -703,15 +696,6 @@ impl IntoIterator for SparseWriteSequence {
 
     fn into_iter(self) -> Self::IntoIter {
         self.writes.into_iter()
-    }
-}
-
-impl<'a> IntoIterator for &'a SparseWriteSequence {
-    type Item = &'a SparseWriteInput;
-    type IntoIter = <&'a Vec<SparseWriteInput> as IntoIterator>::IntoIter;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.writes.iter()
     }
 }
 
@@ -1070,8 +1054,8 @@ impl Iterator for WriteSequenceIter {
 }
 
 pub enum WriteSequenceRefIter<'a> {
-    Dense(<&'a DenseWriteSequence as IntoIterator>::IntoIter),
-    Sparse(<&'a SparseWriteSequence as IntoIterator>::IntoIter),
+    Dense(<&'a Vec<DenseWriteInput> as IntoIterator>::IntoIter),
+    Sparse(<&'a Vec<SparseWriteInput> as IntoIterator>::IntoIter),
 }
 
 impl<'a> Iterator for WriteSequenceRefIter<'a> {

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -650,7 +650,7 @@ impl<'a> IntoIterator for &'a DenseWriteSequence {
     type IntoIter = <&'a Vec<DenseWriteInput> as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
-        (&self.writes).into_iter()
+        self.writes.iter()
     }
 }
 
@@ -711,7 +711,7 @@ impl<'a> IntoIterator for &'a SparseWriteSequence {
     type IntoIter = <&'a Vec<SparseWriteInput> as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
-        (&self.writes).into_iter()
+        self.writes.iter()
     }
 }
 
@@ -805,8 +805,8 @@ impl<'a> WriteInputRef<'a> {
     /// Returns a reference to the cells of input of this write operation.
     pub fn cells(&self) -> &Cells {
         match self {
-            Self::Dense(ref dense) => &dense.data,
-            Self::Sparse(ref sparse) => &sparse.data,
+            Self::Dense(dense) => &dense.data,
+            Self::Sparse(sparse) => &sparse.data,
         }
     }
 
@@ -814,7 +814,7 @@ impl<'a> WriteInputRef<'a> {
     /// the coordinates of this write operation.
     pub fn domain(&self) -> Option<NonEmptyDomain> {
         match self {
-            Self::Dense(ref dense) => Some(
+            Self::Dense(dense) => Some(
                 dense
                     .subarray
                     .clone()
@@ -822,7 +822,7 @@ impl<'a> WriteInputRef<'a> {
                     .map(Range::from)
                     .collect::<NonEmptyDomain>(),
             ),
-            Self::Sparse(ref sparse) => sparse.domain(),
+            Self::Sparse(sparse) => sparse.domain(),
         }
     }
 
@@ -842,8 +842,8 @@ impl<'a> WriteInputRef<'a> {
         b: WriteBuilder<'data>,
     ) -> TileDBResult<WriteBuilder<'data>> {
         match self {
-            Self::Dense(ref d) => d.attach_write(b),
-            Self::Sparse(ref s) => s.attach_write(b),
+            Self::Dense(d) => d.attach_write(b),
+            Self::Sparse(s) => s.attach_write(b),
         }
     }
 
@@ -862,8 +862,8 @@ impl<'a> WriteInputRef<'a> {
         B: ReadQueryBuilder<'data>,
     {
         match self {
-            Self::Dense(ref d) => d.attach_read(b),
-            Self::Sparse(ref s) => s.attach_read(b),
+            Self::Dense(d) => d.attach_read(b),
+            Self::Sparse(s) => s.attach_read(b),
         }
     }
 }


### PR DESCRIPTION
This adds functionality and visibility needed to use the proptests inside of the tables repo.