### PR TITLE
feat: [sc-50382] [tables] or [rs] implement accumulating a subarray from the intersection of predicate ranges

### DIFF
--- a/tiledb/api/src/query/subarray.rs
+++ b/tiledb/api/src/query/subarray.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 
 use anyhow::anyhow;
+use itertools::Itertools;
 
 use crate::array::Schema;
 use crate::context::{CApiInterface, Context, ContextBound};
@@ -410,6 +411,85 @@ impl SubarrayData {
             })
         }
     }
+
+    /// Returns a new `SubarrayData` which represents the intersection
+    /// of all the ranges of `self` with all of the ranges of `other` on each dimension.
+    ///
+    /// ```
+    /// use tiledb::query::subarray::SubarrayData;
+    /// use tiledb::range::Range;
+    ///
+    /// let s1 = SubarrayData {
+    ///     dimension_ranges: vec![
+    ///         vec![Range::from(&[0, 100]), Range::from(&[200, 300])],
+    ///         vec![Range::from(&[2, 6]), Range::from(&[8, 12])],
+    ///         vec![Range::from(&[20, 30]), Range::from(&[40, 50])]
+    ///     ]
+    /// };
+    /// let s2 = SubarrayData {
+    ///     dimension_ranges: vec![
+    ///         vec![Range::from(&[150, 250])],
+    ///         vec![Range::from(&[4, 10]), Range::from(&[12, 12])],
+    ///         vec![Range::from(&[25, 45])]
+    ///     ]
+    /// };
+    /// let intersection = s1.intersect(&s2);
+    ///
+    /// assert_eq!(intersection, Some(SubarrayData {
+    ///     dimension_ranges: vec![
+    ///         vec![Range::from(&[200, 250])],
+    ///         vec![Range::from(&[4, 6]), Range::from(&[8, 10]), Range::from(&[12, 12])],
+    ///         vec![Range::from(&[25, 30]), Range::from(&[40, 45])]
+    ///     ]
+    /// }));
+    /// ```
+    ///
+    /// If any dimension does not have any intersection, then this returns `None`
+    /// as the resulting subarray would select no coordinates.
+    /// ```
+    /// use tiledb::query::subarray::SubarrayData;
+    /// use tiledb::range::Range;
+    ///
+    /// let s1 = SubarrayData {
+    ///     dimension_ranges: vec![
+    ///         vec![Range::from(&[50, 100]), Range::from(&[400, 450])]
+    ///     ]
+    /// };
+    /// let s2 = SubarrayData {
+    ///     dimension_ranges: vec![
+    ///         vec![Range::from(&[150, 250]), Range::from(&[300, 350])],
+    ///     ]
+    /// };
+    /// let intersection = s1.intersect(&s2);
+    /// assert_eq!(intersection, None);
+    /// ```
+    pub fn intersect(&self, other: &SubarrayData) -> Option<Self> {
+        let updated_ranges = self
+            .dimension_ranges
+            .iter()
+            .zip(other.dimension_ranges.iter())
+            .map(|(my_dimension, their_dimension)| {
+                my_dimension
+                    .iter()
+                    .cartesian_product(their_dimension.iter())
+                    .filter_map(|(rm, rt)| rm.intersection(rt))
+                    .collect::<Vec<Range>>()
+            })
+            .collect::<Vec<Vec<Range>>>();
+
+        if self
+            .dimension_ranges
+            .iter()
+            .zip(updated_ranges.iter())
+            .any(|(before, after)| after.is_empty() && !before.is_empty())
+        {
+            None
+        } else {
+            Some(SubarrayData {
+                dimension_ranges: updated_ranges,
+            })
+        }
+    }
 }
 
 #[cfg(any(test, feature = "proptest-strategies"))]
@@ -658,7 +738,7 @@ mod tests {
         Ok(array_uri)
     }
 
-    fn do_subarray_intersect(subarray: &SubarrayData, ranges: &[Range]) {
+    fn do_subarray_intersect_ranges(subarray: &SubarrayData, ranges: &[Range]) {
         if let Some(intersection) = subarray.intersect_ranges(ranges) {
             assert_eq!(
                 subarray.dimension_ranges.len(),
@@ -709,7 +789,57 @@ mod tests {
         }
     }
 
-    fn strat_subarray_intersect(
+    /// Validate the intersection of two subarrays.
+    /// `s1` and `s2` are two subarrays for the same schema.
+    fn do_subarray_intersect_subarray(s1: &SubarrayData, s2: &SubarrayData) {
+        if let Some(intersection) = s1.intersect(s2) {
+            for (di, ds1, ds2) in izip!(
+                intersection.dimension_ranges.iter(),
+                s1.dimension_ranges.iter(),
+                s2.dimension_ranges.iter(),
+            ) {
+                // there must be some pair from (rs1, rs2) where di is the intersection
+                for ri in di.iter() {
+                    let found_input = ds1
+                        .iter()
+                        .cartesian_product(ds2.iter())
+                        .any(|(rs1, rs2)| {
+                            Some(ri) == rs1.intersection(rs2).as_ref()
+                        });
+                    assert!(found_input, "ri = {:?}", ri);
+                }
+
+                // and for all pairs (rs1, rs2), there must be some ri which covers
+                for (rs1, rs2) in ds1.iter().cartesian_product(ds2.iter()) {
+                    let Some(intersection) = rs1.intersection(rs2) else {
+                        continue;
+                    };
+
+                    let found_output = di.iter().any(|ri| intersection == *ri);
+                    assert!(
+                        found_output,
+                        "rs1 = {:?}, rs2 = {:?}, intersection = {:?}",
+                        rs1, rs2, intersection
+                    );
+                }
+            }
+        } else {
+            // for each least one dimension, none of the ranges of `s1`
+            // intersected with any range from `s2`
+            let found_empty_intersection = s1
+                .dimension_ranges
+                .iter()
+                .zip(s2.dimension_ranges.iter())
+                .any(|(ds1, ds2)| {
+                    ds1.iter()
+                        .cartesian_product(ds2.iter())
+                        .all(|(rs1, rs2)| rs1.intersection(rs2).is_none())
+                });
+            assert!(found_empty_intersection);
+        }
+    }
+
+    fn strat_subarray_intersect_ranges(
     ) -> impl Strategy<Value = (SubarrayData, Vec<Range>)> {
         use crate::array::domain::strategy::Requirements as DomainRequirements;
         use crate::array::schema::strategy::Requirements as SchemaRequirements;
@@ -731,10 +861,36 @@ mod tests {
         })
     }
 
+    fn strat_subarray_intersect_subarray(
+    ) -> impl Strategy<Value = (SubarrayData, SubarrayData)> {
+        use crate::array::domain::strategy::Requirements as DomainRequirements;
+        use crate::array::schema::strategy::Requirements as SchemaRequirements;
+
+        let req = Rc::new(SchemaRequirements {
+            domain: Some(Rc::new(DomainRequirements {
+                num_dimensions: 1..=1,
+                ..Default::default()
+            })),
+            ..Default::default()
+        });
+
+        any_with::<SchemaData>(req).prop_flat_map(|schema| {
+            let schema = Rc::new(schema);
+            let strat_subarray =
+                any_with::<SubarrayData>(Some(Rc::clone(&schema)));
+            (strat_subarray.clone(), strat_subarray.clone())
+        })
+    }
+
     proptest! {
         #[test]
-        fn subarray_intersect((subarray, range) in strat_subarray_intersect()) {
-            do_subarray_intersect(&subarray, &range)
+        fn subarray_intersect_ranges((subarray, range) in strat_subarray_intersect_ranges()) {
+            do_subarray_intersect_ranges(&subarray, &range)
+        }
+
+        #[test]
+        fn subarray_intersect_subarray((s1, s2) in strat_subarray_intersect_subarray()) {
+            do_subarray_intersect_subarray(&s1, &s2)
         }
     }
 

--- a/tiledb/api/src/query/subarray.rs
+++ b/tiledb/api/src/query/subarray.rs
@@ -394,12 +394,17 @@ impl SubarrayData {
             .iter()
             .zip(ranges.iter())
             .map(|(current_ranges, new_range)| {
-                current_ranges
-                    .iter()
-                    .filter_map(|current_range| {
-                        current_range.intersection(new_range)
-                    })
-                    .collect::<Vec<Range>>()
+                if current_ranges.is_empty() {
+                    // empty means select the whole thing
+                    vec![new_range.clone()]
+                } else {
+                    current_ranges
+                        .iter()
+                        .filter_map(|current_range| {
+                            current_range.intersection(new_range)
+                        })
+                        .collect::<Vec<Range>>()
+                }
             })
             .collect::<Vec<Vec<Range>>>();
 
@@ -751,6 +756,11 @@ mod tests {
                 intersection.dimension_ranges.iter(),
                 ranges.iter()
             ) {
+                if before.is_empty() {
+                    assert_eq!(vec![update.clone()], *after);
+                    continue;
+                }
+
                 assert!(after.len() <= before.len());
 
                 let mut r_after = after.iter();
@@ -763,12 +773,17 @@ mod tests {
             }
         } else {
             // for at least one dimension, none of the ranges could have intersected
-            let found_empty_intersection =
-                subarray.dimension_ranges.iter().zip(ranges.iter()).any(
-                    |(current, new)| {
+            let found_empty_intersection = subarray
+                .dimension_ranges
+                .iter()
+                .zip(ranges.iter())
+                .any(|(current, new)| {
+                    if current.is_empty() {
+                        false
+                    } else {
                         current.iter().all(|r| r.intersection(new).is_none())
-                    },
-                );
+                    }
+                });
             assert!(
                 found_empty_intersection,
                 "dimensions: {:?}",


### PR DESCRIPTION
Story details: https://app.shortcut.com/tiledb-inc/story/50382

This is a follow-up to #133 which implements the functionality we're *most* interested in, which is the intersection of two subarrays rather than just the intersection of a subarray and a range.

If we have a predicate `(a OR b) AND (c OR d)`, then range analysis will (eventually) give us something like `((dim IN [100, 200]) OR (dim IN [300, 400])) AND ((dim IN 150, 150) OR (dim in [350, 450]))`.  This reduces to `(dim IN [150, 200]) OR (dim IN [300, 350])`.  This pull request implements that reduction and verifies it with property-based testing.

Along the way we also fix the previous function `intersect_ranges`'s handling of the "empty range means everything" special case.