### PR TITLE
Consistent output directory for examples

### DIFF
--- a/tiledb/api/examples/fragment_info.rs
+++ b/tiledb/api/examples/fragment_info.rs
@@ -1,13 +1,21 @@
 extern crate tiledb;
 
+use std::path::PathBuf;
+
 use tiledb::query::QueryBuilder;
 use tiledb::Datatype;
 use tiledb::Result as TileDBResult;
 
-const FRAGMENT_INFO_ARRAY_URI: &str = "fragment_info_example_array";
+const FRAGMENT_INFO_ARRAY_URI: &str = "fragment_info";
 const FRAGMENT_INFO_ATTRIBUTE_NAME: &str = "a";
 
 fn main() {
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        let _ = std::env::set_current_dir(
+            PathBuf::from(manifest_dir).join("examples").join("output"),
+        );
+    }
+
     if !array_exists() {
         create_array().expect("Failed to create array");
 

--- a/tiledb/api/examples/groups.rs
+++ b/tiledb/api/examples/groups.rs
@@ -1,4 +1,7 @@
 extern crate tiledb;
+
+use std::path::PathBuf;
+
 use tiledb::group::Group;
 use tiledb::vfs::VFS;
 use tiledb::{Datatype, Result as TileDBResult};
@@ -146,6 +149,12 @@ fn cleanup() -> TileDBResult<()> {
 }
 
 fn main() -> TileDBResult<()> {
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        let _ = std::env::set_current_dir(
+            PathBuf::from(manifest_dir).join("examples").join("output"),
+        );
+    }
+
     create_arrays_groups()?;
     print_group()?;
     cleanup()?;

--- a/tiledb/api/examples/multi_range_subarray.rs
+++ b/tiledb/api/examples/multi_range_subarray.rs
@@ -1,5 +1,7 @@
 extern crate tiledb;
 
+use std::path::PathBuf;
+
 use itertools::izip;
 
 use tiledb::array::{
@@ -40,6 +42,12 @@ const ARRAY_URI: &str = "multi_range_slicing";
 /// 4   3   15
 /// 4   4   16
 fn main() -> TileDBResult<()> {
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        let _ = std::env::set_current_dir(
+            PathBuf::from(manifest_dir).join("examples").join("output"),
+        );
+    }
+
     let ctx = Context::new()?;
     if !Array::exists(&ctx, ARRAY_URI)? {
         create_array(&ctx)?;

--- a/tiledb/api/examples/output/.gitignore
+++ b/tiledb/api/examples/output/.gitignore
@@ -1,0 +1,9 @@
+fragment_info
+groups
+multi_range_slicing
+query_condition_dense
+query_condition_sparse
+quickstart_dense
+quickstart_sparse_string
+reading_incomplete
+using_tiledb_stats

--- a/tiledb/api/examples/query_condition_dense.rs
+++ b/tiledb/api/examples/query_condition_dense.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::path::PathBuf;
 
 use itertools::izip;
 
@@ -13,13 +14,19 @@ use tiledb::query::{
 };
 use tiledb::{Context, Datatype, Result as TileDBResult};
 
-const ARRAY_URI: &str = "example_query_condition_dense";
+const ARRAY_URI: &str = "query_condition_dense";
 const NUM_ELEMS: i32 = 10;
 const C_FILL_VALUE: i32 = -1;
 const D_FILL_VALUE: f32 = 0.0;
 
 /// Demonstrate reading dense arrays with query conditions.
 fn main() -> TileDBResult<()> {
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        let _ = std::env::set_current_dir(
+            PathBuf::from(manifest_dir).join("examples").join("output"),
+        );
+    }
+
     let ctx = Context::new()?;
     if !Array::exists(&ctx, ARRAY_URI)? {
         create_array(&ctx)?;

--- a/tiledb/api/examples/query_condition_sparse.rs
+++ b/tiledb/api/examples/query_condition_sparse.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::path::PathBuf;
 
 use itertools::izip;
 
@@ -13,13 +14,19 @@ use tiledb::query::{
 };
 use tiledb::{Context, Datatype, Result as TileDBResult};
 
-const ARRAY_URI: &str = "example_query_condition_sparse";
+const ARRAY_URI: &str = "query_condition_sparse";
 const NUM_ELEMS: i32 = 10;
 const C_FILL_VALUE: i32 = -1;
 const D_FILL_VALUE: f32 = 0.0;
 
 /// Demonstrate reading sparse arrays with query conditions.
 fn main() -> TileDBResult<()> {
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        let _ = std::env::set_current_dir(
+            PathBuf::from(manifest_dir).join("examples").join("output"),
+        );
+    }
+
     let ctx = Context::new()?;
     if !Array::exists(&ctx, ARRAY_URI)? {
         create_array(&ctx)?;

--- a/tiledb/api/examples/quickstart_dense.rs
+++ b/tiledb/api/examples/quickstart_dense.rs
@@ -1,10 +1,12 @@
 extern crate tiledb;
 
+use std::path::PathBuf;
+
 use tiledb::query::{QueryBuilder, ReadQuery, ReadQueryBuilder};
 use tiledb::Datatype;
 use tiledb::Result as TileDBResult;
 
-const QUICKSTART_DENSE_ARRAY_URI: &str = "quickstart_dense_array";
+const QUICKSTART_DENSE_ARRAY_URI: &str = "quickstart_dense";
 const QUICKSTART_ATTRIBUTE_NAME: &str = "a";
 
 /// Returns whether the example array already exists
@@ -132,6 +134,12 @@ fn read_array() -> TileDBResult<()> {
 }
 
 fn main() {
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        let _ = std::env::set_current_dir(
+            PathBuf::from(manifest_dir).join("examples").join("output"),
+        );
+    }
+
     if !array_exists() {
         create_array().expect("Failed to create array");
     }

--- a/tiledb/api/examples/quickstart_sparse_string.rs
+++ b/tiledb/api/examples/quickstart_sparse_string.rs
@@ -1,5 +1,7 @@
 extern crate tiledb;
 
+use std::path::PathBuf;
+
 use itertools::izip;
 
 use tiledb::array::dimension::DimensionConstraints;
@@ -14,9 +16,15 @@ use tiledb::query::{
 use tiledb::Result as TileDBResult;
 use tiledb::{Datatype, Factory};
 
-const ARRAY_URI: &str = "quickstart_sparse_string_array";
+const ARRAY_URI: &str = "quickstart_sparse_string";
 
 fn main() -> TileDBResult<()> {
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        let _ = std::env::set_current_dir(
+            PathBuf::from(manifest_dir).join("examples").join("output"),
+        );
+    }
+
     let ctx = Context::new()?;
     if !Array::exists(&ctx, ARRAY_URI)? {
         create_array(&ctx)?;

--- a/tiledb/api/examples/reading_incomplete.rs
+++ b/tiledb/api/examples/reading_incomplete.rs
@@ -1,6 +1,7 @@
 extern crate tiledb;
 
 use std::cell::{Ref, RefCell};
+use std::path::PathBuf;
 
 use itertools::izip;
 use tiledb::array::{CellOrder, TileOrder};
@@ -15,7 +16,7 @@ use tiledb::query::{
 use tiledb::Datatype;
 use tiledb::Result as TileDBResult;
 
-const ARRAY_NAME: &str = "reading_incomplete_array";
+const ARRAY_NAME: &str = "reading_incomplete";
 
 const INT32_ATTRIBUTE_NAME: &str = "a1";
 const CHAR_ATTRIBUTE_NAME: &str = "a2";
@@ -367,6 +368,12 @@ fn read_array_callback() -> TileDBResult<()> {
 }
 
 fn main() -> TileDBResult<()> {
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        let _ = std::env::set_current_dir(
+            PathBuf::from(manifest_dir).join("examples").join("output"),
+        );
+    }
+
     if !array_exists() {
         create_array().expect("Failed to create array");
         write_array().expect("Failed to write array");

--- a/tiledb/api/examples/using_tiledb_stats.rs
+++ b/tiledb/api/examples/using_tiledb_stats.rs
@@ -1,11 +1,14 @@
 extern crate tiledb;
+
+use std::path::PathBuf;
+
 use tiledb::config::Config;
 use tiledb::query::{QueryBuilder, ReadQuery, ReadQueryBuilder};
 use tiledb::vfs::VFS;
 use tiledb::Datatype;
 use tiledb::{Array, Result as TileDBResult};
 
-const ARRAY_NAME: &str = "stats_array";
+const ARRAY_NAME: &str = "using_tiledb_stats";
 const ATTRIBUTE_NAME: &str = "a";
 
 /// Function that takes a vector of tiledb::stats::Metrics struct and prints
@@ -161,6 +164,12 @@ pub fn read_array(json: bool) -> TileDBResult<()> {
 }
 
 fn main() -> TileDBResult<()> {
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        let _ = std::env::set_current_dir(
+            PathBuf::from(manifest_dir).join("examples").join("output"),
+        );
+    }
+
     create_array(1, 12000)?;
     write_array()?;
     read_array(false)?;

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -222,7 +222,7 @@ impl Array {
     {
         Ok(matches!(
             context.object_type(uri)?,
-            crate::context::ObjectType::Array
+            Some(crate::context::ObjectType::Array)
         ))
     }
 

--- a/tiledb/api/src/group/mod.rs
+++ b/tiledb/api/src/group/mod.rs
@@ -261,7 +261,7 @@ impl Group {
         .to_string();
         let uri = uri?;
 
-        let object_type = ObjectType::try_from(tiledb_type)?;
+        let object_type = ObjectType::from_capi(tiledb_type)?.unwrap();
         Ok(GroupInfo {
             uri,
             group_type: object_type,


### PR DESCRIPTION
As written each of our examples creates its array in the current working directory from which you run the example. This clutters the workspace.  This pull request updates the examples to instead write to a consistent output location where we can place a `.gitignore`.

Along the way we fix `Context::object_type` (again - see https://github.com/TileDB-Inc/tiledb-rs/pull/117) to return `None` for paths which do not exist in the absence of I/O errors.