### PR TITLE
Various API additions and one tweak

### DIFF
--- a/tiledb/api/src/array/attribute/arrow.rs
+++ b/tiledb/api/src/array/attribute/arrow.rs
@@ -15,6 +15,20 @@ use crate::filter::arrow::FilterMetadata;
 use crate::filter::FilterListBuilder;
 use crate::{physical_type_go, Context, Datatype, Result as TileDBResult};
 
+// additional methods with arrow features
+impl Attribute {
+    pub fn to_arrow(&self) -> TileDBResult<FieldToArrowResult> {
+        crate::array::attribute::arrow::to_arrow(self)
+    }
+
+    pub fn from_arrow(
+        context: &Context,
+        field: &arrow::datatypes::Field,
+    ) -> TileDBResult<AttributeFromArrowResult> {
+        crate::array::attribute::arrow::from_arrow(context, field)
+    }
+}
+
 /// Encapsulates TileDB Attribute fill value data for storage in Arrow field metadata
 #[derive(Deserialize, Serialize)]
 pub struct FillValueMetadata {

--- a/tiledb/api/src/array/dimension/arrow.rs
+++ b/tiledb/api/src/array/dimension/arrow.rs
@@ -17,6 +17,20 @@ use crate::{
     error::Error as TileDBError, physical_type_go, Result as TileDBResult,
 };
 
+// additional methods with arrow features
+impl Dimension {
+    pub fn to_arrow(&self) -> TileDBResult<FieldToArrowResult> {
+        crate::array::dimension::arrow::to_arrow(self)
+    }
+
+    pub fn from_arrow(
+        context: &TileDBContext,
+        field: &arrow::datatypes::Field,
+    ) -> TileDBResult<DimensionFromArrowResult> {
+        crate::array::dimension::arrow::from_arrow(context, field)
+    }
+}
+
 /// Encapsulates fields of a TileDB dimension which are not part of an Arrow
 /// field
 #[derive(Deserialize, Serialize)]

--- a/tiledb/api/src/array/domain/mod.rs
+++ b/tiledb/api/src/array/domain/mod.rs
@@ -59,7 +59,8 @@ impl Domain {
         }
     }
 
-    pub fn ndim(&self) -> TileDBResult<usize> {
+    /// Returns the number of dimensions.
+    pub fn num_dimensions(&self) -> TileDBResult<usize> {
         let mut ndim: u32 = out_ptr!();
         self.capi_call(|ctx| unsafe {
             ffi::tiledb_domain_get_ndim(ctx, *self.raw, &mut ndim)
@@ -73,7 +74,7 @@ impl Domain {
         key: K,
     ) -> TileDBResult<bool> {
         match key.into() {
-            LookupKey::Index(idx) => Ok(idx < self.ndim()?),
+            LookupKey::Index(idx) => Ok(idx < self.num_dimensions()?),
             LookupKey::Name(name) => {
                 let c_domain = *self.raw;
                 let c_name = cstring!(name);
@@ -143,7 +144,7 @@ impl Domain {
             LookupKey::Name(name) => name,
         };
 
-        for i in 0..self.ndim()? {
+        for i in 0..self.num_dimensions()? {
             let dim = self.dimension(i)?;
             if dim.name()? == name {
                 return Ok(i);
@@ -173,7 +174,7 @@ impl Debug for Domain {
 
 impl PartialEq<Domain> for Domain {
     fn eq(&self, other: &Domain) -> bool {
-        let ndim_match = match (self.ndim(), other.ndim()) {
+        let ndim_match = match (self.num_dimensions(), other.num_dimensions()) {
             (Ok(mine), Ok(theirs)) => mine == theirs,
             _ => false,
         };
@@ -181,7 +182,7 @@ impl PartialEq<Domain> for Domain {
             return false;
         }
 
-        for d in 0..self.ndim().unwrap() {
+        for d in 0..self.num_dimensions().unwrap() {
             let dim_match = match (self.dimension(d), other.dimension(d)) {
                 (Ok(mine), Ok(theirs)) => mine == theirs,
                 _ => false,
@@ -206,7 +207,7 @@ impl<'a> Dimensions<'a> {
         Ok(Dimensions {
             domain,
             cursor: 0,
-            bound: domain.ndim()?,
+            bound: domain.num_dimensions()?,
         })
     }
 }
@@ -341,7 +342,7 @@ impl TryFrom<&Domain> for DomainData {
 
     fn try_from(domain: &Domain) -> TileDBResult<Self> {
         Ok(DomainData {
-            dimension: (0..domain.ndim()?)
+            dimension: (0..domain.num_dimensions()?)
                 .map(|d| DimensionData::try_from(&domain.dimension(d)?))
                 .collect::<TileDBResult<Vec<DimensionData>>>()?,
         })
@@ -386,7 +387,7 @@ mod tests {
         // no dimensions
         {
             let domain = Builder::new(&context).unwrap().build();
-            assert_eq!(0, domain.ndim().unwrap());
+            assert_eq!(0, domain.num_dimensions().unwrap());
 
             assert!(!domain.has_dimension(0).unwrap());
             assert!(!domain.has_dimension("d1").unwrap());
@@ -418,7 +419,7 @@ mod tests {
                 .add_dimension(dim_in)
                 .unwrap()
                 .build();
-            assert_eq!(1, domain.ndim().unwrap());
+            assert_eq!(1, domain.num_dimensions().unwrap());
 
             assert!(domain.has_dimension(0).unwrap());
             assert!(domain.has_dimension(dim_cmp.name().unwrap()).unwrap());
@@ -483,7 +484,7 @@ mod tests {
                 .add_dimension(dim2_in)
                 .unwrap()
                 .build();
-            assert_eq!(2, domain.ndim().unwrap());
+            assert_eq!(2, domain.num_dimensions().unwrap());
 
             assert!(domain.has_dimension(0).unwrap());
             assert!(domain.has_dimension(1).unwrap());

--- a/tiledb/api/src/array/fragment_info.rs
+++ b/tiledb/api/src/array/fragment_info.rs
@@ -545,7 +545,7 @@ impl<'info> FragmentInfo<'info> {
 
     pub fn non_empty_domain(&self) -> TileDBResult<TypedNonEmptyDomain> {
         let schema = self.info.schema(self.index)?;
-        let num_dims = schema.domain()?.ndim()? as u32;
+        let num_dims = schema.domain()?.num_dimensions()? as u32;
 
         let mut ret = Vec::<TypedRange>::new();
         for dimension in 0..num_dims {
@@ -562,7 +562,7 @@ impl<'info> FragmentInfo<'info> {
 
     pub fn mbr(&self, mbr_idx: u32) -> TileDBResult<MinimumBoundingRectangle> {
         let schema = self.info.schema(self.index)?;
-        let num_dims = schema.domain()?.ndim()? as u32;
+        let num_dims = schema.domain()?.num_dimensions()? as u32;
 
         let mut ret = Vec::<TypedRange>::new();
         for dimension in 0..num_dims {

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -665,7 +665,7 @@ impl Array {
         // note to devs: calling `tiledb_array_get_non_empty_domain`
         // looks like a huge pain, if this is ever a performance bottleneck
         // then maybe we can look into it
-        (0..self.schema()?.domain()?.ndim()?)
+        (0..self.schema()?.domain()?.num_dimensions()?)
             .map(|d| self.dimension_nonempty_domain(d))
             .collect::<TileDBResult<Option<TypedNonEmptyDomain>>>()
     }

--- a/tiledb/api/src/array/schema/arrow.rs
+++ b/tiledb/api/src/array/schema/arrow.rs
@@ -72,7 +72,7 @@ impl SchemaMetadata {
             )?,
             offsets_filters: FilterMetadata::new(&schema.offsets_filters()?)?,
             nullity_filters: FilterMetadata::new(&schema.nullity_filters()?)?,
-            ndim: schema.domain()?.ndim()?,
+            ndim: schema.domain()?.num_dimensions()?,
         })
     }
 }
@@ -84,7 +84,7 @@ pub fn to_arrow(tiledb: &Schema) -> TileDBResult<SchemaToArrowResult> {
 
     let mut inexact = false;
 
-    for d in 0..tiledb.domain()?.ndim()? {
+    for d in 0..tiledb.domain()?.num_dimensions()? {
         let dim = tiledb.domain()?.dimension(d)?;
         match crate::array::dimension::arrow::to_arrow(&dim)? {
             FieldToArrowResult::None => {

--- a/tiledb/api/src/array/schema/arrow.rs
+++ b/tiledb/api/src/array/schema/arrow.rs
@@ -27,6 +27,20 @@ pub type SchemaToArrowResult =
 pub type SchemaFromArrowResult =
     crate::arrow::ArrowConversionResult<SchemaBuilder, SchemaBuilder>;
 
+// additional methods with arrow features
+impl Schema {
+    pub fn to_arrow(&self) -> TileDBResult<SchemaToArrowResult> {
+        crate::array::schema::arrow::to_arrow(self)
+    }
+
+    pub fn from_arrow(
+        context: &Context,
+        schema: &arrow::datatypes::Schema,
+    ) -> TileDBResult<SchemaFromArrowResult> {
+        crate::array::schema::arrow::from_arrow(context, schema)
+    }
+}
+
 /// Represents required metadata to convert from an arrow schema
 /// to a TileDB schema.
 #[derive(Deserialize, Serialize)]

--- a/tiledb/api/src/array/schema/mod.rs
+++ b/tiledb/api/src/array/schema/mod.rs
@@ -535,7 +535,7 @@ impl Schema {
     }
 
     pub fn num_fields(&self) -> TileDBResult<usize> {
-        Ok(self.domain()?.ndim()? + self.num_attributes()?)
+        Ok(self.domain()?.num_dimensions()? + self.num_attributes()?)
     }
 
     /// Returns a reference to a field (dimension or attribute) in this schema.
@@ -546,7 +546,7 @@ impl Schema {
         let domain = self.domain()?;
         match key.into() {
             LookupKey::Index(idx) => {
-                let ndim = domain.ndim()?;
+                let ndim = domain.num_dimensions()?;
                 if idx < ndim {
                     Ok(Field::Dimension(domain.dimension(idx)?))
                 } else {

--- a/tiledb/api/src/query/strategy.rs
+++ b/tiledb/api/src/query/strategy.rs
@@ -1026,6 +1026,22 @@ impl Cells {
 
         self.filter(&preserve)
     }
+
+    /// Adds an additional field to `self`. Returns `true` if successful,
+    /// i.e. the field data is valid for the current set of cells
+    /// and there is not already a field for the key.
+    pub fn add_field(&mut self, key: &str, values: FieldData) -> bool {
+        if self.len() != values.len() {
+            return false;
+        }
+
+        if self.fields.contains_key(key) {
+            false
+        } else {
+            self.fields.insert(key.to_owned(), values);
+            true
+        }
+    }
 }
 
 impl BitsEq for Cells {

--- a/tiledb/api/src/query/strategy.rs
+++ b/tiledb/api/src/query/strategy.rs
@@ -1027,6 +1027,20 @@ impl Cells {
         self.filter(&preserve)
     }
 
+    /// Returns a copy of `self` with only the fields in `fields`,
+    /// or `None` if not all the requested fields are present.
+    pub fn projection(&self, fields: &[&str]) -> Option<Cells> {
+        let projection = fields
+            .iter()
+            .map(|f| {
+                self.fields
+                    .get(*f)
+                    .map(|data| (f.to_string(), data.clone()))
+            })
+            .collect::<Option<HashMap<String, FieldData>>>()?;
+        Some(Cells::new(projection))
+    }
+
     /// Adds an additional field to `self`. Returns `true` if successful,
     /// i.e. the field data is valid for the current set of cells
     /// and there is not already a field for the key.

--- a/tiledb/api/src/query/strategy.rs
+++ b/tiledb/api/src/query/strategy.rs
@@ -666,7 +666,7 @@ impl Arbitrary for FieldData {
 pub struct RawReadQueryResult(pub HashMap<String, FieldData>);
 
 pub struct RawResultCallback {
-    field_order: Vec<String>,
+    pub field_order: Vec<String>,
 }
 
 impl ReadCallbackVarArg for RawResultCallback {

--- a/tiledb/api/src/query/subarray.rs
+++ b/tiledb/api/src/query/subarray.rs
@@ -64,7 +64,7 @@ impl<'query> Subarray<'query> {
     /// and the inner `Vec` is the set of ranges set for that dimension.
     pub fn ranges(&self) -> TileDBResult<Vec<Vec<Range>>> {
         let c_subarray = self.capi();
-        let ndims = self.schema.domain()?.ndim()? as u32;
+        let ndims = self.schema.domain()?.num_dimensions()? as u32;
         let mut ranges: Vec<Vec<Range>> = Vec::new();
         for dim_idx in 0..ndims {
             let mut nranges: u64 = 0;

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -70,7 +70,7 @@ pub fn query_write_schema_requirements(
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct DenseWriteInput {
     pub layout: CellOrder,
     pub data: Cells,
@@ -467,7 +467,7 @@ impl Arbitrary for DenseWriteInput {
 
 pub type SparseWriteParameters = DenseWriteParameters; // TODO: determine if this should be different
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SparseWriteInput {
     pub dimensions: Vec<(String, CellValNum)>,
     pub data: Cells,
@@ -763,7 +763,7 @@ impl FromIterator<SparseWriteInput> for SparseWriteSequence {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum WriteInput {
     Dense(DenseWriteInput),
     Sparse(SparseWriteInput),

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -605,6 +605,12 @@ pub struct DenseWriteSequence {
     writes: Vec<DenseWriteInput>,
 }
 
+impl DenseWriteSequence {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut DenseWriteInput> {
+        self.writes.iter_mut()
+    }
+}
+
 impl Deref for DenseWriteSequence {
     type Target = Vec<DenseWriteInput>;
     fn deref(&self) -> &Self::Target {
@@ -679,6 +685,12 @@ impl FromIterator<DenseWriteInput> for DenseWriteSequence {
 #[derive(Debug)]
 pub struct SparseWriteSequence {
     writes: Vec<SparseWriteInput>,
+}
+
+impl SparseWriteSequence {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut SparseWriteInput> {
+        self.writes.iter_mut()
+    }
 }
 
 impl Deref for SparseWriteSequence {


### PR DESCRIPTION
Some small usability additions as well as a name change: `Domain::ndim` to `Domain::num_dimensions`, to match the style of our other `num_thing` methods.

The underlying functions are already tested, except for the addition to the test code `Cells` but I plan to use that in a branch I'm working on.