### PR TITLE
Remove cfg(test) for Datatype::iter

### DIFF
--- a/tiledb/api/src/datatype/mod.rs
+++ b/tiledb/api/src/datatype/mod.rs
@@ -5,8 +5,6 @@ pub use logical::*;
 pub use physical::PhysicalType;
 
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
-#[cfg(test)]
-use std::slice::Iter;
 
 use serde::{Deserialize, Serialize};
 use util::option::OptionSubset;
@@ -393,8 +391,9 @@ impl Datatype {
         })
     }
 
-    #[cfg(test)]
-    pub fn iter() -> Iter<'static, Datatype> {
+    /// Returns an `Iterator` which yields each variant of `Datatype`
+    /// exactly once in an unspecified order.
+    pub fn iter() -> impl Iterator<Item = Datatype> {
         static DATATYPES: [Datatype; 43] = [
             Datatype::Int32,
             Datatype::Int64,
@@ -440,7 +439,7 @@ impl Datatype {
             Datatype::GeometryWkb,
             Datatype::GeometryWkt,
         ];
-        DATATYPES.iter()
+        DATATYPES.iter().copied()
     }
 }
 
@@ -804,9 +803,12 @@ pub mod strategy;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::collections::HashSet;
+
     use proptest::prelude::*;
     use util::{assert_not_option_subset, assert_option_subset};
+
+    use super::*;
 
     #[test]
     fn datatype_roundtrips() {
@@ -837,6 +839,15 @@ mod tests {
             } else {
                 assert!(Datatype::try_from(i as u32).is_err());
             }
+        }
+    }
+
+    #[test]
+    fn iter() {
+        let mut yielded = HashSet::<Datatype>::new();
+        for dt in Datatype::iter() {
+            let prev = yielded.insert(dt);
+            assert!(prev);
         }
     }
 

--- a/tiledb/api/src/range.rs
+++ b/tiledb/api/src/range.rs
@@ -1765,14 +1765,14 @@ mod tests {
 
                     let range = Range::from(&[start, end]);
                     test_clone(&range);
-                    test_dimension_compatibility(&range, *datatype)?;
+                    test_dimension_compatibility(&range, datatype)?;
                     test_serialization_roundtrip(&range);
 
                     let start_slice = start.to_le_bytes();
                     let end_slice = end.to_le_bytes();
                     test_from_slices(
                         &range,
-                        *datatype,
+                        datatype,
                         CellValNum::try_from(1)?,
                         &start_slice[..],
                         &end_slice[..]
@@ -1796,7 +1796,7 @@ mod tests {
                     let range = Range::try_from(
                         (cell_val_num, start.clone(), end.clone()))?;
                     test_clone(&range);
-                    test_dimension_compatibility(&range, *datatype)?;
+                    test_dimension_compatibility(&range, datatype)?;
                     test_serialization_roundtrip(&range);
 
                     let nbytes = (len as u64 * datatype.size()) as usize;
@@ -1819,7 +1819,7 @@ mod tests {
 
                     test_from_slices(
                         &range,
-                        *datatype,
+                        datatype,
                         CellValNum::try_from(len)?,
                         start_slice,
                         end_slice
@@ -1858,7 +1858,7 @@ mod tests {
 
                     let range = Range::from((start.clone(), end.clone()));
                     test_clone(&range);
-                    test_dimension_compatibility(&range, *datatype)?;
+                    test_dimension_compatibility(&range, datatype)?;
                     test_serialization_roundtrip(&range);
 
                     // Test from slices
@@ -1878,7 +1878,7 @@ mod tests {
 
                     test_from_slices(
                         &range,
-                        *datatype,
+                        datatype,
                         CellValNum::Var,
                         start_slice,
                         end_slice


### PR DESCRIPTION
This function is conceivably useful for test code in crates using `tiledb-rs`.  For example, `tables`.