### PR TITLE
SC-51253

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ test.config
 
 .*.swp
 .*.swo
+
+/.idea/*

--- a/tiledb/sys/.gitignore
+++ b/tiledb/sys/.gitignore
@@ -2,3 +2,6 @@ generated.rs
 generated-functions.txt
 covered-functions.txt
 todo.txt
+ignored-but-covered.txt
+ignored-functions.txt
+not-covered.txt

--- a/tiledb/sys/Makefile
+++ b/tiledb/sys/Makefile
@@ -10,11 +10,20 @@ generated.rs:
     -- -I/opt/tiledb/include
 
 generated-functions.txt: generated.rs
+    # Which functions are exponsed by the C++ API.
 	rg -o --no-line-number --no-filename '\bfn\s+tiledb_[^(]+' generated.rs | sort > generated-functions.txt
 
 covered-functions.txt:
+    # Which functions are already implemented.
 	rg -o --no-line-number --no-filename '\bfn\s+tiledb_[^(]+' src/*.rs | sort > covered-functions.txt
 
-todo: generated-functions.txt covered-functions.txt
-	comm -23 generated-functions.txt covered-functions.txt > todo.txt
+ignored-functions.txt:
+    # Which functions we do not wish to implement.
+	rg -o --no-line-number --no-filename '\bfn\s+tiledb_[^(]+' ignored.rs | sort > ignored-functions.txt
+
+todo: generated-functions.txt covered-functions.txt ignored-functions.txt
+	comm -23 generated-functions.txt covered-functions.txt > not-covered.txt
+	comm -23 not-covered.txt ignored-functions.txt > todo.txt
+	comm -12 covered-functions.txt ignored-functions.txt > ignored-but-covered.txt
 	cat todo.txt
+


### PR DESCRIPTION
[SC-51253](https://app.shortcut.com/tiledb-inc/story/51253/tweak-the-makefile-which-produces-lists-of-implemented-covered-and-desired-to-implement-todo-functions)

Tweak the makefile which produces lists of implemented (covered) and desired to implement (TODO) functions