### PR TITLE
Set local rpath lookups for libtiledb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1332,6 +1332,7 @@ name = "tiledb-sys"
 version = "0.1.0"
 dependencies = [
  "pkg-config",
+ "tiledb-utils",
 ]
 
 [[package]]

--- a/tiledb/api/Cargo.toml
+++ b/tiledb/api/Cargo.toml
@@ -31,6 +31,7 @@ tiledb-test-utils = { workspace = true }
 
 [build-dependencies]
 pkg-config = { workspace = true }
+tiledb-utils = { workspace = true }
 
 [features]
 default = []

--- a/tiledb/api/build.rs
+++ b/tiledb/api/build.rs
@@ -1,5 +1,5 @@
 fn main() {
     let libdir = pkg_config::get_variable("tiledb", "libdir")
         .expect("Build-time TileDB library missing.");
-    println!("cargo:rustc-link-arg=-Wl,-rpath,{}", libdir);
+    tiledb_utils::build::set_linker_rpath(&libdir);
 }

--- a/tiledb/sys/Cargo.toml
+++ b/tiledb/sys/Cargo.toml
@@ -5,3 +5,4 @@ edition = { workspace = true }
 
 [build-dependencies]
 pkg-config = { workspace = true }
+tiledb-utils = { workspace = true }

--- a/tiledb/sys/build.rs
+++ b/tiledb/sys/build.rs
@@ -1,11 +1,11 @@
 fn main() {
-    // Hard coded for now
-    println!("cargo:rustc-link-lib=tiledb");
-    let libdir = pkg_config::get_variable("tiledb", "libdir")
-        .expect("Missing tiledb dependency.");
-    println!("cargo:rustc-link-arg=-Wl,-rpath,{}", libdir);
     pkg_config::Config::new()
         .atleast_version("2.20.0")
         .probe("tiledb")
         .expect("Build-time TileDB library missing, version >= 2.4 not found.");
+    println!("cargo:rustc-link-lib=tiledb");
+
+    let libdir = pkg_config::get_variable("tiledb", "libdir")
+        .expect("Missing tiledb dependency.");
+    tiledb_utils::build::set_linker_rpath(&libdir);
 }

--- a/tiledb/utils/src/build.rs
+++ b/tiledb/utils/src/build.rs
@@ -1,0 +1,6 @@
+pub fn set_linker_rpath(libdir: &str) {
+    println!(
+        "cargo:rustc-link-arg=-Wl,-rpath,@loader_path,-rpath,$ORIGIN,-rpath,{}",
+        libdir
+    );
+}

--- a/tiledb/utils/src/lib.rs
+++ b/tiledb/utils/src/lib.rs
@@ -5,6 +5,7 @@ extern crate tiledb_proc_macro;
 #[cfg(feature = "serde_json")]
 extern crate serde_json;
 
+pub mod build;
 pub mod numbers;
 #[macro_use]
 pub mod option;


### PR DESCRIPTION
Adding $ORIGIN and @loader_path to the RPATH allows users to just place a copy of libtiledb.{so,dylib,dll} next to the binary instead of forcing it's presence in a specific system directory. This should allow for users to be able to play with the binaries created by rustc without having to setup a full build and install of libtiledb.