### PR TITLE
Reduce DEFAULT_MAX_SPARSE_TILE_CAPACITY to reduce max size of proptest sparse tiles

### DIFF
--- a/tiledb/api/src/array/schema/mod.rs
+++ b/tiledb/api/src/array/schema/mod.rs
@@ -410,6 +410,10 @@ impl Schema {
         ArrayType::try_from(c_atype)
     }
 
+    /// Returns the sparse tile capacity for this schema,
+    /// i.e. the number of cells which are contained in each tile of a sparse schema.
+    /// If this is a dense array schema, the value returned is
+    /// not used by tiledb.
     pub fn capacity(&self) -> TileDBResult<u64> {
         let c_schema = self.capi();
         let mut c_capacity: u64 = out_ptr!();
@@ -701,6 +705,12 @@ impl Builder {
         })
     }
 
+    /// Set the sparse tile capacity of this schema.
+    ///
+    /// # Errors
+    ///
+    /// This function is not guaranteed to error if this schema
+    /// is for a dense array - this method may instead have no effect.
     pub fn capacity(self, capacity: u64) -> TileDBResult<Self> {
         let c_schema = *self.schema.raw;
         self.context().capi_call(|ctx| unsafe {

--- a/tiledb/api/src/array/schema/strategy.rs
+++ b/tiledb/api/src/array/schema/strategy.rs
@@ -34,7 +34,8 @@ impl Requirements {
     pub const DEFAULT_MAX_ATTRIBUTES: usize = 32;
 
     pub const DEFAULT_MIN_SPARSE_TILE_CAPACITY: u64 = 1;
-    pub const DEFAULT_MAX_SPARSE_TILE_CAPACITY: u64 = 1024 * 1024;
+    pub const DEFAULT_MAX_SPARSE_TILE_CAPACITY: u64 =
+        DomainRequirements::DEFAULT_CELLS_PER_TILE_LIMIT as u64;
 }
 
 impl Default for Requirements {


### PR DESCRIPTION
I believe this is what has been responsible for the spurious failures in https://github.com/TileDB-Inc/TileDB-Tables/pull/16 .  When the schema strategy chooses a very large sparse tile capacity, we allocate huge amounts of memory in the query writer, which can lead to OOM in any environment.  The previous limit apparently led to OOMs frequently enough in CI to prevent merging.

This pull request syncs the default limit on sparse tile capacity with the default upper bound on dense array domains.  This bound is much less and should not result in OOMs.