### PR TITLE
Fix PR CI Install TileDB Step

### DIFF
--- a/.github/workflows/pr-api-coverage.yml
+++ b/.github/workflows/pr-api-coverage.yml
@@ -16,6 +16,8 @@ jobs:
         run: cargo install cargo-expand
       - name: Install TileDB
         uses: ./.github/actions/install-tiledb
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build API Coverage Tool
         run: cd tools/api-coverage && cargo build
       - name: Calculate Coverage

--- a/.github/workflows/pr-build-and-test.yml
+++ b/.github/workflows/pr-build-and-test.yml
@@ -14,6 +14,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Install TileDB
         uses: ./.github/actions/install-tiledb
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         run: cargo build --all-targets --all-features
       - name: Test

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -14,6 +14,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Install TileDB
         uses: ./.github/actions/install-tiledb
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check Formatting
         run: cargo fmt --quiet --check
       - name: Lint


### PR DESCRIPTION
The install-tiledb composite action requires that the `GITHUB_TOKEN` be forwarded explicitly.