### PR TITLE
Split fn_typed into logical_type_go and physical_type_go and add example

### DIFF
--- a/tiledb/api/src/array/attribute/strategy.rs
+++ b/tiledb/api/src/array/attribute/strategy.rs
@@ -5,10 +5,9 @@ use proptest::prelude::*;
 use crate::array::{
     attribute::FillData, ArrayType, AttributeData, CellValNum, DomainData,
 };
-use crate::datatype::LogicalType;
 use crate::filter::list::FilterListData;
 use crate::filter::strategy::Requirements as FilterRequirements;
-use crate::{fn_typed, Datatype};
+use crate::{physical_type_go, Datatype};
 
 #[derive(Clone)]
 pub enum StrategyContext {
@@ -88,11 +87,10 @@ fn prop_attribute_for_datatype(
     datatype: Datatype,
     requirements: Rc<Requirements>,
 ) -> impl Strategy<Value = AttributeData> {
-    fn_typed!(
+    physical_type_go!(
         datatype,
-        LT,
+        DT,
         {
-            type DT = <LT as LogicalType>::PhysicalType;
             let name = requirements
                 .name
                 .as_ref()

--- a/tiledb/api/src/array/dimension/arrow.rs
+++ b/tiledb/api/src/array/dimension/arrow.rs
@@ -11,10 +11,11 @@ use crate::array::schema::arrow::{
 use crate::array::{Dimension, DimensionBuilder};
 use crate::context::{Context as TileDBContext, ContextBound};
 use crate::datatype::arrow::{DatatypeFromArrowResult, DatatypeToArrowResult};
-use crate::datatype::LogicalType;
 use crate::filter::arrow::FilterMetadata;
 use crate::filter::FilterListBuilder;
-use crate::{error::Error as TileDBError, fn_typed, Result as TileDBResult};
+use crate::{
+    error::Error as TileDBError, physical_type_go, Result as TileDBResult,
+};
 
 /// Encapsulates fields of a TileDB dimension which are not part of an Arrow
 /// field
@@ -27,8 +28,7 @@ pub struct DimensionMetadata {
 
 impl DimensionMetadata {
     pub fn new(dim: &Dimension) -> TileDBResult<Self> {
-        fn_typed!(dim.datatype()?, LT, {
-            type DT = <LT as LogicalType>::PhysicalType;
+        physical_type_go!(dim.datatype()?, DT, {
             let domain = dim.domain::<DT>()?;
             let extent = dim.extent::<DT>()?;
 
@@ -102,8 +102,7 @@ pub fn from_arrow(
             ))))?,
         };
 
-        let dim = fn_typed!(datatype, LT, {
-            type DT = <LT as LogicalType>::PhysicalType;
+        let dim = physical_type_go!(datatype, DT, {
             let deser = |v: &serde_json::value::Value| {
                 serde_json::from_value::<DT>(v.clone()).map_err(|e| {
                     TileDBError::Deserialization(

--- a/tiledb/api/src/array/dimension/mod.rs
+++ b/tiledb/api/src/array/dimension/mod.rs
@@ -7,11 +7,11 @@ use util::option::OptionSubset;
 
 use crate::array::CellValNum;
 use crate::context::{CApiInterface, Context, ContextBound};
-use crate::datatype::{LogicalType, PhysicalType};
+use crate::datatype::PhysicalType;
 use crate::error::{DatatypeErrorKind, Error};
 use crate::filter::list::{FilterList, FilterListData, RawFilterList};
 use crate::range::SingleValueRange;
-use crate::{fn_typed, Datatype, Factory, Result as TileDBResult};
+use crate::{physical_type_go, Datatype, Factory, Result as TileDBResult};
 
 pub(crate) enum RawDimension {
     Owned(*mut ffi::tiledb_dimension_t),
@@ -161,8 +161,7 @@ impl PartialEq<Dimension> for Dimension {
         eq_helper!(self.cell_val_num(), other.cell_val_num());
         eq_helper!(self.filters(), other.filters());
 
-        fn_typed!(self.datatype().unwrap(), LT, {
-            type DT = <LT as LogicalType>::PhysicalType;
+        physical_type_go!(self.datatype().unwrap(), DT, {
             eq_helper!(self.domain::<DT>(), other.domain::<DT>());
             eq_helper!(self.extent::<DT>(), other.extent::<DT>())
         });
@@ -584,8 +583,7 @@ impl TryFrom<&Dimension> for DimensionData {
 
     fn try_from(dim: &Dimension) -> TileDBResult<Self> {
         let datatype = dim.datatype()?;
-        let constraints = fn_typed!(datatype, LT, {
-            type DT = <LT as LogicalType>::PhysicalType;
+        let constraints = physical_type_go!(datatype, DT, {
             let domain = dim.domain::<DT>()?;
             let extent = dim.extent::<DT>()?;
             if let Some(domain) = domain {

--- a/tiledb/api/src/array/dimension/strategy.rs
+++ b/tiledb/api/src/array/dimension/strategy.rs
@@ -12,12 +12,11 @@ use crate::array::dimension::DimensionConstraints;
 use crate::array::{ArrayType, CellValNum, DimensionData};
 use crate::datatype::physical::BitsOrd;
 use crate::datatype::strategy::*;
-use crate::datatype::LogicalType;
 use crate::filter::list::FilterListData;
 use crate::filter::strategy::{
     Requirements as FilterRequirements, StrategyContext as FilterContext,
 };
-use crate::{fn_typed, Datatype};
+use crate::{physical_type_go, Datatype};
 
 #[derive(Clone)]
 pub struct Requirements {
@@ -193,8 +192,7 @@ fn prop_dimension_for_datatype(
     } else {
         CellValNum::single()
     };
-    fn_typed!(datatype, LT, {
-        type DT = <LT as LogicalType>::PhysicalType;
+    physical_type_go!(datatype, DT, {
         let name = prop_dimension_name();
         let range_and_extent = if !datatype.is_string_type() {
             prop_range_and_extent::<DT>(params.extent_limit)

--- a/tiledb/api/src/array/enumeration/strategy.rs
+++ b/tiledb/api/src/array/enumeration/strategy.rs
@@ -4,8 +4,8 @@ use proptest::collection::vec;
 use proptest::prelude::*;
 
 use crate::array::EnumerationData;
-use crate::datatype::{LogicalType, PhysicalType};
-use crate::{fn_typed, Datatype};
+use crate::datatype::PhysicalType;
+use crate::{physical_type_go, Datatype};
 
 const MIN_ENUMERATION_VALUES: usize = 1;
 const MAX_ENUMERATION_VALUES: usize = 1024;
@@ -28,8 +28,7 @@ fn do_cmp<T: PhysicalType>(a: &T, b: &T) -> Ordering {
 }
 
 fn prop_enumeration_values(datatype: Datatype) -> BoxedStrategy<Box<[u8]>> {
-    fn_typed!(datatype, LT, {
-        type DT = <LT as LogicalType>::PhysicalType;
+    physical_type_go!(datatype, DT, {
         vec(any::<DT>(), MIN_ENUMERATION_VALUES..=MAX_ENUMERATION_VALUES)
             .prop_map(|data| {
                 let mut data = data;

--- a/tiledb/api/src/array/fragment_info.rs
+++ b/tiledb/api/src/array/fragment_info.rs
@@ -6,9 +6,9 @@ use anyhow::anyhow;
 use crate::array::schema::{RawSchema, Schema};
 use crate::config::{Config, RawConfig};
 use crate::context::{CApiInterface, Context, ContextBound};
-use crate::datatype::{Datatype, LogicalType};
+use crate::datatype::Datatype;
 use crate::error::{DatatypeErrorKind, Error};
-use crate::fn_typed;
+use crate::physical_type_go;
 use crate::range::{
     MinimumBoundingRectangle, Range, TypedNonEmptyDomain, TypedRange,
 };
@@ -304,8 +304,7 @@ impl FragmentInfoInternal {
         frag_idx: u32,
         dim_idx: u32,
     ) -> TileDBResult<TypedRange> {
-        fn_typed!(datatype, LT, {
-            type DT = <LT as LogicalType>::PhysicalType;
+        physical_type_go!(datatype, DT, {
             let c_frag = self.capi();
             let mut range = [DT::default(), DT::default()];
             let c_range = range.as_mut_ptr();
@@ -345,8 +344,7 @@ impl FragmentInfoInternal {
             )
         })?;
 
-        fn_typed!(datatype, LT, {
-            type DT = <LT as LogicalType>::PhysicalType;
+        physical_type_go!(datatype, DT, {
             if start_size % std::mem::size_of::<DT>() as u64 != 0 {
                 return Err(Error::Datatype(DatatypeErrorKind::TypeMismatch {
                     user_type: std::any::type_name::<DT>().to_owned(),
@@ -420,8 +418,7 @@ impl FragmentInfoInternal {
         dim_idx: u32,
     ) -> TileDBResult<TypedRange> {
         let c_frag = self.capi();
-        fn_typed!(datatype, LT, {
-            type DT = <LT as LogicalType>::PhysicalType;
+        physical_type_go!(datatype, DT, {
             let mut range = [DT::default(), DT::default()];
             let c_range = range.as_mut_ptr();
             self.capi_call(|ctx| unsafe {
@@ -464,8 +461,7 @@ impl FragmentInfoInternal {
             )
         })?;
 
-        fn_typed!(datatype, LT, {
-            type DT = <LT as LogicalType>::PhysicalType;
+        physical_type_go!(datatype, DT, {
             if start_size % std::mem::size_of::<DT>() as u64 != 0 {
                 return Err(Error::Datatype(DatatypeErrorKind::TypeMismatch {
                     user_type: std::any::type_name::<DT>().to_owned(),

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -9,7 +9,7 @@ use util::option::OptionSubset;
 
 use crate::array::schema::RawSchema;
 use crate::context::{CApiInterface, Context, ContextBound};
-use crate::datatype::{LogicalType, PhysicalType};
+use crate::datatype::PhysicalType;
 use crate::error::{DatatypeErrorKind, Error, ModeErrorKind};
 use crate::key::LookupKey;
 use crate::metadata::Metadata;
@@ -17,7 +17,7 @@ use crate::range::{
     Range, SingleValueRange, TypedNonEmptyDomain, TypedRange, VarValueRange,
 };
 use crate::Result as TileDBResult;
-use crate::{fn_typed, Datatype};
+use crate::{physical_type_go, Datatype};
 
 pub mod attribute;
 pub mod dimension;
@@ -605,8 +605,7 @@ impl Array {
     ) -> TileDBResult<Option<TypedRange>> {
         match cell_val_num {
             CellValNum::Fixed(nz) => {
-                fn_typed!(datatype, LT, {
-                    type DT = <LT as LogicalType>::PhysicalType;
+                physical_type_go!(datatype, DT, {
                     Ok(self
                         .dimension_nonempty_domain_impl_fixed::<DT>(
                             dimension_key,
@@ -616,8 +615,7 @@ impl Array {
                 })
             }
             CellValNum::Var => {
-                fn_typed!(datatype, LT, {
-                    type DT = <LT as LogicalType>::PhysicalType;
+                physical_type_go!(datatype, DT, {
                     let var_range = self
                         .dimension_nonempty_domain_impl_var::<DT>(
                             dimension_key,

--- a/tiledb/api/src/datatype/strategy.rs
+++ b/tiledb/api/src/datatype/strategy.rs
@@ -226,7 +226,6 @@ mod tests {
         ArrayType, AttributeBuilder, DimensionBuilder, DomainBuilder, Schema,
         SchemaBuilder,
     };
-    use crate::datatype::LogicalType;
     use crate::error::Error;
     use crate::{Context, Result as TileDBResult};
 
@@ -237,7 +236,7 @@ mod tests {
         array_type: ArrayType,
         datatype: Datatype,
     ) -> TileDBResult<Schema> {
-        let dim = fn_typed!(datatype, LT, {
+        let dim = physical_type_go!(datatype, DT, {
             if matches!(datatype, Datatype::StringAscii) {
                 DimensionBuilder::new(
                     context,
@@ -246,7 +245,6 @@ mod tests {
                     DimensionConstraints::StringAscii,
                 )
             } else {
-                type DT = <LT as LogicalType>::PhysicalType;
                 let domain: [DT; 2] = [0 as DT, 127 as DT];
                 let extent: DT = 16 as DT;
                 DimensionBuilder::new(context, "d", datatype, (domain, extent))

--- a/tiledb/api/src/metadata.rs
+++ b/tiledb/api/src/metadata.rs
@@ -1,6 +1,6 @@
-use crate::datatype::{Datatype, LogicalType};
+use crate::datatype::Datatype;
 use crate::error::DatatypeErrorKind;
-use crate::fn_typed;
+use crate::physical_type_go;
 use crate::Result as TileDBResult;
 use core::slice;
 use std::convert::From;
@@ -219,8 +219,7 @@ impl Metadata {
         vec_ptr: *const std::ffi::c_void,
         vec_size: u32,
     ) -> Self {
-        let value = fn_typed!(datatype, LT, {
-            type DT = <LT as LogicalType>::PhysicalType;
+        let value = physical_type_go!(datatype, DT, {
             let vec_slice = unsafe {
                 slice::from_raw_parts(
                     vec_ptr as *const DT,
@@ -254,7 +253,6 @@ pub mod strategy {
     use proptest::prelude::*;
 
     use crate::datatype::strategy::DatatypeContext;
-    use crate::datatype::LogicalType;
 
     pub struct Requirements {
         key: BoxedStrategy<String>,
@@ -287,8 +285,7 @@ pub mod strategy {
             params
                 .datatype
                 .prop_flat_map(move |dt| {
-                    let value_strat = fn_typed!(dt, LT, {
-                        type DT = <LT as LogicalType>::PhysicalType;
+                    let value_strat = physical_type_go!(dt, DT, {
                         vec(any::<DT>(), params.value_length.clone())
                             .prop_map(Value::from)
                             .boxed()

--- a/tiledb/api/src/query/read/output/strategy.rs
+++ b/tiledb/api/src/query/read/output/strategy.rs
@@ -4,10 +4,9 @@ use std::num::NonZeroU32;
 use proptest::prelude::*;
 
 use crate::array::CellValNum;
-use crate::datatype::LogicalType;
 use crate::query::buffer::{CellStructure, QueryBuffers};
 use crate::query::read::output::{RawReadOutput, TypedRawReadOutput};
-use crate::{fn_typed, Datatype};
+use crate::{physical_type_go, Datatype};
 
 #[derive(Clone, Debug)]
 pub struct RawReadOutputParameters {
@@ -129,10 +128,10 @@ impl<'data> Arbitrary for TypedRawReadOutput<'data> {
 
         strategy_datatype
             .prop_flat_map(move |datatype| {
-                fn_typed!(
+                physical_type_go!(
                     datatype,
-                    LT,
-                    any_with::<RawReadOutput<<LT as LogicalType>::PhysicalType>>(
+                    DT,
+                    any_with::<RawReadOutput<DT>>(
                         params
                             .as_ref()
                             .cloned()

--- a/tiledb/api/src/query/subarray.rs
+++ b/tiledb/api/src/query/subarray.rs
@@ -5,13 +5,13 @@ use anyhow::anyhow;
 
 use crate::array::Schema;
 use crate::context::{CApiInterface, Context, ContextBound};
-use crate::datatype::{LogicalType, PhysicalType};
+use crate::datatype::PhysicalType;
 use crate::error::{DatatypeErrorKind, Error};
 use crate::key::LookupKey;
 use crate::query::QueryBuilder;
 use crate::range::{Range, SingleValueRange, TypedRange, VarValueRange};
 use crate::Result as TileDBResult;
-use crate::{fn_typed, single_value_range_go, var_value_range_go};
+use crate::{physical_type_go, single_value_range_go, var_value_range_go};
 
 pub(crate) enum RawSubarray {
     Owned(*mut ffi::tiledb_subarray_t),
@@ -120,8 +120,7 @@ impl<'query> Subarray<'query> {
                     // Apparently stride exists in the API but isn't used.
                     let mut stride: *const std::ffi::c_void = out_ptr!();
 
-                    fn_typed!(dtype, LT, {
-                        type DT = <LT as LogicalType>::PhysicalType;
+                    physical_type_go!(dtype, DT, {
                         let mut start_ptr: *const DT = out_ptr!();
                         let mut end_ptr: *const DT = out_ptr!();
                         self.capi_call(|ctx| unsafe {

--- a/tiledb/api/src/range.rs
+++ b/tiledb/api/src/range.rs
@@ -7,11 +7,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::array::CellValNum;
-use crate::datatype::logical::*;
 use crate::datatype::physical::BitsOrd;
 use crate::datatype::Datatype;
 use crate::error::{DatatypeErrorKind, Error};
-use crate::fn_typed;
+use crate::physical_type_go;
 use crate::Result as TileDBResult;
 
 pub type MinimumBoundingRectangle = Vec<TypedRange>;
@@ -909,8 +908,7 @@ impl TypedRange {
             }
         }
 
-        fn_typed!(datatype, LT, {
-            type DT = <LT as LogicalType>::PhysicalType;
+        physical_type_go!(datatype, DT, {
             let start_slice = unsafe {
                 std::slice::from_raw_parts(
                     start.as_ptr() as *const DT,
@@ -1115,14 +1113,13 @@ mod tests {
         assert_eq!(*range, range2.range);
     }
 
-    // fn_typed! seems to be fairly heavy for using with llvm-cov so I've
+    // physical_type_go! seems to be fairly heavy for using with llvm-cov so I've
     // minimized the number of usages in these tests by adding test helpers
-    // that are called from as few fn_typed macros as possible.
+    // that are called from as few physical_type_go macros as possible.
     #[test]
     fn test_single_value_range() {
         for datatype in Datatype::iter() {
-            fn_typed!(datatype, LT, {
-                type DT = <LT as LogicalType>::PhysicalType;
+            physical_type_go!(datatype, DT, {
                 proptest!(ProptestConfig::with_cases(8),
                         |(start in any::<DT>(), end in any::<DT>())| {
 
@@ -1148,8 +1145,7 @@ mod tests {
     #[test]
     fn test_multi_value_range() {
         for datatype in Datatype::iter() {
-            fn_typed!(datatype, LT, {
-                type DT = <LT as LogicalType>::PhysicalType;
+            physical_type_go!(datatype, DT, {
                 proptest!(ProptestConfig::with_cases(8),
                         |(data in vec(any::<DT>(), 2..=32))| {
                     let len = data.len() as u32;
@@ -1214,8 +1210,7 @@ mod tests {
     #[test]
     fn test_var_value_range() {
         for datatype in Datatype::iter() {
-            fn_typed!(datatype, LT, {
-                type DT = <LT as LogicalType>::PhysicalType;
+            physical_type_go!(datatype, DT, {
                 proptest!(ProptestConfig::with_cases(8),
                         |(start in vec(any::<DT>(), 0..=32), end in vec(any::<DT>(), 0..=32))| {
                     let start = start.into_boxed_slice();

--- a/tiledb/api/src/range.rs
+++ b/tiledb/api/src/range.rs
@@ -67,6 +67,11 @@ impl SingleValueRange {
         Some(1 + (high - low) as u128)
     }
 
+    /// Returns a `CellValNum` description of values in this range, i.e. `CellValNum::single()`.
+    pub fn cell_val_num(&self) -> CellValNum {
+        CellValNum::single()
+    }
+
     pub fn is_integral(&self) -> bool {
         matches!(
             self,
@@ -533,6 +538,11 @@ pub enum VarValueRange {
 }
 
 impl VarValueRange {
+    /// Returns a `CellValNum` which matches the values in this range, i.e. `CellValNum::Var`.
+    pub fn cell_val_num(&self) -> CellValNum {
+        CellValNum::Var
+    }
+
     pub fn check_datatype(&self, datatype: Datatype) -> TileDBResult<()> {
         check_datatype!(self, datatype);
         Ok(())
@@ -720,6 +730,14 @@ pub enum Range {
 }
 
 impl Range {
+    pub fn cell_val_num(&self) -> CellValNum {
+        match self {
+            Self::Single(ref r) => r.cell_val_num(),
+            Self::Multi(ref r) => r.cell_val_num(),
+            Self::Var(ref r) => r.cell_val_num(),
+        }
+    }
+
     // N.B. This is not `check_field_compatibility` because dimensions have
     // restrictions on their cell_val_num that don't apply to attributes.
     //
@@ -866,6 +884,10 @@ pub struct TypedRange {
 impl TypedRange {
     pub fn new(datatype: Datatype, range: Range) -> Self {
         Self { datatype, range }
+    }
+
+    pub fn cell_val_num(&self) -> CellValNum {
+        self.range.cell_val_num()
     }
 
     pub fn from_slices(


### PR DESCRIPTION
`fn_typed` was our earliest foray into this sort of meta-programming and it predates what has become our preferred style.  Additionally, almost all usages of it immediately bound a new type identifier `type DT = <LT as LogicalType>::PhysicalType`.

This pull request addresses both of those by splitting `fn_typed` into `logical_type_go` and `physical_type_go`, whose purposes are hopefully clear from the names.