### PR TITLE
Add permissions for uploading release artifacts

### DIFF
--- a/.github/workflows/nightly-libtiledb.yml
+++ b/.github/workflows/nightly-libtiledb.yml
@@ -12,6 +12,8 @@ jobs:
         include:
           - os: ubuntu-latest
           - os: macos-latest
+    permissions:
+      contents: write
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout tiledb-rs


### PR DESCRIPTION
Apparently, the public repostiories have a default permissions setting that prevents this for the entire TileDB-Inc organization.