### PR TITLE
Various metadata API changes and improvements in support of SC-48994

### DIFF
--- a/tiledb/api/src/array/attribute/mod.rs
+++ b/tiledb/api/src/array/attribute/mod.rs
@@ -703,7 +703,7 @@ impl Factory for AttributeData {
             }
         }
         if let Some(ref fill) = self.fill {
-            b = crate::metadata::value_typed!(fill.data, _DT, value, {
+            b = crate::metadata::value_go!(fill.data, _DT, ref value, {
                 if let Some(fill_nullability) = fill.nullability {
                     b.fill_value_nullability(value.as_slice(), fill_nullability)
                 } else {

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -306,13 +306,16 @@ impl Array {
         Ok(num)
     }
 
-    pub fn metadata(&self, key: LookupKey) -> TileDBResult<Metadata> {
+    pub fn metadata<K: Into<LookupKey>>(
+        &self,
+        key: K,
+    ) -> TileDBResult<Metadata> {
         let c_array = *self.raw;
         let mut vec_size: u32 = out_ptr!();
         let mut c_datatype: ffi::tiledb_datatype_t = out_ptr!();
         let mut vec_ptr: *const std::ffi::c_void = out_ptr!();
 
-        let name: String = match key {
+        let name: String = match key.into() {
             LookupKey::Index(index) => {
                 let mut key_ptr: *const std::ffi::c_char = out_ptr!();
                 let mut key_len: u32 = out_ptr!();

--- a/tiledb/api/src/datatype/mod.rs
+++ b/tiledb/api/src/datatype/mod.rs
@@ -385,11 +385,13 @@ impl Datatype {
     }
 
     pub fn same_physical_type(&self, other: &Datatype) -> bool {
-        crate::fn_typed!(self, MLT, {
-            type MPT = <MLT as LogicalType>::PhysicalType;
-            crate::fn_typed!(other, TLT, {
-                type TPT = <TLT as LogicalType>::PhysicalType;
-                std::any::TypeId::of::<MPT>() == std::any::TypeId::of::<TPT>()
+        crate::fn_typed!(self, MyLogicalType, {
+            type MyPhysicalType = <MyLogicalType as LogicalType>::PhysicalType;
+            crate::fn_typed!(other, TheirLogicalType, {
+                type TheirPhysicalType =
+                    <TheirLogicalType as LogicalType>::PhysicalType;
+                std::any::TypeId::of::<MyPhysicalType>()
+                    == std::any::TypeId::of::<TheirPhysicalType>()
             })
         })
     }

--- a/tiledb/api/src/datatype/mod.rs
+++ b/tiledb/api/src/datatype/mod.rs
@@ -384,6 +384,16 @@ impl Datatype {
                 || self.is_time_type())
     }
 
+    pub fn same_physical_type(&self, other: &Datatype) -> bool {
+        crate::fn_typed!(self, MLT, {
+            type MPT = <MLT as LogicalType>::PhysicalType;
+            crate::fn_typed!(other, TLT, {
+                type TPT = <TLT as LogicalType>::PhysicalType;
+                std::any::TypeId::of::<MPT>() == std::any::TypeId::of::<TPT>()
+            })
+        })
+    }
+
     #[cfg(test)]
     pub fn iter() -> Iter<'static, Datatype> {
         static DATATYPES: [Datatype; 43] = [

--- a/tiledb/api/src/datatype/strategy.rs
+++ b/tiledb/api/src/datatype/strategy.rs
@@ -190,6 +190,7 @@ pub enum DatatypeContext {
     DenseDimension,
     SparseDimension,
     DeltaFilterReinterpretDatatype,
+    Fixed(Datatype),
 }
 
 impl Arbitrary for Datatype {
@@ -208,6 +209,7 @@ impl Arbitrary for Datatype {
             DatatypeContext::DeltaFilterReinterpretDatatype => {
                 prop_datatype_for_delta_filter().boxed()
             }
+            DatatypeContext::Fixed(dt) => Just(dt).boxed(),
         }
     }
 }

--- a/tiledb/api/src/datatype/strategy.rs
+++ b/tiledb/api/src/datatype/strategy.rs
@@ -187,6 +187,7 @@ fn prop_datatype_for_delta_filter() -> impl Strategy<Value = Datatype> {
 pub enum DatatypeContext {
     #[default]
     Any,
+    NotAny,
     DenseDimension,
     SparseDimension,
     DeltaFilterReinterpretDatatype,
@@ -200,6 +201,9 @@ impl Arbitrary for Datatype {
     fn arbitrary_with(p: Self::Parameters) -> Self::Strategy {
         match p {
             DatatypeContext::Any => prop_datatype().boxed(),
+            DatatypeContext::NotAny => prop_datatype()
+                .prop_filter("Datatype::Any", |dt| *dt != Datatype::Any)
+                .boxed(),
             DatatypeContext::DenseDimension => {
                 prop_datatype_for_dense_dimension().boxed()
             }

--- a/tiledb/api/src/group/mod.rs
+++ b/tiledb/api/src/group/mod.rs
@@ -364,13 +364,16 @@ impl Group {
         Ok(num)
     }
 
-    pub fn metadata(&self, key: LookupKey) -> TileDBResult<Metadata> {
+    pub fn metadata<K: Into<LookupKey>>(
+        &self,
+        key: K,
+    ) -> TileDBResult<Metadata> {
         let c_group = self.capi();
         let mut vec_size: u32 = out_ptr!();
         let mut c_datatype: ffi::tiledb_datatype_t = out_ptr!();
         let mut vec_ptr: *const std::ffi::c_void = out_ptr!();
 
-        let name: String = match key {
+        let name: String = match key.into() {
             LookupKey::Index(index) => {
                 let mut key_ptr: *const std::ffi::c_char = out_ptr!();
                 let mut key_len: u32 = out_ptr!();

--- a/tiledb/api/src/metadata.rs
+++ b/tiledb/api/src/metadata.rs
@@ -181,7 +181,7 @@ value_impl!(u64, Value::UInt64Value);
 value_impl!(f32, Value::Float32Value);
 value_impl!(f64, Value::Float64Value);
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Metadata {
     pub key: String,
     pub datatype: Datatype,

--- a/tiledb/api/src/metadata.rs
+++ b/tiledb/api/src/metadata.rs
@@ -290,7 +290,7 @@ pub mod strategy {
                     let value_strat = fn_typed!(dt, LT, {
                         type DT = <LT as LogicalType>::PhysicalType;
                         vec(any::<DT>(), params.value_length.clone())
-                            .prop_map(|v| Value::from(v))
+                            .prop_map(Value::from)
                             .boxed()
                     });
                     (params.key.clone(), Just(dt), value_strat)


### PR DESCRIPTION
SC-48994 is about adding a DataFusion TableProvider which scans, and later maybe inserts, metadata.

The tables PR which depends on this is [here](https://github.com/TileDB-Inc/TileDB-Tables/pull/17).