### PR TITLE
feat: [sc-50382] [tables] or [rs] implement accumulating a subarray from the intersection of predicate ranges

### DIFF
--- a/tiledb/api/src/array/domain/mod.rs
+++ b/tiledb/api/src/array/domain/mod.rs
@@ -313,6 +313,18 @@ impl DomainData {
     }
 }
 
+#[cfg(any(test, feature = "proptest-strategies"))]
+impl DomainData {
+    pub fn subarray_strategy(
+        &self,
+    ) -> impl proptest::prelude::Strategy<Value = Vec<Range>> {
+        self.dimension
+            .iter()
+            .map(|d| d.subarray_strategy(None).unwrap())
+            .collect::<Vec<proptest::prelude::BoxedStrategy<Range>>>()
+    }
+}
+
 impl Display for DomainData {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         write!(f, "{}", json!(*self))

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -774,10 +774,11 @@ pub mod strategy;
 pub mod tests {
     use tiledb_test_utils::{self, TestArrayUri};
 
-    use crate::array::*;
+    use super::*;
+    use crate::array::dimension::DimensionConstraints;
     use crate::metadata::Value;
     use crate::query::QueryType;
-    use crate::Datatype;
+    use crate::{Datatype, Factory};
 
     /// Create the array used in the "quickstart_dense" example
     pub fn create_quickstart_dense(
@@ -826,6 +827,52 @@ pub mod tests {
             .with_path("quickstart_dense")
             .map_err(|e| Error::Other(e.to_string()))?;
         Array::create(context, &uri, s)?;
+        Ok(uri)
+    }
+
+    /// Creates an array whose schema is used in the
+    /// `quickstart_sparse_string` example and returns the URI.
+    pub fn create_quickstart_sparse_string(
+        test_uri: &dyn TestArrayUri,
+        ctx: &Context,
+    ) -> TileDBResult<String> {
+        let schema = SchemaData {
+            array_type: ArrayType::Sparse,
+            domain: DomainData {
+                dimension: vec![
+                    DimensionData {
+                        name: "rows".to_owned(),
+                        datatype: Datatype::StringAscii,
+                        constraints: DimensionConstraints::StringAscii,
+                        cell_val_num: None,
+                        filters: None,
+                    },
+                    DimensionData {
+                        name: "cols".to_owned(),
+                        datatype: Datatype::Int32,
+                        constraints: ([1i32, 4], 4i32).into(),
+                        cell_val_num: None,
+                        filters: None,
+                    },
+                ],
+            },
+            attributes: vec![AttributeData {
+                name: "a".to_owned(),
+                datatype: Datatype::Int32,
+                ..Default::default()
+            }],
+            tile_order: Some(TileOrder::RowMajor),
+            cell_order: Some(CellOrder::RowMajor),
+
+            ..Default::default()
+        };
+
+        let schema = schema.create(ctx)?;
+
+        let uri = test_uri
+            .with_path("quickstart_dense")
+            .map_err(|e| Error::Other(e.to_string()))?;
+        Array::create(ctx, &uri, schema)?;
         Ok(uri)
     }
 

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -27,7 +27,9 @@ pub mod fragment_info;
 pub mod schema;
 
 pub use attribute::{Attribute, AttributeData, Builder as AttributeBuilder};
-pub use dimension::{Builder as DimensionBuilder, Dimension, DimensionData};
+pub use dimension::{
+    Builder as DimensionBuilder, Dimension, DimensionConstraints, DimensionData,
+};
 pub use domain::{Builder as DomainBuilder, Domain, DomainData};
 pub use enumeration::{
     Builder as EnumerationBuilder, Enumeration, EnumerationData,

--- a/tiledb/api/src/datatype/physical.rs
+++ b/tiledb/api/src/datatype/physical.rs
@@ -83,6 +83,26 @@ pub trait BitsOrd {
             max
         }
     }
+
+    /// Returns `true` if `self` is less than `other` by `self.bits_cmp`.
+    fn bits_lt(&self, other: &Self) -> bool {
+        matches!(self.bits_cmp(other), Ordering::Less)
+    }
+
+    /// Returns `true` if `self` is less than or equal to `other` by `self.bits_cmp`.
+    fn bits_le(&self, other: &Self) -> bool {
+        matches!(self.bits_cmp(other), Ordering::Less | Ordering::Equal)
+    }
+
+    /// Returns `true` if `self` is greater than or equal to `other` by `self.bits_cmp`.
+    fn bits_ge(&self, other: &Self) -> bool {
+        matches!(self.bits_cmp(other), Ordering::Equal | Ordering::Greater)
+    }
+
+    /// Returns `true` if `self` is greater than `other` by `self.bits_cmp`.
+    fn bits_gt(&self, other: &Self) -> bool {
+        matches!(self.bits_cmp(other), Ordering::Greater)
+    }
 }
 
 impl<T> BitsOrd for &T

--- a/tiledb/api/src/query/subarray.rs
+++ b/tiledb/api/src/query/subarray.rs
@@ -756,7 +756,7 @@ mod tests {
             h.finish() as i32
         };
 
-        let row_values = vec!["foo", "bar", "baz", "quux", "gub"];
+        let row_values = ["foo", "bar", "baz", "quux", "gub"];
         let col_values = (1..=4).collect::<Vec<i32>>();
 
         // write some data

--- a/tiledb/api/src/query/subarray.rs
+++ b/tiledb/api/src/query/subarray.rs
@@ -369,7 +369,7 @@ impl SubarrayData {
     ///
     /// If any dimension does not have any intersection with `ranges`, then
     /// this returns `None` as the resulting subarray would select no coordinates.
-    pub fn intersect_ranges(&self, ranges: &Vec<Range>) -> Option<Self> {
+    pub fn intersect_ranges(&self, ranges: &[Range]) -> Option<Self> {
         let updated_ranges = self
             .dimension_ranges
             .iter()
@@ -462,7 +462,7 @@ mod tests {
         let test_uri =
             crate::array::tests::create_quickstart_dense(&test_uri, &ctx)?;
 
-        let a = Array::open(&ctx, &test_uri, Mode::Read)?;
+        let a = Array::open(&ctx, test_uri, Mode::Read)?;
         let b = ReadBuilder::new(a)?;
 
         // inspect builder in-progress subarray
@@ -511,7 +511,7 @@ mod tests {
             &test_uri, &ctx,
         )?;
 
-        let a = Array::open(&ctx, &test_uri, Mode::Read)?;
+        let a = Array::open(&ctx, test_uri, Mode::Read)?;
         let b = ReadBuilder::new(a)?;
 
         // inspect builder in-progress subarray
@@ -636,8 +636,8 @@ mod tests {
         Ok(array_uri)
     }
 
-    fn do_subarray_intersect(subarray: &SubarrayData, ranges: &Vec<Range>) {
-        if let Some(intersection) = subarray.intersect_ranges(&ranges) {
+    fn do_subarray_intersect(subarray: &SubarrayData, ranges: &[Range]) {
+        if let Some(intersection) = subarray.intersect_ranges(ranges) {
             assert_eq!(
                 subarray.dimension_ranges.len(),
                 intersection.dimension_ranges.len()

--- a/tiledb/api/src/query/subarray.rs
+++ b/tiledb/api/src/query/subarray.rs
@@ -340,6 +340,24 @@ where
         Ok(self)
     }
 
+    /// Adds a set of ranges on each dimension.
+    /// The outer `Vec` of `ranges` is the list of dimensions and the inner
+    /// `Vec` is the list of requested ranges for that dimension.
+    /// If a list is empty for a dimension, then all the coordinates of that
+    /// dimension are selected.
+    pub fn dimension_ranges(
+        self,
+        ranges: Vec<Vec<Range>>,
+    ) -> TileDBResult<Self> {
+        let mut b = self;
+        for (d, ranges) in ranges.into_iter().enumerate() {
+            for r in ranges.into_iter() {
+                b = b.add_range(d, r)?;
+            }
+        }
+        Ok(b)
+    }
+
     /// Apply the subarray to the query, returning the query builder.
     pub fn finish_subarray(self) -> TileDBResult<Q> {
         let c_query = **self.query.base().cquery();
@@ -359,7 +377,7 @@ pub struct SubarrayData {
     /// The outer `Vec` is the list of dimensions and the inner `Vec`
     /// is the list of requested ranges for that dimension.
     /// If a list is empty for a dimension, then all the coordinates
-    /// are selected.
+    /// of that dimension are selected.
     pub dimension_ranges: Vec<Vec<Range>>,
 }
 
@@ -440,6 +458,7 @@ pub mod strategy {
 
 #[cfg(test)]
 mod tests {
+    use std::hash::{DefaultHasher, Hash, Hasher};
     use std::rc::Rc;
 
     use itertools::izip;
@@ -448,7 +467,10 @@ mod tests {
 
     use super::*;
     use crate::array::*;
-    use crate::query::{Query, QueryBuilder, ReadBuilder};
+    use crate::query::{
+        Query, QueryBuilder, ReadBuilder, ReadQuery, ReadQueryBuilder,
+        WriteBuilder,
+    };
     use crate::Datatype;
 
     /// The default subarray of a query with a constrained dimension
@@ -714,5 +736,113 @@ mod tests {
         fn subarray_intersect((subarray, range) in strat_subarray_intersect()) {
             do_subarray_intersect(&subarray, &range)
         }
+    }
+
+    #[test]
+    fn dimension_ranges() {
+        let ctx = Context::new().unwrap();
+
+        let test_uri = tiledb_test_utils::get_uri_generator()
+            .map_err(|e| Error::Other(e.to_string()))
+            .unwrap();
+        let test_uri = crate::array::tests::create_quickstart_sparse_string(
+            &test_uri, &ctx,
+        )
+        .unwrap();
+
+        let derive_att = |row: &str, col: &i32| -> i32 {
+            let mut h = DefaultHasher::new();
+            (row, col).hash(&mut h);
+            h.finish() as i32
+        };
+
+        // write some data
+        {
+            let row_values = vec!["foo", "bar", "baz", "quux", "gub"];
+            let col_values = (1..=4).collect::<Vec<i32>>();
+
+            let (rows, (cols, atts)) = row_values
+                .iter()
+                .flat_map(|r| {
+                    col_values.iter().map(move |c| {
+                        let att = derive_att(r, c);
+                        (r.to_string(), (*c, att))
+                    })
+                })
+                .collect::<(Vec<String>, (Vec<i32>, Vec<i32>))>();
+
+            let w = Array::open(&ctx, &test_uri, Mode::Write).unwrap();
+            let q = WriteBuilder::new(w)
+                .unwrap()
+                .data("rows", &rows)
+                .unwrap()
+                .data("cols", &cols)
+                .unwrap()
+                .data("a", &atts)
+                .unwrap()
+                .build();
+
+            q.submit().unwrap();
+            q.finalize().unwrap();
+        }
+
+        let schema = {
+            let array = Array::open(&ctx, &test_uri, Mode::Read).unwrap();
+            Rc::new(SchemaData::try_from(array.schema().unwrap()).unwrap())
+        };
+
+        let do_dimension_ranges = |subarray: SubarrayData| -> TileDBResult<()> {
+            let array = Array::open(&ctx, &test_uri, Mode::Read).unwrap();
+            let mut q = ReadBuilder::new(array)?
+                .start_subarray()?
+                .dimension_ranges(subarray.dimension_ranges.clone())?
+                .finish_subarray()?
+                .register_constructor::<_, Vec<String>>(
+                    "rows",
+                    Default::default(),
+                )?
+                .register_constructor::<_, Vec<i32>>(
+                    "cols",
+                    Default::default(),
+                )?
+                .register_constructor::<_, Vec<i32>>("a", Default::default())?
+                .build();
+
+            let (atts, (cols, (rows, _))) = q.execute()?;
+            assert_eq!(rows.len(), cols.len());
+            assert_eq!(rows.len(), atts.len());
+
+            for (row, col, att) in izip!(rows, cols, atts) {
+                assert_eq!(att, derive_att(&row, &col));
+
+                let row_in_bounds = subarray.dimension_ranges[0].is_empty()
+                    || subarray.dimension_ranges[0].iter().any(|r| {
+                        let Range::Var(VarValueRange::UInt8(ref lb, ref ub)) =
+                            r
+                        else {
+                            unreachable!()
+                        };
+                        lb.as_ref() <= row.as_bytes()
+                            && row.as_bytes() <= ub.as_ref()
+                    });
+                assert!(row_in_bounds);
+
+                let col_in_bounds = subarray.dimension_ranges[1].is_empty()
+                    || subarray.dimension_ranges[1].iter().any(|r| {
+                        let Range::Single(SingleValueRange::Int32(lb, ub)) = r
+                        else {
+                            unreachable!()
+                        };
+                        *lb <= col && col <= *ub
+                    });
+                assert!(col_in_bounds);
+            }
+
+            Ok(())
+        };
+
+        proptest!(move |(subarray in any_with::<SubarrayData>(Some(Rc::clone(&schema))))| {
+            do_dimension_ranges(subarray).expect("Read query error");
+        })
     }
 }

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -356,7 +356,15 @@ impl Strategy for DenseWriteStrategy {
             .domain
             .dimension
             .iter()
-            .map(|d| d.subarray_strategy(Some(cell_limit)).unwrap())
+            .map(|d| {
+                d.subarray_strategy(Some(cell_limit)).expect("Dense dimension subarray not found")
+                    .prop_map(|r| {
+                        let Range::Single(s) = r else {
+                            unreachable!("Dense dimension subarray is not `Range::Single`: {:?}", r)
+                        };
+                        s
+                    }).boxed()
+            })
             .collect::<Vec<BoxedStrategy<SingleValueRange>>>();
 
         let bounding_subarray = strat_subarray_bounds

--- a/tiledb/api/src/range.rs
+++ b/tiledb/api/src/range.rs
@@ -53,6 +53,16 @@ fn intersection<'a, B>(
 where
     B: BitsOrd + ?Sized,
 {
+    // input integrity check
+    assert!(matches!(
+        left_lower.bits_cmp(left_upper),
+        Ordering::Less | Ordering::Equal
+    ));
+    assert!(matches!(
+        right_lower.bits_cmp(right_upper),
+        Ordering::Less | Ordering::Equal
+    ));
+
     if matches!(left_upper.bits_cmp(right_lower), Ordering::Less)
         || matches!(right_upper.bits_cmp(left_lower), Ordering::Less)
     {
@@ -71,6 +81,12 @@ where
     } else {
         left_upper
     };
+
+    // output integrity check
+    assert!(matches!(
+        lower.bits_cmp(upper),
+        Ordering::Less | Ordering::Equal
+    ));
 
     Some((lower, upper))
 }

--- a/tiledb/api/src/range.rs
+++ b/tiledb/api/src/range.rs
@@ -53,9 +53,9 @@ fn intersection<'a, B>(
 where
     B: BitsOrd + ?Sized,
 {
-    if matches!(left_upper.bits_cmp(right_lower), Ordering::Less) {
-        return None;
-    } else if matches!(right_upper.bits_cmp(left_lower), Ordering::Less) {
+    if matches!(left_upper.bits_cmp(right_lower), Ordering::Less)
+        || matches!(right_upper.bits_cmp(left_lower), Ordering::Less)
+    {
         return None;
     }
 
@@ -173,7 +173,7 @@ impl SingleValueRange {
             rend,
             {
                 let (lower, upper) =
-                    intersection::<DT>(&lstart, &lend, &rstart, &rend)?;
+                    intersection::<DT>(lstart, lend, rstart, rend)?;
                 Some(SingleValueRange::from(&[*lower, *upper]))
             },
             {
@@ -2029,19 +2029,19 @@ mod tests {
 
         // also check against false positives
         assert!(matches!(
-            lstart.bits_cmp(&rend),
+            lstart.bits_cmp(rend),
             Ordering::Less | Ordering::Equal
         ));
         assert!(matches!(
-            rstart.bits_cmp(&lend),
+            rstart.bits_cmp(lend),
             Ordering::Less | Ordering::Equal
         ));
         assert!(matches!(
-            lend.bits_cmp(&rstart),
+            lend.bits_cmp(rstart),
             Ordering::Equal | Ordering::Greater
         ));
         assert!(matches!(
-            rend.bits_cmp(&lstart),
+            rend.bits_cmp(lstart),
             Ordering::Equal | Ordering::Greater
         ));
     }

--- a/tiledb/api/src/range.rs
+++ b/tiledb/api/src/range.rs
@@ -55,6 +55,8 @@ where
 {
     if matches!(left_upper.bits_cmp(right_lower), Ordering::Less) {
         return None;
+    } else if matches!(right_upper.bits_cmp(left_lower), Ordering::Less) {
+        return None;
     }
 
     let lower = if matches!(left_lower.bits_cmp(right_lower), Ordering::Less) {
@@ -2024,6 +2026,24 @@ mod tests {
                 assert_eq!(Ordering::Equal, rend.bits_cmp(oend))
             }
         }
+
+        // also check against false positives
+        assert!(matches!(
+            lstart.bits_cmp(&rend),
+            Ordering::Less | Ordering::Equal
+        ));
+        assert!(matches!(
+            rstart.bits_cmp(&lend),
+            Ordering::Less | Ordering::Equal
+        ));
+        assert!(matches!(
+            lend.bits_cmp(&rstart),
+            Ordering::Equal | Ordering::Greater
+        ));
+        assert!(matches!(
+            rend.bits_cmp(&lstart),
+            Ordering::Equal | Ordering::Greater
+        ));
     }
 
     fn do_intersection_single(left: SingleValueRange, right: SingleValueRange) {


### PR DESCRIPTION
Story details: https://app.shortcut.com/tiledb-inc/story/50382

> In tables we might see a query with multiple predicates on dimensions. Each of these predicates can restrict the subarray we want to select (using range analysis - see technical discussion [49433](https://app.shortcut.com/tiledb-inc/story/49433/technical-design-discussion-for-dense-range-pushdown) ). As we run over the predicates, we want to accumulate the minimal subarray across all predicates.
> 
> If we have "a AND b", then we want to compute the intersection of the range which can satisfy "a" and the range which can satisfy "b" for our subarray.
> 
> If we have "a OR b", then we want to append multiple ranges to the subarray - the range which can satisfy "a" plus the range which can satisfy "b" (and happily, core will consolidate them for us).
> 
> If we have "(a OR b) AND c", then we must distribute the intersection, e.g. "(a AND c) OR (b AND c)".
> 
> If we have "(a AND b) OR c" then... probably we don't really have to do anything.
> 
> The scope of this story is to write the interval arithmetic intersection with property-based testing, and to write the function which distributes an intersection to each clause of a disjunction (and validate the implementation with property-based testing).

I chose to implement the functionality in `rs` since it is sort of generic and it seems plausible that someone somewhere someday might also want it.  Side note, I am thinking maybe we should break the range stuff out into a separate crate in the workspace.

Anyway...

This pull request implements what is described, alongside a small bit of some extra arithmetic stuff (`MultiValueRange::num_cells` being what comes to mind).  A new (possibly redundant?) struct `SubarrayData` is added to hold the range set for each dimension and is where we implement the critical logic.