### PR TITLE
chore: [sc-49541] [rs] add memory limit to default allocation strategy for query read buffer

### DIFF
--- a/tiledb/api/src/array/attribute/mod.rs
+++ b/tiledb/api/src/array/attribute/mod.rs
@@ -728,6 +728,34 @@ mod test {
     use crate::filter::list::Builder as FilterListBuilder;
     use crate::filter::*;
 
+    /// Test what the default values filled in for `None` with attribute data are.
+    /// Mostly because if we write code which does need the default, we're expecting
+    /// to match core and need to be notified if something changes or we did something
+    /// wrong.
+    #[test]
+    fn attribute_defaults() {
+        let ctx = Context::new().expect("Error creating context instance.");
+
+        {
+            let spec = AttributeData {
+                name: "xkcd".to_owned(),
+                datatype: Datatype::UInt32,
+                ..Default::default()
+            };
+            let attr = spec.create(&ctx).unwrap();
+            assert_eq!(CellValNum::single(), attr.cell_val_num().unwrap());
+        }
+        {
+            let spec = AttributeData {
+                name: "xkcd".to_owned(),
+                datatype: Datatype::StringAscii,
+                ..Default::default()
+            };
+            let attr = spec.create(&ctx).unwrap();
+            assert_eq!(CellValNum::single(), attr.cell_val_num().unwrap());
+        }
+    }
+
     #[test]
     fn attribute_get_name_and_type() {
         let ctx = Context::new().expect("Error creating context instance.");

--- a/tiledb/api/src/array/dimension/mod.rs
+++ b/tiledb/api/src/array/dimension/mod.rs
@@ -388,6 +388,24 @@ impl DimensionConstraints {
         Some(1 + (high - low) as u128)
     }
 
+    /// Returns the number of cells spanned by a
+    /// single tile under this constraint, if applicable
+    pub fn num_cells_per_tile(&self) -> Option<usize> {
+        crate::dimension_constraints_go!(
+            self,
+            _DT,
+            _,
+            extent,
+            extent.map(|extent| {
+                #[allow(clippy::unnecessary_fallible_conversions)]
+                // this `unwrap` should be safe, validation will confirm nonzero
+                usize::try_from(extent).unwrap()
+            }),
+            None,
+            None
+        )
+    }
+
     /// Returns the domain of the dimension constraint, if present, as a range.
     pub fn domain(&self) -> Option<SingleValueRange> {
         crate::dimension_constraints_go!(

--- a/tiledb/api/src/array/domain/mod.rs
+++ b/tiledb/api/src/array/domain/mod.rs
@@ -292,6 +292,17 @@ impl DomainData {
         usize::try_from(total).ok()
     }
 
+    /// Returns the number of cells in each tile, or `None` if:
+    /// - any dimension does not have a tile extent specified (e.g. for a sparse array); or
+    /// - the number of cells in a tile exceeds `usize::MAX`.
+    pub fn num_cells_per_tile(&self) -> Option<usize> {
+        let mut total = 1usize;
+        for d in self.dimension.iter() {
+            total = total.checked_mul(d.constraints.num_cells_per_tile()?)?;
+        }
+        Some(total)
+    }
+
     /// Returns the domains of each dimension as a `NonEmptyDomain`,
     /// or `None` if any dimension is not constrained into a domain
     pub fn domains(&self) -> Option<NonEmptyDomain> {

--- a/tiledb/api/src/array/schema/mod.rs
+++ b/tiledb/api/src/array/schema/mod.rs
@@ -870,6 +870,22 @@ impl SchemaData {
     pub fn fields(&self) -> FieldDataIter {
         FieldDataIter::new(self)
     }
+
+    /// Returns the number of cells per tile
+    pub fn num_cells_per_tile(&self) -> usize {
+        match self.array_type {
+            ArrayType::Dense => {
+                // it should be safe to unwrap, the two `None` conditions must not
+                // be satisfied for a dense array domain
+                // (TODO: what about for string ascii dense domains?)
+                self.domain.num_cells_per_tile().unwrap()
+            }
+            ArrayType::Sparse => {
+                self.capacity.unwrap_or(Self::DEFAULT_SPARSE_TILE_CAPACITY)
+                    as usize
+            }
+        }
+    }
 }
 
 impl Display for SchemaData {

--- a/tiledb/api/src/query/read/mod.rs
+++ b/tiledb/api/src/query/read/mod.rs
@@ -240,7 +240,7 @@ macro_rules! fn_register_callback {
                         let metadata = FieldMetadata::try_from(&field)?;
                         match [< scratch_ $U:snake >] {
                             ScratchStrategy::AttributeDefault => {
-                                let alloc : Box<dyn ScratchAllocator<<T as $Callback>::$U> + 'data> = Box::new(field.query_scratch_allocator()?);
+                                let alloc : Box<dyn ScratchAllocator<<T as $Callback>::$U> + 'data> = Box::new(field.query_scratch_allocator(None)?);
                                 let managed = ManagedBuffer::from(alloc);
                                 RawReadHandle::managed(metadata, managed)
                             },

--- a/tiledb/api/src/query/read/output/mod.rs
+++ b/tiledb/api/src/query/read/output/mod.rs
@@ -528,6 +528,10 @@ pub struct FieldScratchAllocator {
     pub is_nullable: bool,
 }
 
+impl FieldScratchAllocator {
+    pub const DEFAULT_MEMORY_LIMIT: usize = 64 * 1024 * 1024;
+}
+
 impl<C> ScratchAllocator<C> for FieldScratchAllocator
 where
     C: PhysicalType,

--- a/tiledb/api/src/query/strategy.rs
+++ b/tiledb/api/src/query/strategy.rs
@@ -797,7 +797,7 @@ impl Cells {
                     fn_typed!(field.datatype().unwrap(), LT, {
                         type DT = <LT as LogicalType>::PhysicalType;
                         let managed: ManagedBuffer<DT> = ManagedBuffer::new(
-                            field.query_scratch_allocator().unwrap(),
+                            field.query_scratch_allocator(None).unwrap(),
                         );
                         let metadata = FieldMetadata::try_from(&field).unwrap();
                         let rr = RawReadHandle::managed(metadata, managed);


### PR DESCRIPTION
Story details: https://app.shortcut.com/tiledb-inc/story/49541


This should fix, or at least significantly diminish the probability of, the "could not allocate memory" issues we observed in `tables` CI.