### PR TITLE
Add test utility to run a callback as a signal handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "chrono"
 version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,6 +852,18 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nom"
@@ -1321,6 +1339,7 @@ name = "tiledb-test-utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "nix",
  "proptest",
  "tempfile",
 ]

--- a/tiledb/test-utils/Cargo.toml
+++ b/tiledb/test-utils/Cargo.toml
@@ -6,6 +6,10 @@ version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-nix = { version = "0", features = ["signal"] }
+nix = { version = "0", features = ["signal"], optional = true }
 proptest = { workspace = true }
 tempfile = "3"
+
+[features]
+default = ["signal"]
+signal = ["dep:nix"]

--- a/tiledb/test-utils/Cargo.toml
+++ b/tiledb/test-utils/Cargo.toml
@@ -6,5 +6,6 @@ version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+nix = { version = "0", features = ["signal"] }
 proptest = { workspace = true }
 tempfile = "3"

--- a/tiledb/test-utils/src/lib.rs
+++ b/tiledb/test-utils/src/lib.rs
@@ -1,6 +1,9 @@
 extern crate proptest;
 
+pub mod signal;
 pub mod strategy;
 pub mod uri_generators;
 
+pub use nix::sys::signal::{SigHandler, Signal};
+pub use signal::*;
 pub use uri_generators::{get_uri_generator, TestArrayUri};

--- a/tiledb/test-utils/src/lib.rs
+++ b/tiledb/test-utils/src/lib.rs
@@ -4,6 +4,5 @@ pub mod signal;
 pub mod strategy;
 pub mod uri_generators;
 
-pub use nix::sys::signal::{SigHandler, Signal};
 pub use signal::*;
 pub use uri_generators::{get_uri_generator, TestArrayUri};

--- a/tiledb/test-utils/src/lib.rs
+++ b/tiledb/test-utils/src/lib.rs
@@ -1,8 +1,11 @@
 extern crate proptest;
 
+#[cfg(feature = "signal")]
 pub mod signal;
 pub mod strategy;
 pub mod uri_generators;
 
+#[cfg(feature = "signal")]
 pub use signal::*;
+
 pub use uri_generators::{get_uri_generator, TestArrayUri};

--- a/tiledb/test-utils/src/signal.rs
+++ b/tiledb/test-utils/src/signal.rs
@@ -1,0 +1,232 @@
+use std::pin::Pin;
+use std::sync::Mutex;
+
+use nix::sys::signal::{SigHandler, Signal};
+
+/// Overrides a signal handler within its scope.
+pub struct SignalGuard {
+    signo: Signal,
+    restore_handler: SigHandler,
+}
+
+impl SignalGuard {
+    pub fn new(signo: Signal, handler: SigHandler) -> Self {
+        let restore_handler =
+            unsafe { nix::sys::signal::signal(signo, handler) }
+                .expect("Error installing signal handler");
+
+        SignalGuard {
+            signo,
+            restore_handler,
+        }
+    }
+}
+
+impl Drop for SignalGuard {
+    fn drop(&mut self) {
+        unsafe {
+            nix::sys::signal::signal(self.signo, self.restore_handler)
+                .expect("Error restoring previous signal handler");
+        }
+    }
+}
+
+struct RawSignalCallback(*mut ());
+
+impl<'a> From<&mut SignalCallback<'a>> for RawSignalCallback {
+    fn from(value: &mut SignalCallback<'a>) -> Self {
+        let ptr = value as *const SignalCallback<'a>;
+        RawSignalCallback(unsafe { std::mem::transmute::<_, _>(ptr) })
+    }
+}
+
+unsafe impl Send for RawSignalCallback {}
+
+const SIGNAL_CALLBACK_DEFAULT: Mutex<Option<RawSignalCallback>> =
+    Mutex::new(None);
+static SIGNAL_CALLBACKS: [Mutex<Option<RawSignalCallback>>; 32] =
+    [SIGNAL_CALLBACK_DEFAULT; 32];
+
+/// Overrides a signal handler within its scope, running a callback when the signal is received.
+pub struct SignalCallback<'a> {
+    guard: SignalGuard,
+    restore_callback: Option<RawSignalCallback>,
+    action: Box<dyn FnMut() -> () + 'a>,
+}
+
+extern "C" fn signal_callback_dispatch(signo: i32) {
+    if let Some(handler) =
+        SIGNAL_CALLBACKS[signo as usize].lock().unwrap().as_mut()
+    {
+        let action = &mut unsafe {
+            &mut *std::mem::transmute::<_, *mut SignalCallback<'static>>(
+                handler.0,
+            )
+        }
+        .action;
+        action();
+    }
+}
+
+impl<'a> SignalCallback<'a> {
+    pub fn new<F>(signo: Signal, handler: F) -> Pin<Box<Self>>
+    where
+        F: FnMut() -> () + 'a,
+    {
+        // probably should mask off the signal during the following non-atomic operations
+
+        let guard = SignalGuard::new(
+            signo,
+            SigHandler::Handler(signal_callback_dispatch),
+        );
+
+        let mut callback = Box::pin(SignalCallback {
+            guard,
+            restore_callback: None,
+            action: Box::new(handler),
+        });
+        callback.restore_callback = std::mem::replace(
+            &mut SIGNAL_CALLBACKS[signo as i32 as usize].lock().unwrap(),
+            Some(RawSignalCallback::from(callback.as_mut().get_mut())),
+        );
+
+        callback
+    }
+}
+
+impl<'a> Drop for SignalCallback<'a> {
+    fn drop(&mut self) {
+        // probably should mask off the signal around the non-atomic
+        // operations including this and dropping the guard
+        *SIGNAL_CALLBACKS[self.guard.signo as i32 as usize]
+            .lock()
+            .unwrap() = self.restore_callback.take();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guard_simple() {
+        // set handler to ignore for the test
+        {
+            let _ignore = SignalGuard::new(Signal::SIGINT, SigHandler::SigIgn);
+
+            // this will end test if ignoring did not work
+            nix::sys::signal::raise(Signal::SIGINT).unwrap();
+        }
+
+        // check that default was restored
+        let default = unsafe {
+            nix::sys::signal::signal(Signal::SIGINT, SigHandler::SigDfl)
+        }
+        .unwrap();
+        assert_eq!(default, SigHandler::SigDfl);
+    }
+
+    #[test]
+    fn callback_simple() {
+        let mut value = 0;
+
+        // set handler to ignore for the test
+        let _ignore = SignalGuard::new(Signal::SIGINT, SigHandler::SigIgn);
+
+        nix::sys::signal::raise(Signal::SIGINT).unwrap();
+        assert_eq!(value, 0);
+
+        // callback handler shall overwrite
+        {
+            let _cb = SignalCallback::new(Signal::SIGINT, || value += 1);
+            nix::sys::signal::raise(Signal::SIGINT).unwrap();
+        }
+        assert_eq!(value, 1);
+
+        // callback should have been unregistered, previous guard is used
+        nix::sys::signal::raise(Signal::SIGINT).unwrap();
+        assert_eq!(value, 1);
+    }
+
+    #[test]
+    fn callback_nest() {
+        let mut v1 = 0;
+        let mut v2 = 0;
+
+        // set handler to ignore for the test
+        let _ignore = SignalGuard::new(Signal::SIGINT, SigHandler::SigIgn);
+
+        nix::sys::signal::raise(Signal::SIGINT).unwrap();
+        assert_eq!(v1, 0);
+        assert_eq!(v2, 0);
+
+        // callback handler shall overwrite
+        {
+            let _cb1 = SignalCallback::new(Signal::SIGINT, || v1 += 1);
+            nix::sys::signal::raise(Signal::SIGINT).unwrap();
+
+            // nested callback handler shall overwrite again
+            {
+                let _cb2 = SignalCallback::new(Signal::SIGINT, || v2 += 100);
+                nix::sys::signal::raise(Signal::SIGINT).unwrap();
+            }
+            assert_eq!(v2, 100);
+
+            // then the previous callback should have been restored
+            nix::sys::signal::raise(Signal::SIGINT).unwrap();
+        }
+        assert_eq!(v1, 2);
+        assert_eq!(v2, 100);
+
+        // then the ignore handler should have been restored
+        nix::sys::signal::raise(Signal::SIGINT).unwrap();
+        assert_eq!(v1, 2);
+        assert_eq!(v2, 100);
+    }
+
+    #[test]
+    fn callback_multi() {
+        let mut v1 = 0;
+        let mut v2 = 0;
+
+        // set handler to ignore for the test
+        let _usr1 = SignalGuard::new(Signal::SIGUSR1, SigHandler::SigIgn);
+        let _usr2 = SignalGuard::new(Signal::SIGUSR2, SigHandler::SigIgn);
+
+        nix::sys::signal::raise(Signal::SIGUSR1).unwrap();
+        assert_eq!(v1, 0);
+        assert_eq!(v2, 0);
+
+        nix::sys::signal::raise(Signal::SIGUSR2).unwrap();
+        assert_eq!(v1, 0);
+        assert_eq!(v2, 0);
+
+        // register both but see only SIGUSR1
+        {
+            let _cb1 = SignalCallback::new(Signal::SIGUSR1, || v1 += 1);
+            let _cb2 = SignalCallback::new(Signal::SIGUSR2, || v2 += 1);
+            nix::sys::signal::raise(Signal::SIGUSR1).unwrap();
+        }
+        assert_eq!(v1, 1);
+        assert_eq!(v2, 0);
+
+        // register both but see only SIGUSR2
+        {
+            let _cb1 = SignalCallback::new(Signal::SIGUSR1, || v1 += 1);
+            let _cb2 = SignalCallback::new(Signal::SIGUSR2, || v2 += 1);
+            nix::sys::signal::raise(Signal::SIGUSR2).unwrap();
+        }
+        assert_eq!(v1, 1);
+        assert_eq!(v2, 1);
+
+        // register both and see both signals
+        {
+            let _cb1 = SignalCallback::new(Signal::SIGUSR1, || v1 += 1);
+            let _cb2 = SignalCallback::new(Signal::SIGUSR2, || v2 += 1);
+            nix::sys::signal::raise(Signal::SIGUSR1).unwrap();
+            nix::sys::signal::raise(Signal::SIGUSR2).unwrap();
+        }
+        assert_eq!(v1, 2);
+        assert_eq!(v2, 2);
+    }
+}

--- a/tiledb/test-utils/src/signal.rs
+++ b/tiledb/test-utils/src/signal.rs
@@ -1,7 +1,7 @@
 use std::pin::Pin;
 use std::sync::Mutex;
 
-use nix::sys::signal::{SigHandler, Signal};
+pub use nix::sys::signal::{SigHandler, Signal};
 
 /// Overrides a signal handler within its scope.
 pub struct SignalGuard {

--- a/tiledb/test-utils/src/signal.rs
+++ b/tiledb/test-utils/src/signal.rs
@@ -3,12 +3,24 @@ use std::sync::Mutex;
 
 pub use nix::sys::signal::{SigHandler, Signal};
 
-/// Overrides a signal handler within its scope.
+/// On unix systems, overrides a signal handler within its scope.
+/// On windows, does nothing.
 pub struct SignalGuard {
     signo: Signal,
     restore_handler: SigHandler,
 }
 
+#[cfg(windows)]
+impl SignalGuard {
+    pub fn new(signo: Signal, handler: SigHandler) -> Self {
+        SignalGuard {
+            signo,
+            signal_handler,
+        }
+    }
+}
+
+#[cfg(not(windows))]
 impl SignalGuard {
     pub fn new(signo: Signal, handler: SigHandler) -> Self {
         let restore_handler =
@@ -22,6 +34,7 @@ impl SignalGuard {
     }
 }
 
+#[cfg(not(windows))]
 impl Drop for SignalGuard {
     fn drop(&mut self) {
         unsafe {
@@ -104,7 +117,7 @@ impl<'a> Drop for SignalCallback<'a> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(windows)))]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
This was useful in debugging the recent tables CI issues.  When Rust fails to allocate memory, it terminates the process with SIGABRT which does not bubble up to proptest to print the current test case.  Using this utility I was able to register a callback to print the current test case in response to that SIGABRT, leading to a reproducer I could inspect on my laptop.

It's certainly not production ready, as some of the comments indicate, but I'd like to merge it in case it proves useful again in the future.