### PR TITLE
Use 'sm.var_offsets.extra_element=true' for write queries

### DIFF
--- a/tiledb/api/src/query/write/input/mod.rs
+++ b/tiledb/api/src/query/write/input/mod.rs
@@ -98,6 +98,127 @@ where
     }
 }
 
+/// Used to convert data into a slice for use as query input.
+// Note that this is a *private* trait, not a public one!
+// That's because it's very hard to write a generic impl of
+// DataProvider for `[S] where S: AsSlice` and `Vec<S> where S: AsSlice`,
+// meaning there's not much use for this beyond consolidating
+// some common impl logic inside of private functions.
+// Maybe we could make an adapter type in the future.
+trait AsSlice {
+    type Item: PhysicalType;
+    fn values(&self) -> &[Self::Item];
+}
+
+impl<T> AsSlice for Vec<T>
+where
+    T: PhysicalType,
+{
+    type Item = T;
+    fn values(&self) -> &[Self::Item] {
+        self.as_slice()
+    }
+}
+
+impl<T> AsSlice for [T]
+where
+    T: PhysicalType,
+{
+    type Item = T;
+    fn values(&self) -> &[Self::Item] {
+        self
+    }
+}
+
+impl AsSlice for &str {
+    type Item = u8;
+    fn values(&self) -> &[Self::Item] {
+        self.as_bytes()
+    }
+}
+
+impl AsSlice for String {
+    type Item = u8;
+    fn values(&self) -> &[Self::Item] {
+        self.as_bytes()
+    }
+}
+
+/// Helper function to compute the cell structure
+/// of objects which resemble a nested slice
+fn cell_structure<S>(
+    cell_val_num: CellValNum,
+    items: &[S],
+) -> TileDBResult<CellStructure>
+where
+    S: AsSlice,
+{
+    match cell_val_num {
+        CellValNum::Fixed(nz) => {
+            let expect_len = nz.get() as usize;
+            for cell in items.iter() {
+                if cell.values().len() != expect_len {
+                    return Err(Error::Datatype(
+                        DatatypeErrorKind::UnexpectedCellStructure {
+                            context: None,
+                            expected: CellValNum::Fixed(nz),
+                            found: CellValNum::Var,
+                        },
+                    ));
+                }
+            }
+            Ok(CellStructure::Fixed(nz))
+        }
+        CellValNum::Var => {
+            let mut offset_accumulator = 0;
+            let offsets = std::iter::once(0u64)
+                .chain(items.iter().map(|s| {
+                    offset_accumulator += s.values().len();
+                    offset_accumulator as u64
+                }))
+                .collect::<Vec<u64>>()
+                .into_boxed_slice();
+            Ok(CellStructure::Var(offsets.into()))
+        }
+    }
+}
+
+/// Helper function to implement `DataProvider::query_buffers`
+/// for types which resemble a nested slice.
+// (Without negative trait bounds we can't provide separate DataProvider
+// impls for `Vec<C> where C: PhysicalType` and `Vec<S> where S: AsSlice`)
+fn query_buffers_impl<S>(
+    value: &[S],
+    cell_val_num: CellValNum,
+    is_nullable: bool,
+) -> TileDBResult<QueryBuffers<<S as AsSlice>::Item>>
+where
+    S: AsSlice,
+{
+    let cell_structure = cell_structure(cell_val_num, value)?;
+    let data_capacity = match cell_structure {
+        CellStructure::Fixed(nz) => value.len() * nz.get() as usize,
+        CellStructure::Var(ref offsets) => *offsets.last().unwrap() as usize,
+    };
+
+    let mut data = Vec::with_capacity(data_capacity);
+    value.iter().for_each(|s| {
+        data.extend(s.values());
+    });
+
+    let validity = if is_nullable {
+        Some(Buffer::Owned(vec![1u8; value.len()].into_boxed_slice()))
+    } else {
+        None
+    };
+
+    Ok(QueryBuffers {
+        data: Buffer::Owned(data.into_boxed_slice()),
+        cell_structure,
+        validity,
+    })
+}
+
 impl<C> DataProvider for Vec<C>
 where
     C: PhysicalType,
@@ -149,54 +270,7 @@ where
         cell_val_num: CellValNum,
         is_nullable: bool,
     ) -> TileDBResult<QueryBuffers<Self::Unit>> {
-        let mut offset_accumulator = 0;
-
-        let cell_structure = match cell_val_num {
-            CellValNum::Fixed(nz) => {
-                let expect_len = nz.get() as usize;
-                for cell in self.iter() {
-                    if cell.len() != expect_len {
-                        return Err(Error::Datatype(
-                            DatatypeErrorKind::UnexpectedCellStructure {
-                                context: None,
-                                expected: CellValNum::Fixed(nz),
-                                found: CellValNum::Var,
-                            },
-                        ));
-                    }
-                }
-                CellStructure::Fixed(nz)
-            }
-            CellValNum::Var => {
-                let offsets = self
-                    .iter()
-                    .map(|s| {
-                        let my_offset = offset_accumulator;
-                        offset_accumulator += s.len();
-                        my_offset as u64
-                    })
-                    .collect::<Vec<u64>>()
-                    .into_boxed_slice();
-                CellStructure::Var(offsets.into())
-            }
-        };
-
-        let mut data = Vec::with_capacity(offset_accumulator);
-        self.iter().for_each(|s| {
-            data.extend(s);
-        });
-
-        let validity = if is_nullable {
-            Some(Buffer::Owned(vec![1u8; self.len()].into_boxed_slice()))
-        } else {
-            None
-        };
-
-        Ok(QueryBuffers {
-            data: Buffer::Owned(data.into_boxed_slice()),
-            cell_structure,
-            validity,
-        })
+        query_buffers_impl(self, cell_val_num, is_nullable)
     }
 }
 
@@ -208,53 +282,7 @@ impl DataProvider for Vec<&str> {
         cell_val_num: CellValNum,
         is_nullable: bool,
     ) -> TileDBResult<QueryBuffers<Self::Unit>> {
-        let mut offset_accumulator = 0;
-
-        let cell_structure = match cell_val_num {
-            CellValNum::Fixed(nz) => {
-                let expect_len = nz.get() as usize;
-                for s in self.iter() {
-                    if s.len() != expect_len {
-                        return Err(Error::Datatype(
-                            DatatypeErrorKind::UnexpectedCellStructure {
-                                context: None,
-                                expected: CellValNum::Fixed(nz),
-                                found: CellValNum::Var,
-                            },
-                        ));
-                    }
-                }
-                CellStructure::Fixed(nz)
-            }
-            CellValNum::Var => {
-                let offsets = self
-                    .iter()
-                    .map(|s| {
-                        let my_offset = offset_accumulator;
-                        offset_accumulator += s.len();
-                        my_offset as u64
-                    })
-                    .collect::<Vec<u64>>();
-                CellStructure::Var(offsets.into())
-            }
-        };
-
-        let mut data = Vec::with_capacity(offset_accumulator);
-        self.iter().for_each(|s| {
-            data.extend(s.as_bytes());
-        });
-
-        let validity = if is_nullable {
-            Some(Buffer::Owned(vec![1u8; self.len()].into_boxed_slice()))
-        } else {
-            None
-        };
-
-        Ok(QueryBuffers {
-            data: Buffer::Owned(data.into_boxed_slice()),
-            cell_structure,
-            validity,
-        })
+        query_buffers_impl(self, cell_val_num, is_nullable)
     }
 }
 
@@ -266,52 +294,7 @@ impl DataProvider for Vec<String> {
         cell_val_num: CellValNum,
         is_nullable: bool,
     ) -> TileDBResult<QueryBuffers<Self::Unit>> {
-        let mut offset_accumulator = 0;
-        let cell_structure = match cell_val_num {
-            CellValNum::Fixed(nz) => {
-                let expect_len = nz.get() as usize;
-                for s in self.iter() {
-                    if s.len() != expect_len {
-                        return Err(Error::Datatype(
-                            DatatypeErrorKind::UnexpectedCellStructure {
-                                context: None,
-                                expected: CellValNum::Fixed(nz),
-                                found: CellValNum::Var,
-                            },
-                        ));
-                    }
-                }
-                CellStructure::Fixed(nz)
-            }
-            CellValNum::Var => {
-                let offsets = self
-                    .iter()
-                    .map(|s| {
-                        let my_offset = offset_accumulator;
-                        offset_accumulator += s.len();
-                        my_offset as u64
-                    })
-                    .collect::<Vec<u64>>();
-                CellStructure::Var(offsets.into())
-            }
-        };
-
-        let mut data = Vec::with_capacity(offset_accumulator);
-        self.iter().for_each(|s| {
-            data.extend(s.as_bytes());
-        });
-
-        let validity = if is_nullable {
-            Some(Buffer::Owned(vec![1u8; self.len()].into_boxed_slice()))
-        } else {
-            None
-        };
-
-        Ok(QueryBuffers {
-            data: Buffer::Owned(data.into_boxed_slice()),
-            cell_structure,
-            validity,
-        })
+        query_buffers_impl(self, cell_val_num, is_nullable)
     }
 }
 
@@ -330,23 +313,64 @@ mod tests {
     const MIN_RECORDS: usize = 0;
     const MAX_RECORDS: usize = 1024;
 
+    fn do_input_provider_u64(u64vec: Vec<u64>) {
+        let input = u64vec.query_buffers(CellValNum::single(), false).unwrap();
+        let (u64in, offsets) =
+            (input.data.as_ref(), input.cell_structure.offsets_ref());
+        assert!(offsets.is_none());
+
+        let u64out = if u64vec.is_empty() {
+            assert!(u64in.is_empty());
+            vec![]
+        } else {
+            unsafe {
+                std::slice::from_raw_parts(&u64in[0] as *const u64, u64in.len())
+            }
+            .to_vec()
+        };
+
+        assert_eq!(u64vec, u64out);
+    }
+
+    fn do_input_provider_as_slice<S>(slicevec: Vec<S>)
+    where
+        S: AsSlice,
+        Vec<S>: DataProvider<Unit = S::Item>,
+    {
+        let input = slicevec.query_buffers(CellValNum::Var, false).unwrap();
+        let values: &[S::Item] = input.data.as_ref();
+        let structure = input.cell_structure;
+
+        assert!(input.validity.is_none());
+
+        assert!(structure.is_var());
+        let offsets = structure.unwrap().unwrap().to_vec();
+
+        assert_eq!(slicevec.len() + 1, offsets.len());
+
+        let expected_total_values: usize =
+            slicevec.iter().map(|s| s.values().len()).sum();
+        assert_eq!(expected_total_values, values.len());
+
+        if slicevec.is_empty() {
+            assert!(values.is_empty());
+            assert_eq!(offsets, vec![0]);
+        } else {
+            assert_eq!(slicevec.len(), offsets.windows(2).count());
+
+            for (expected, offset) in slicevec.iter().zip(offsets.windows(2)) {
+                assert!(offset[1] >= offset[0]);
+
+                let s = &values[offset[0] as usize..offset[1] as usize];
+                assert_eq!(expected.values(), s);
+            }
+        }
+    }
+
     proptest! {
         #[test]
         fn input_provider_u64(u64vec in vec(any::<u64>(), MIN_RECORDS..=MAX_RECORDS)) {
-            let input = u64vec.query_buffers(CellValNum::try_from(1).unwrap(), false).unwrap();
-            let (u64in, offsets) = (input.data.as_ref(), input.cell_structure.offsets_ref());
-            assert!(offsets.is_none());
-
-            let u64out = if u64vec.is_empty() {
-                assert!(u64in.is_empty());
-                vec![]
-            } else {
-                unsafe {
-                    std::slice::from_raw_parts(&u64in[0] as *const u64, u64in.len())
-                }.to_vec()
-            };
-
-            assert_eq!(u64vec, u64out);
+            do_input_provider_u64(u64vec)
         }
 
         #[test]
@@ -355,38 +379,12 @@ mod tests {
                 (MIN_RECORDS..=MAX_RECORDS).into()
             )
         ) {
-            let input = stringvec.query_buffers(CellValNum::Var, false).unwrap();
-            let (bytes, structure) = (input.data.as_ref(), input.cell_structure);
-            assert!(structure.is_var());
-            let mut offsets = structure.unwrap().unwrap().to_vec();
+            do_input_provider_as_slice(stringvec)
+        }
 
-            assert_eq!(stringvec.len(), offsets.len());
-
-            let expected_total_bytes : usize = stringvec.iter().map(|s| s.len()).sum();
-            assert_eq!(expected_total_bytes, bytes.len());
-
-            if stringvec.is_empty() {
-                assert!(bytes.is_empty());
-            } else {
-                assert_eq!(stringvec.len(), offsets.windows(2).count() + 1);
-
-                offsets.push(bytes.len() as u64);
-
-                for (expected, offset) in stringvec.iter().zip(offsets.windows(2)) {
-                    assert!(offset[1] >= offset[0]);
-
-                    let slen = (offset[1] - offset[0]) as usize;
-                    let s = if slen == 0 {
-                        String::from("")
-                    } else {
-                        let slice = unsafe {
-                            std::slice::from_raw_parts(&bytes[offset[0] as usize] as *const u8, slen)
-                        };
-                        std::str::from_utf8(slice).unwrap().to_string()
-                    };
-                    assert_eq!(*expected, s);
-                }
-            }
+        #[test]
+        fn input_provider_u64_vec(u64vecvec in vec(vec(any::<u64>(), MIN_RECORDS..=MAX_RECORDS), MIN_RECORDS..=MAX_RECORDS)) {
+            do_input_provider_as_slice(u64vecvec)
         }
     }
 }

--- a/tiledb/api/src/query/write/mod.rs
+++ b/tiledb/api/src/query/write/mod.rs
@@ -85,6 +85,7 @@ impl<'data> WriteBuilder<'data> {
             let mut config = Config::new()?;
             config.set("sm.var_offsets.bitsize", "64")?;
             config.set("sm.var_offsets.mode", "elements")?;
+            config.set("sm.var_offsets.extra_element", "true")?;
 
             /*
              * TODO: make sure that users can't override this somehow,


### PR DESCRIPTION
`tiledb-rs` queries use extra offsets for read mode, but not write mode.  This creates some confusion when interacting with raw buffers - a buffer cannot be passed from read query to write query, it has to be adjusted.  It also creates some difficulty with testing and conversion to arrow.

This pull request synchronizes read and write queries in their usage of the extra offset, which simplifies a lot of the testing code and will further pay off in upstream crates and repositories.