### PR TITLE
Setup nightly libtiledb builds

### DIFF
--- a/.github/actions/build-tiledb/action.yml
+++ b/.github/actions/build-tiledb/action.yml
@@ -1,0 +1,74 @@
+name: Build TileDB
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Dependencies - Ubuntu
+      if: ${{ startsWith(matrix.os, 'ubuntu-') == true }}
+      shell: bash
+      run: |
+        set -e pipefail
+        sudo apt-get update
+        sudo apt-get -y install \
+          build-essential \
+          gdb \
+          ninja-build \
+          git \
+          curl \
+          zip \
+          unzip \
+          tar \
+          pkg-config
+    - name: Install Dependencies - macOS
+      if: ${{ startsWith(matrix.os, 'macos-') == true }}
+      shell: bash
+      run: |
+        set -e pipefail
+        brew install automake pkg-config
+    - name: Install Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Configure Vcpkg
+      uses: actions/github-script@v6
+      with:
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+    - name: Build and Install TileDB
+      shell: bash
+      env:
+        MACOSX_DEPLOYMENT_TARGET: "14.0"
+        VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+      run: |
+        set -e pipefail
+
+        # Using git directly to avoid issues reported here:
+        # https://github.com/actions/checkout/issues/1498
+        mkdir -p ~/repos
+        git -C ~/repos clone https://github.com/TileDB-Inc/TileDB tiledb
+
+        # Build TileDB
+        mkdir -p ~/repos/tiledb/build
+        cd ~/repos/tiledb/build
+        cmake \
+          -DCMAKE_INSTALL_PREFIX=/opt/github-actions/ \
+          -DTILEDB_WERROR=OFF \
+          -DTILEDB_VCPKG=ON \
+          -DTILEDB_GCS=ON \
+          -DTILEDB_S3=ON \
+          -DTILEDB_AZURE=ON \
+          -DTILEDB_HDFS=OFF \
+          -DTILEDB_TESTS=OFF \
+          -DTILEDB_SERIALIZATION=ON \
+          -DTILEDB_VERBOSE=OFF \
+          ..
+
+        # Build TileDB
+        make -j4 && make -C tiledb -j4
+
+        # Install TileDB
+        sudo make -C tiledb -j4 install
+
+        # Setup pkg-config paths
+        echo "PKG_CONFIG_PATH=/opt/github-actions/lib/pkgconfig" >> $GITHUB_ENV

--- a/.github/actions/install-tiledb/action.yml
+++ b/.github/actions/install-tiledb/action.yml
@@ -2,23 +2,29 @@
 name: Install TileDB
 
 inputs:
-  version:
-   required: false
-   description: "The version of TileDB to Install"
-   default: "2.21.0/tiledb-linux-x86_64-2.21.0-0ea9c13"
+  token:
+    description: 'A Github PAT'
+    required: true
 
 runs:
   using: "composite"
   steps:
-    - name: Install Conda
-      uses: conda-incubator/setup-miniconda@v3
+    - name: Set Tarball Name
+      shell: bash
+      run: |
+        OS=$(uname -o | tr '[:upper:]' '[:lower:]' | tr '/' '-')
+        ARCH=$(uname -m)
+        echo "TDB_TARBALL_NAME=libtiledb-$OS-$ARCH.tar.gz" >> $GITHUB_ENV
+    - uses: robinraju/release-downloader@v1
+      with:
+        repository: 'davisp/tiledb-rs'
+        tag: nightly-libtiledb
+        fileName: ${{ env.TDB_TARBALL_NAME }}
+        extract: false
+        token: ${{ inputs.token }}
     - name: Install TileDB
       shell: bash
       run: |
-        set -e pipefail
-        # Add conda-forge for aws-crt-cpp
-        conda config --add channels conda-forge
-        # Install TileDB Nightly
-        conda install tiledb/label/nightlies::tiledb
-        # Setup pkg-config paths
-        echo "PKG_CONFIG_PATH=$CONDA/lib/pkgconfig" >> $GITHUB_ENV
+        mkdir -p /opt/github-actions
+        tar -C /opt/github-actions -xzf ${{ env.TDB_TARBALL_NAME }}
+        echo "PKG_CONFIG_PATH=/opt/github-actions/lib/pkgconfig" >> $GITHUB_ENV

--- a/.github/workflows/nightly-libtiledb.yml
+++ b/.github/workflows/nightly-libtiledb.yml
@@ -1,0 +1,36 @@
+name: Libtiledb Nightlies
+on:
+  schedule:
+    # runs every day at 00:37 UTC
+    - cron: "37 00 * * *"
+  workflow_dispatch:
+
+jobs:
+  nightly_cli_release:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+          - os: macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout tiledb-rs
+        uses: actions/checkout@v4
+      - name: Build and Install TileDB
+        uses: ./.github/actions/build-tiledb
+      - name: Set Tarball Name
+        run: |
+          OS=$(uname -o | tr '[:upper:]' '[:lower:]' | tr '/' '-')
+          ARCH=$(uname -m)
+          echo "TDB_TARBALL_NAME=libtiledb-$OS-$ARCH.tar.gz" >> $GITHUB_ENV
+      - name: Create Release Artifact
+        run: |
+          tar -C /opt/github-actions/ -cvzf ${{ env.TDB_TARBALL_NAME }} include/ lib/
+      - name: Update Nightly CLI Release
+        uses: pyTooling/Actions/releaser/composite@main
+        with:
+          tag: nightly-libtiledb
+          rm: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: |
+            ${{ env.TDB_TARBALL_NAME }}

--- a/.github/workflows/nigthtly-ci.yml
+++ b/.github/workflows/nigthtly-ci.yml
@@ -21,6 +21,8 @@ jobs:
           components: clippy, rustfmt
       - name: Install TileDB
         uses: ./.github/actions/install-tiledb
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check Formatting
         run: cargo fmt --quiet --check
       - name: Update Dependencies


### PR DESCRIPTION
This builds libtiledb once a day and stores it under the `nightly-libtiledb` release tag. This can then be used by all other CI workflows for consuming libtiledb.