### PR TITLE
Set local rpath lookups for libtiledb

### DIFF
--- a/tiledb/api/build.rs
+++ b/tiledb/api/build.rs
@@ -1,5 +1,8 @@
 fn main() {
     let libdir = pkg_config::get_variable("tiledb", "libdir")
         .expect("Build-time TileDB library missing.");
-    println!("cargo:rustc-link-arg=-Wl,-rpath,{}", libdir);
+    println!(
+        "cargo:rustc-link-arg=-Wl,-rpath,{},-rpath,@loader_path,-rpath,$ORIGIN",
+        libdir
+    );
 }

--- a/tiledb/sys/build.rs
+++ b/tiledb/sys/build.rs
@@ -3,7 +3,10 @@ fn main() {
     println!("cargo:rustc-link-lib=tiledb");
     let libdir = pkg_config::get_variable("tiledb", "libdir")
         .expect("Missing tiledb dependency.");
-    println!("cargo:rustc-link-arg=-Wl,-rpath,{}", libdir);
+    println!(
+        "cargo:rustc-link-arg=-Wl,-rpath,{},-rpath,@loader_path,-rpath,$ORIGIN",
+        libdir
+    );
     pkg_config::Config::new()
         .atleast_version("2.20.0")
         .probe("tiledb")


### PR DESCRIPTION
Adding $ORIGIN and @loader_path to the RPATH allows users to just place a copy of libtiledb.{so,dylib,dll} next to the binary instead of forcing it's presence in a specific system directory. This should allow for users to be able to play with the binaries created by rustc without having to setup a full build and install of libtiledb.