### PR TITLE
Remove Option return from Context::object_type

### DIFF
--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -222,7 +222,7 @@ impl Array {
     {
         Ok(matches!(
             context.object_type(uri)?,
-            Some(crate::context::ObjectType::Array)
+            crate::context::ObjectType::Array
         ))
     }
 


### PR DESCRIPTION
This small pull request is a very minor usability enhancement.  The function `Context::object_type` returns an `ObjectType` for whatever it finds at a given URI.

This method currently returns `Option`... but not for any documented reason.  And the one you would expect, that an object is not found at all, is actually an error from inside core.

Why do we return `Option`?  Because of a possible conversion failure from the C value to the `ObjectType` enum.  But that should be an internal error, as indicated the method this PR switches to using instead.