### PR TITLE
Alternative strategy for a vector of records

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,6 +1321,7 @@ name = "tiledb-test-utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "proptest",
  "tempfile",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ version = "0.1.0"
 
 [workspace.dependencies]
 anyhow = "1.0"
+proptest = { version = "1.0.0" }
+proptest-derive = { version = "0.4.0" }
 serde_json = { version = "1.0.114", features = ["float_roundtrip"] }
 tiledb = { path = "tiledb/api", version = "0.1.0" }
 tiledb-proc-macro = { path = "tiledb/proc-macro", version = "0.1.0" }

--- a/tiledb/api/Cargo.toml
+++ b/tiledb/api/Cargo.toml
@@ -13,8 +13,8 @@ arrow = { version = "51.0.0", features = ["prettyprint"], optional = true }
 itertools = "0"
 num-traits = { version = "0.2", optional = true }
 paste = "1.0"
-proptest = { version = "1.0.0", optional = true }
-proptest-derive = { version = "0.4.0", optional = true }
+proptest = { workspace = true, optional = true }
+proptest-derive = { workspace = true, optional = true }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = "1.0.58"
@@ -24,8 +24,8 @@ tiledb-utils = { workspace = true, features = ["serde_json"] }
 
 [dev-dependencies]
 num-traits = { version = "0.2" }
-proptest = { version = "1.0.0" }
-proptest-derive = { version = "0.4.0" }
+proptest = { workspace = true }
+proptest-derive = { workspace = true }
 tiledb-test-utils = { workspace = true }
 
 [build-dependencies]

--- a/tiledb/api/Cargo.toml
+++ b/tiledb/api/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = { workspace = true }
 thiserror = "1.0.58"
 tiledb-proc-macro = { workspace = true }
 tiledb-sys = { workspace = true }
+tiledb-test-utils = { workspace = true, optional = true }
 tiledb-utils = { workspace = true, features = ["serde_json"] }
 
 [dev-dependencies]
@@ -33,5 +34,5 @@ pkg-config = { workspace = true }
 
 [features]
 default = []
-proptest-strategies = ["dep:num-traits", "dep:proptest", "dep:proptest-derive"]
+proptest-strategies = ["dep:num-traits", "dep:proptest", "dep:proptest-derive", "dep:tiledb-test-utils"]
 arrow = ["dep:arrow"]

--- a/tiledb/test-utils/Cargo.toml
+++ b/tiledb/test-utils/Cargo.toml
@@ -6,4 +6,5 @@ version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+proptest = { workspace = true }
 tempfile = "3"

--- a/tiledb/test-utils/src/lib.rs
+++ b/tiledb/test-utils/src/lib.rs
@@ -1,3 +1,6 @@
+extern crate proptest;
+
+pub mod strategy;
 pub mod uri_generators;
 
 pub use uri_generators::{get_uri_generator, TestArrayUri};

--- a/tiledb/test-utils/src/strategy/mod.rs
+++ b/tiledb/test-utils/src/strategy/mod.rs
@@ -1,0 +1,1 @@
+pub mod records;

--- a/tiledb/test-utils/src/strategy/records.rs
+++ b/tiledb/test-utils/src/strategy/records.rs
@@ -1,0 +1,354 @@
+use std::cmp::Ordering;
+use std::collections::{BTreeSet, HashMap};
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use proptest::bits::{BitSetLike, VarBitSet};
+use proptest::collection::SizeRange;
+use proptest::num::sample_uniform_incl;
+use proptest::prelude::*;
+use proptest::strategy::{NewTree, ValueTree};
+use proptest::test_runner::TestRunner;
+
+pub fn vec_records_strategy<T>(
+    element: T,
+    size: impl Into<SizeRange>,
+) -> VecRecordsStrategy<T>
+where
+    T: Strategy,
+{
+    VecRecordsStrategy {
+        element,
+        size: size.into(),
+    }
+}
+
+pub trait Records: Clone + Debug {
+    fn len(&self) -> usize;
+    fn filter(&self, subset: &VarBitSet) -> Self;
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<T> Records for Vec<T>
+where
+    T: Clone + Debug,
+{
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn filter(&self, subset: &VarBitSet) -> Self {
+        self.iter()
+            .enumerate()
+            .filter(|&(ix, _)| subset.test(ix))
+            .map(|v| v.1.clone())
+            .collect::<Self>()
+    }
+}
+
+impl<K, V> Records for HashMap<K, V>
+where
+    K: Clone + Debug + Eq + Hash,
+    V: Records,
+{
+    fn len(&self) -> usize {
+        let mut nrecords = None;
+        for f in self.values() {
+            if let Some(nrecords) = nrecords {
+                assert_eq!(nrecords, f.len())
+            } else {
+                nrecords = Some(f.len())
+            }
+        }
+        nrecords.unwrap()
+    }
+
+    fn filter(&self, subset: &VarBitSet) -> Self {
+        self.iter()
+            .map(|(k, v)| (k.clone(), v.filter(subset)))
+            .collect::<Self>()
+    }
+}
+
+#[derive(Debug)]
+pub struct VecRecordsStrategy<T> {
+    element: T,
+    size: SizeRange,
+}
+
+impl<T> Strategy for VecRecordsStrategy<T>
+where
+    T: Strategy,
+    T::Value: Clone + Debug,
+{
+    type Value = <<Self as Strategy>::Tree as ValueTree>::Value;
+    type Tree = RecordsValueTree<Vec<T::Value>>;
+
+    fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
+        let (min_size, max_size) = self.size.start_end_incl();
+        let init_size = sample_uniform_incl(runner, min_size, max_size);
+        let mut elements = Vec::with_capacity(init_size);
+        while elements.len() < init_size {
+            elements.push(self.element.new_tree(runner)?.current());
+        }
+
+        Ok(RecordsValueTree::new(min_size, elements))
+    }
+}
+
+pub struct RecordsValueTree<R> {
+    min_records: usize,
+    init: R,
+    last_records_included: Option<Vec<usize>>,
+    records_included: Vec<usize>,
+    explore_results: Box<[Option<bool>]>,
+    search: Option<ShrinkStep>,
+}
+
+impl<R> RecordsValueTree<R>
+where
+    R: Records,
+{
+    const CONTAINER_VALUE_TREE_DEFAULT_EXPLORE_CHUNKS: usize = 8;
+
+    pub fn new(min_records: usize, init: R) -> Self {
+        let nchunks = std::cmp::min(
+            init.len(),
+            Self::CONTAINER_VALUE_TREE_DEFAULT_EXPLORE_CHUNKS,
+        );
+        let records_included = (0..init.len()).collect::<Vec<usize>>();
+
+        RecordsValueTree {
+            min_records,
+            init,
+            last_records_included: None,
+            records_included,
+            explore_results: vec![None; nchunks].into_boxed_slice(),
+            search: None,
+        }
+    }
+
+    fn record_mask(&self) -> VarBitSet {
+        match self.search {
+            None => VarBitSet::saturated(self.init.len()),
+            Some(ShrinkStep::Explore(c)) => {
+                let nchunks = self
+                    .records_included
+                    .len()
+                    .clamp(1, self.explore_results.len());
+
+                let approx_chunk_len = self.records_included.len() / nchunks;
+
+                if approx_chunk_len == 0 {
+                    /* no records are included, we have shrunk down to empty */
+                    VarBitSet::new_bitset(self.init.len())
+                } else {
+                    let mut record_mask =
+                        VarBitSet::new_bitset(self.init.len());
+
+                    let exclude_min = c * approx_chunk_len;
+                    let exclude_max = if c + 1 == nchunks {
+                        self.records_included.len()
+                    } else {
+                        (c + 1) * approx_chunk_len
+                    };
+
+                    for r in self.records_included[0..exclude_min]
+                        .iter()
+                        .chain(self.records_included[exclude_max..].iter())
+                    {
+                        record_mask.set(*r)
+                    }
+
+                    record_mask
+                }
+            }
+            Some(ShrinkStep::Recur) | Some(ShrinkStep::Done) => {
+                let mut record_mask = VarBitSet::new_bitset(self.init.len());
+                for r in self.records_included.iter() {
+                    record_mask.set(*r);
+                }
+                record_mask
+            }
+        }
+    }
+
+    fn explore_step(&mut self, failed: bool) -> bool {
+        match self.search {
+            None => {
+                if failed {
+                    /* failed on the initial input */
+                    if self.init.is_empty() {
+                        /* no way to shrink */
+                        false
+                    } else {
+                        /* begin search */
+                        self.search = Some(ShrinkStep::Explore(0));
+                        true
+                    }
+                } else {
+                    /* passed on the initial input, nothing to do */
+                    false
+                }
+            }
+            Some(ShrinkStep::Explore(c)) => {
+                let nchunks = std::cmp::min(
+                    self.records_included.len(),
+                    self.explore_results.len(),
+                );
+
+                self.explore_results[c] = Some(failed);
+
+                match (c + 1).cmp(&nchunks) {
+                    Ordering::Less => {
+                        /* advance to the next */
+                        self.search = Some(ShrinkStep::Explore(c + 1));
+                        true
+                    }
+                    Ordering::Greater => {
+                        assert_eq!(nchunks, 0);
+                        false
+                    }
+                    Ordering::Equal => {
+                        /* finished exploring at this level, either recur or finish */
+                        self.explore_level_finished()
+                    }
+                }
+            }
+            Some(ShrinkStep::Recur) => {
+                if failed {
+                    self.search = Some(ShrinkStep::Explore(0));
+                } else {
+                    /*
+                     * This means that removing more than one chunk causes the
+                     * test to no longer fail.
+                     * Try again with a larger chunk size if possible
+                     */
+                    if self.explore_results.len() == 1 {
+                        unreachable!()
+                    }
+                    let Some(last_records_included) =
+                        self.last_records_included.take()
+                    else {
+                        unreachable!()
+                    };
+                    self.last_records_included = None;
+                    self.records_included = last_records_included;
+                    self.explore_results =
+                        vec![None; self.explore_results.len() / 2]
+                            .into_boxed_slice();
+                }
+                self.search = Some(ShrinkStep::Explore(0));
+                true
+            }
+            Some(ShrinkStep::Done) => false,
+        }
+    }
+
+    fn explore_level_finished(&mut self) -> bool {
+        let nchunks = self.explore_results.len();
+        let approx_chunk_len = self.records_included.len() / nchunks;
+
+        let new_records_included = {
+            let mut new_records_included = vec![];
+            for i in 0..nchunks {
+                let chunk_min = i * approx_chunk_len;
+                let chunk_max = if i + 1 == nchunks {
+                    self.records_included.len()
+                } else {
+                    (i + 1) * approx_chunk_len
+                };
+
+                if !self.explore_results[i].take().unwrap() {
+                    /* the test passed when chunk `i` was not included; keep it */
+                    new_records_included.extend_from_slice(
+                        &self.records_included[chunk_min..chunk_max],
+                    );
+                }
+            }
+
+            if new_records_included.len() < self.min_records {
+                /* buffer with some extras because the strategy requires it */
+                let mut rec = new_records_included
+                    .into_iter()
+                    .collect::<BTreeSet<usize>>();
+                let mut i = 0;
+                while rec.len() < self.min_records {
+                    rec.insert(i);
+                    i += 1;
+                }
+                new_records_included = rec.into_iter().collect::<Vec<usize>>();
+            }
+
+            new_records_included
+        };
+
+        if new_records_included == self.records_included {
+            /* everything was needed to pass */
+            self.search = Some(ShrinkStep::Done);
+        } else {
+            self.last_records_included = Some(std::mem::replace(
+                &mut self.records_included,
+                new_records_included,
+            ));
+            self.search = Some(ShrinkStep::Recur);
+        }
+        /* run another round on the updated input */
+        true
+    }
+}
+
+impl<R> ValueTree for RecordsValueTree<R>
+where
+    R: Records,
+{
+    type Value = R;
+
+    fn current(&self) -> Self::Value {
+        let record_mask = self.record_mask();
+        self.init.filter(&record_mask)
+    }
+
+    fn simplify(&mut self) -> bool {
+        self.explore_step(true)
+    }
+
+    fn complicate(&mut self) -> bool {
+        self.explore_step(false)
+    }
+}
+
+/// Tracks the last step taken for the container shrinking.
+enum ShrinkStep {
+    Explore(usize),
+    Recur,
+    Done,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shrink_convergence_u64() {
+        let strat = vec_records_strategy(any::<u64>(), 0..=1024);
+
+        let mut runner = TestRunner::new(Default::default());
+
+        for _ in 0..runner.config().cases {
+            let mut tree = strat.new_tree(&mut runner).unwrap();
+
+            while tree.simplify() {}
+
+            let convergence = tree.current();
+            assert!(
+                convergence.is_empty(),
+                "Value tree converged to: {:?}",
+                convergence
+            );
+        }
+    }
+}


### PR DESCRIPTION
The strategy produced by `proptest::collection::vec` shrinks very slowly, lopping records off from the end one at a time.  It also stores a value tree for each element of the `Vec`, and shrinks those when the minimum set of elements has been determined.

This strategy is easy to use but is not really right for some of our use cases.  For example, if we want to write a large number of records into tiledb and the test fails, then shrinking the input data one record at a time is hardly sensible.  And shrinking the individual elements, while not worthless, is also not worth the state overhead.

This pull request takes the strategy already written to reason about sparse write inputs, and generalizes it to a new `Records` trait.

A simple experiment shows that on large inputs, this new strategy shrinks down to nothing significantly faster (~2 minutes vs. ~14 minutes in one experiment in a debug build, which while unreliable for a performance comparison is nonetheless the manner in which we run most of our testing).