### PR TITLE
Rr/api query borrow array

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,6 +1207,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1278,6 +1287,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,6 +1334,7 @@ dependencies = [
  "tiledb-sys",
  "tiledb-test-utils",
  "tiledb-utils",
+ "trybuild",
 ]
 
 [[package]]
@@ -1362,6 +1381,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "207aa50d36c4be8d8c6ea829478be44a372c6a77669937bb39c698e52f1491e8"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "termcolor",
+ "toml",
 ]
 
 [[package]]
@@ -1590,6 +1657,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+
+[[package]]
+name = "winnow"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ version = "0.1.0"
 
 [workspace.dependencies]
 anyhow = "1.0"
+pkg-config = "0.3.30"
 proptest = { version = "1.0.0" }
 proptest-derive = { version = "0.4.0" }
 serde_json = { version = "1.0.114", features = ["float_roundtrip"] }
@@ -30,4 +31,4 @@ tiledb-proc-macro = { path = "tiledb/proc-macro", version = "0.1.0" }
 tiledb-sys = { path = "tiledb/sys", version = "0.1.0" }
 tiledb-test-utils = { path = "tiledb/test-utils", version = "0.1.0" }
 tiledb-utils = { path = "tiledb/utils", version = "0.1.0" }
-pkg-config = "0.3.30"
+trybuild = "1"

--- a/tiledb/api/Cargo.toml
+++ b/tiledb/api/Cargo.toml
@@ -28,6 +28,7 @@ num-traits = { version = "0.2" }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 tiledb-test-utils = { workspace = true }
+trybuild = { workspace = true }
 
 [build-dependencies]
 pkg-config = { workspace = true }

--- a/tiledb/api/examples/fragment_info.rs
+++ b/tiledb/api/examples/fragment_info.rs
@@ -148,7 +148,7 @@ fn create_array() -> TileDBResult<()> {
 fn write_array() -> TileDBResult<()> {
     let tdb = tiledb::context::Context::new()?;
 
-    let array = tiledb::Array::open(
+    let mut array = tiledb::Array::open(
         &tdb,
         FRAGMENT_INFO_ARRAY_URI,
         tiledb::array::Mode::Write,
@@ -156,7 +156,7 @@ fn write_array() -> TileDBResult<()> {
 
     let data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 
-    let query = tiledb::query::WriteBuilder::new(array)?
+    let query = tiledb::query::WriteBuilder::new(&mut array)?
         .layout(tiledb::query::QueryLayout::RowMajor)?
         .data_typed(FRAGMENT_INFO_ATTRIBUTE_NAME, &data)?
         .build();

--- a/tiledb/api/examples/multi_range_subarray.rs
+++ b/tiledb/api/examples/multi_range_subarray.rs
@@ -55,7 +55,7 @@ fn main() -> TileDBResult<()> {
     }
 
     let array = Array::open(&ctx, ARRAY_URI, tiledb::array::Mode::Read)?;
-    let mut query = ReadBuilder::new(array)?
+    let mut query = ReadBuilder::new(&array)?
         .layout(tiledb::query::QueryLayout::RowMajor)?
         .register_constructor::<_, Vec<i32>>("rows", Default::default())?
         .register_constructor::<_, Vec<i32>>("cols", Default::default())?
@@ -117,10 +117,10 @@ fn create_array(ctx: &Context) -> TileDBResult<()> {
 fn write_array(ctx: &Context) -> TileDBResult<()> {
     let data = vec![1i32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 
-    let array =
+    let mut array =
         tiledb::Array::open(ctx, ARRAY_URI, tiledb::array::Mode::Write)?;
 
-    let query = WriteBuilder::new(array)?
+    let query = WriteBuilder::new(&mut array)?
         .layout(CellOrder::RowMajor)?
         .data_typed("a", &data)?
         .build();

--- a/tiledb/api/examples/query_condition_dense.rs
+++ b/tiledb/api/examples/query_condition_dense.rs
@@ -66,7 +66,7 @@ fn main() -> TileDBResult<()> {
 /// to stdout.
 fn read_array(ctx: &Context, qc: Option<QC>) -> TileDBResult<()> {
     let array = tiledb::Array::open(ctx, ARRAY_URI, tiledb::array::Mode::Read)?;
-    let mut query = ReadBuilder::new(array)?
+    let mut query = ReadBuilder::new(&array)?
         .layout(tiledb::query::QueryLayout::RowMajor)?
         .register_constructor::<_, Vec<i32>>("index", Default::default())?
         .register_constructor::<_, (Vec<i32>, Vec<u8>)>(
@@ -182,10 +182,10 @@ fn write_array(ctx: &Context) -> TileDBResult<()> {
     let c_input = vec![0i32, 0, 0, 0, 0, 0, 1, 2, 3, 4];
     let d_input = vec![4.1f32, 3.4, 5.6, 3.7, 2.3, 1.7, 3.8, 4.9, 3.2, 3.1];
 
-    let array =
+    let mut array =
         tiledb::Array::open(ctx, ARRAY_URI, tiledb::array::Mode::Write)?;
 
-    let query = WriteBuilder::new(array)?
+    let query = WriteBuilder::new(&mut array)?
         .data_typed("a", &a_input)?
         .data_typed("b", &b_input)?
         .data_typed("c", &c_input)?

--- a/tiledb/api/examples/query_condition_sparse.rs
+++ b/tiledb/api/examples/query_condition_sparse.rs
@@ -66,7 +66,7 @@ fn main() -> TileDBResult<()> {
 /// to stdout.
 fn read_array(ctx: &Context, qc: Option<QC>) -> TileDBResult<()> {
     let array = tiledb::Array::open(ctx, ARRAY_URI, tiledb::array::Mode::Read)?;
-    let mut query = ReadBuilder::new(array)?
+    let mut query = ReadBuilder::new(&array)?
         .layout(tiledb::query::QueryLayout::RowMajor)?
         .register_constructor::<_, Vec<i32>>("index", Default::default())?
         .register_constructor::<_, (Vec<i32>, Vec<u8>)>(
@@ -184,10 +184,10 @@ fn write_array(ctx: &Context) -> TileDBResult<()> {
     let c_input = vec![0i32, 0, 0, 0, 0, 0, 1, 2, 3, 4];
     let d_input = vec![4.1f32, 3.4, 5.6, 3.7, 2.3, 1.7, 3.8, 4.9, 3.2, 3.1];
 
-    let array =
+    let mut array =
         tiledb::Array::open(ctx, ARRAY_URI, tiledb::array::Mode::Write)?;
 
-    let query = WriteBuilder::new(array)?
+    let query = WriteBuilder::new(&mut array)?
         .layout(CellOrder::Unordered)?
         .data_typed("index", &index_input)?
         .data_typed("a", &a_input)?

--- a/tiledb/api/examples/quickstart_dense.rs
+++ b/tiledb/api/examples/quickstart_dense.rs
@@ -80,7 +80,7 @@ fn create_array() -> TileDBResult<()> {
 fn write_array() -> TileDBResult<()> {
     let tdb = tiledb::context::Context::new()?;
 
-    let array = tiledb::Array::open(
+    let mut array = tiledb::Array::open(
         &tdb,
         QUICKSTART_DENSE_ARRAY_URI,
         tiledb::array::Mode::Write,
@@ -88,7 +88,7 @@ fn write_array() -> TileDBResult<()> {
 
     let data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 
-    let query = tiledb::query::WriteBuilder::new(array)?
+    let query = tiledb::query::WriteBuilder::new(&mut array)?
         .layout(tiledb::query::QueryLayout::RowMajor)?
         .data_typed(QUICKSTART_ATTRIBUTE_NAME, &data)?
         .build();
@@ -113,7 +113,7 @@ fn read_array() -> TileDBResult<()> {
         tiledb::array::Mode::Read,
     )?;
 
-    let mut query = tiledb::query::ReadBuilder::new(array)?
+    let mut query = tiledb::query::ReadBuilder::new(&array)?
         .layout(tiledb::query::QueryLayout::RowMajor)?
         .register_constructor::<_, Vec<i32>>(
             QUICKSTART_ATTRIBUTE_NAME,

--- a/tiledb/api/examples/quickstart_sparse_string.rs
+++ b/tiledb/api/examples/quickstart_sparse_string.rs
@@ -32,7 +32,7 @@ fn main() -> TileDBResult<()> {
     }
 
     let array = Array::open(&ctx, ARRAY_URI, tiledb::array::Mode::Read)?;
-    let mut query = ReadBuilder::new(array)?
+    let mut query = ReadBuilder::new(&array)?
         .layout(tiledb::query::QueryLayout::RowMajor)?
         .register_constructor::<_, Vec<String>>("rows", Default::default())?
         .register_constructor::<_, Vec<i32>>("cols", Default::default())?
@@ -95,10 +95,10 @@ fn write_array(ctx: &Context) -> TileDBResult<()> {
     let col_data = vec![1, 4, 3];
     let a_data = vec![1, 2, 3];
 
-    let array =
+    let mut array =
         tiledb::Array::open(ctx, ARRAY_URI, tiledb::array::Mode::Write)?;
 
-    let query = WriteBuilder::new(array)?
+    let query = WriteBuilder::new(&mut array)?
         .layout(CellOrder::Unordered)?
         .data_typed("rows", &row_data)?
         .data_typed("cols", &col_data)?

--- a/tiledb/api/examples/using_tiledb_stats.rs
+++ b/tiledb/api/examples/using_tiledb_stats.rs
@@ -99,11 +99,11 @@ pub fn create_array(
 ///  [143988000, 143988001 ... 143999999]]
 pub fn write_array() -> TileDBResult<()> {
     let tdb = tiledb::context::Context::new()?;
-    let array: Array =
+    let mut array: Array =
         tiledb::Array::open(&tdb, ARRAY_NAME, tiledb::array::Mode::Write)?;
     let data: Vec<i32> = Vec::from_iter(0..12000 * 12000);
 
-    let query = tiledb::query::WriteBuilder::new(array)?
+    let query = tiledb::query::WriteBuilder::new(&mut array)?
         .layout(tiledb::query::QueryLayout::RowMajor)?
         .data_typed(ATTRIBUTE_NAME, &data)?
         .build();
@@ -131,7 +131,7 @@ pub fn read_array(json: bool) -> TileDBResult<()> {
     let array =
         tiledb::Array::open(&tdb, ARRAY_NAME, tiledb::array::Mode::Read)?;
 
-    let mut query = tiledb::query::ReadBuilder::new(array)?
+    let mut query = tiledb::query::ReadBuilder::new(&array)?
         .layout(tiledb::query::QueryLayout::RowMajor)?
         .register_constructor::<_, Vec<i32>>(
             ATTRIBUTE_NAME,

--- a/tiledb/api/src/array/fragment_info.rs
+++ b/tiledb/api/src/array/fragment_info.rs
@@ -975,9 +975,10 @@ pub mod tests {
     /// Write another fragment to the test array.
     fn write_dense_array(ctx: &Context, array_uri: &str) -> TileDBResult<()> {
         let data = vec![1u64, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-        let array = Array::open(ctx, array_uri, Mode::Write)?;
-        let query =
-            WriteBuilder::new(array)?.data_typed("attr", &data)?.build();
+        let mut array = Array::open(ctx, array_uri, Mode::Write)?;
+        let query = WriteBuilder::new(&mut array)?
+            .data_typed("attr", &data)?
+            .build();
         query.submit()?;
         Ok(())
     }
@@ -1021,8 +1022,8 @@ pub mod tests {
     fn write_sparse_array(ctx: &Context, array_uri: &str) -> TileDBResult<()> {
         let id_data = vec![1u32, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         let attr_data = vec![1u64, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-        let array = Array::open(ctx, array_uri, Mode::Write)?;
-        let query = WriteBuilder::new(array)?
+        let mut array = Array::open(ctx, array_uri, Mode::Write)?;
+        let query = WriteBuilder::new(&mut array)?
             .data_typed("id", &id_data)?
             .data_typed("attr", &attr_data)?
             .build();

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -1168,9 +1168,9 @@ pub mod tests {
 
             let opener = ArrayOpener::new(ctx, array_uri, Mode::Write)?
                 .end_timestamp(timestamp + i as u64 + 1)?;
-            let array = opener.open()?;
+            let mut array = opener.open()?;
 
-            let q1 = WriteBuilder::new(array)?
+            let q1 = WriteBuilder::new(&mut array)?
                 .layout(QueryLayout::RowMajor)?
                 .start_subarray()?
                 .add_range(0, &[low_bound + 1, boundaries[i + 1]])?

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -187,6 +187,19 @@ impl Drop for RawArray {
     }
 }
 
+/// A handle to a tiledb array object.
+///
+/// An array object represents array data at some URI.
+/// This structure provides methods for querying and managing
+/// the array location, schema, fragments, non-empty domain, and so on.
+/// See the `query` module for constructing queries to the array contents.
+//
+// NB: `query::ReadBuilder::new` takes `&Array` as its argument,
+// and that means that we must not add async query support AND we must
+// require that `Array` is not `Sync`. See test `compile_fail/array.rs`.
+// If either of the above requriements changes then we can make
+// `query::ReadBuilder::new` take `&mut Array` instead, but that feels
+// sort of wrong.
 pub struct Array {
     context: Context,
     uri: String,

--- a/tiledb/api/src/query/read/mod.rs
+++ b/tiledb/api/src/query/read/mod.rs
@@ -182,7 +182,7 @@ impl<'data, C> From<&'data RefCell<QueryBuffersMut<'data, C>>>
 }
 
 /// Trait for runnable read queries.
-pub trait ReadQuery: Query {
+pub trait ReadQuery<'a>: Query<'a> {
     type Intermediate;
     type Final;
 
@@ -204,7 +204,7 @@ pub trait ReadQuery: Query {
 
     /// Convert this query into an iterator which yields an item
     /// for each step of the query.
-    fn into_iter(self) -> ReadQueryIterator<Self::Intermediate, Self::Final>
+    fn into_iter(self) -> ReadQueryIterator<'a, Self::Intermediate, Self::Final>
     where
         Self: Sized + 'static,
     {
@@ -272,7 +272,7 @@ macro_rules! fn_register_callback {
 /// Trait for constructing a read query.
 /// Provides methods for flexibly adapting requested attributes into raw results,
 /// callbacks, or strongly-typed objects.
-pub trait ReadQueryBuilder<'data>: QueryBuilder {
+pub trait ReadQueryBuilder<'array, 'data>: QueryBuilder<'array> {
     /// Register a raw memory location to read query results into.
     fn register_raw<S, C>(
         self,
@@ -385,18 +385,18 @@ pub trait ReadQueryBuilder<'data>: QueryBuilder {
     }
 }
 
-pub struct ReadBuilder {
-    base: BuilderBase,
+pub struct ReadBuilder<'a> {
+    base: BuilderBase<'a>,
 }
 
-impl ContextBound for ReadBuilder {
+impl<'a> ContextBound for ReadBuilder<'a> {
     fn context(&self) -> Context {
         self.base.context()
     }
 }
 
-impl ReadBuilder {
-    pub fn new(array: Array) -> TileDBResult<Self> {
+impl<'a> ReadBuilder<'a> {
+    pub fn new(array: &'a Array) -> TileDBResult<Self> {
         let base = BuilderBase::new(array, QueryType::Read)?;
 
         /* configure the query to always use arrow-like output */
@@ -421,10 +421,10 @@ impl ReadBuilder {
     }
 }
 
-impl QueryBuilder for ReadBuilder {
-    type Query = QueryBase;
+impl<'a> QueryBuilder<'a> for ReadBuilder<'a> {
+    type Query = QueryBase<'a>;
 
-    fn base(&self) -> &BuilderBase {
+    fn base(&self) -> &BuilderBase<'a> {
         &self.base
     }
 
@@ -433,13 +433,13 @@ impl QueryBuilder for ReadBuilder {
     }
 }
 
-impl<'data> ReadQueryBuilder<'data> for ReadBuilder {}
+impl<'array, 'data> ReadQueryBuilder<'array, 'data> for ReadBuilder<'array> {}
 
-pub struct ReadQueryIterator<I, F> {
-    query: Option<Box<dyn ReadQuery<Intermediate = I, Final = F>>>,
+pub struct ReadQueryIterator<'array, I, F> {
+    query: Option<Box<dyn ReadQuery<'array, Intermediate = I, Final = F>>>,
 }
 
-impl<I, F> Iterator for ReadQueryIterator<I, F> {
+impl<'a, I, F> Iterator for ReadQueryIterator<'a, I, F> {
     type Item = TileDBResult<ReadStepOutput<I, F>>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -453,4 +453,4 @@ impl<I, F> Iterator for ReadQueryIterator<I, F> {
     }
 }
 
-impl<I, F> std::iter::FusedIterator for ReadQueryIterator<I, F> {}
+impl<'a, I, F> std::iter::FusedIterator for ReadQueryIterator<'a, I, F> {}

--- a/tiledb/api/src/query/read/raw.rs
+++ b/tiledb/api/src/query/read/raw.rs
@@ -451,22 +451,22 @@ where
     }
 }
 
-impl<'data, Q> Query for RawReadQuery<'data, Q>
+impl<'array, 'data, Q> Query<'array> for RawReadQuery<'data, Q>
 where
-    Q: Query,
+    Q: Query<'array>,
 {
-    fn base(&self) -> &QueryBase {
+    fn base(&self) -> &QueryBase<'array> {
         self.base.base()
     }
 
-    fn finalize(self) -> TileDBResult<Array> {
+    fn finalize(self) -> TileDBResult<()> {
         self.base.finalize()
     }
 }
 
-impl<'data, Q> ReadQuery for RawReadQuery<'data, Q>
+impl<'array, 'data, Q> ReadQuery<'array> for RawReadQuery<'data, Q>
 where
-    Q: ReadQuery + ContextBound,
+    Q: ReadQuery<'array> + ContextBound,
 {
     type Intermediate = (usize, Q::Intermediate);
     type Final = (usize, Q::Final);
@@ -521,23 +521,23 @@ pub struct RawReadBuilder<'data, B> {
     pub(crate) base: B,
 }
 
-impl<'data, B> ContextBound for RawReadBuilder<'data, B>
+impl<'array, 'data, B> ContextBound for RawReadBuilder<'data, B>
 where
-    B: QueryBuilder,
+    B: QueryBuilder<'array>,
 {
     fn context(&self) -> Context {
         self.base.base().context()
     }
 }
 
-impl<'data, B> QueryBuilder for RawReadBuilder<'data, B>
+impl<'array, 'data, B> QueryBuilder<'array> for RawReadBuilder<'data, B>
 where
-    B: QueryBuilder,
-    <B as QueryBuilder>::Query: ContextBound,
+    B: QueryBuilder<'array>,
+    <B as QueryBuilder<'array>>::Query: ContextBound,
 {
     type Query = RawReadQuery<'data, B::Query>;
 
-    fn base(&self) -> &BuilderBase {
+    fn base(&self) -> &BuilderBase<'array> {
         self.base.base()
     }
 
@@ -549,10 +549,11 @@ where
     }
 }
 
-impl<'data, B> ReadQueryBuilder<'data> for RawReadBuilder<'data, B>
+impl<'array, 'data, B> ReadQueryBuilder<'array, 'data>
+    for RawReadBuilder<'data, B>
 where
-    B: ReadQueryBuilder<'data>,
-    <B as QueryBuilder>::Query: ContextBound,
+    B: ReadQueryBuilder<'array, 'data>,
+    <B as QueryBuilder<'array>>::Query: ContextBound,
 {
 }
 
@@ -574,22 +575,22 @@ where
     }
 }
 
-impl<'data, Q> Query for VarRawReadQuery<'data, Q>
+impl<'array, 'data, Q> Query<'array> for VarRawReadQuery<'data, Q>
 where
-    Q: Query,
+    Q: Query<'array>,
 {
-    fn base(&self) -> &QueryBase {
+    fn base(&self) -> &QueryBase<'array> {
         self.base.base()
     }
 
-    fn finalize(self) -> TileDBResult<Array> {
+    fn finalize(self) -> TileDBResult<()> {
         self.base.finalize()
     }
 }
 
-impl<'data, Q> ReadQuery for VarRawReadQuery<'data, Q>
+impl<'array, 'data, Q> ReadQuery<'array> for VarRawReadQuery<'data, Q>
 where
-    Q: ReadQuery,
+    Q: ReadQuery<'array>,
 {
     type Intermediate = (Vec<usize>, Q::Intermediate);
     type Final = (Vec<usize>, Q::Final);
@@ -669,13 +670,13 @@ where
     }
 }
 
-impl<'data, B> QueryBuilder for VarRawReadBuilder<'data, B>
+impl<'array, 'data, B> QueryBuilder<'array> for VarRawReadBuilder<'data, B>
 where
-    B: QueryBuilder,
+    B: QueryBuilder<'array>,
 {
     type Query = VarRawReadQuery<'data, B::Query>;
 
-    fn base(&self) -> &BuilderBase {
+    fn base(&self) -> &BuilderBase<'array> {
         self.base.base()
     }
 
@@ -687,7 +688,9 @@ where
     }
 }
 
-impl<'data, B> ReadQueryBuilder<'data> for VarRawReadBuilder<'data, B> where
-    B: ReadQueryBuilder<'data>
+impl<'array, 'data, B> ReadQueryBuilder<'array, 'data>
+    for VarRawReadBuilder<'data, B>
+where
+    B: ReadQueryBuilder<'array, 'data>,
 {
 }

--- a/tiledb/api/src/query/read/typed.rs
+++ b/tiledb/api/src/query/read/typed.rs
@@ -26,24 +26,24 @@ where
     }
 }
 
-impl<'data, T, Q> Query for TypedReadQuery<'data, T, Q>
+impl<'array, 'data, T, Q> Query<'array> for TypedReadQuery<'data, T, Q>
 where
     T: ReadResult,
-    CallbackReadQuery<'data, <T as ReadResult>::Constructor, Q>: Query,
+    CallbackReadQuery<'data, <T as ReadResult>::Constructor, Q>: Query<'array>,
 {
-    fn base(&self) -> &QueryBase {
+    fn base(&self) -> &QueryBase<'array> {
         self.base.base()
     }
 
-    fn finalize(self) -> TileDBResult<Array> {
+    fn finalize(self) -> TileDBResult<()> {
         self.base.finalize()
     }
 }
 
-impl<'data, T, Q> ReadQuery for TypedReadQuery<'data, T, Q>
+impl<'array, 'data, T, Q> ReadQuery<'array> for TypedReadQuery<'data, T, Q>
 where
     T: ReadResult,
-    Q: ReadQuery,
+    Q: ReadQuery<'array>,
 {
     type Intermediate = Q::Intermediate;
     type Final = (T, Q::Final);
@@ -82,14 +82,14 @@ where
     }
 }
 
-impl<'data, T, B> QueryBuilder for TypedReadBuilder<'data, T, B>
+impl<'array, 'data, T, B> QueryBuilder<'array> for TypedReadBuilder<'data, T, B>
 where
     T: ReadResult,
-    B: QueryBuilder,
+    B: QueryBuilder<'array>,
 {
     type Query = TypedReadQuery<'data, T, B::Query>;
 
-    fn base(&self) -> &BuilderBase {
+    fn base(&self) -> &BuilderBase<'array> {
         self.base.base()
     }
 
@@ -101,10 +101,11 @@ where
     }
 }
 
-impl<'data, T, B> ReadQueryBuilder<'data> for TypedReadBuilder<'data, T, B>
+impl<'array, 'data, T, B> ReadQueryBuilder<'array, 'data>
+    for TypedReadBuilder<'data, T, B>
 where
     T: ReadResult,
-    B: ReadQueryBuilder<'data>,
+    B: ReadQueryBuilder<'array, 'data>,
 {
 }
 

--- a/tiledb/api/src/query/strategy.rs
+++ b/tiledb/api/src/query/strategy.rs
@@ -764,10 +764,10 @@ impl Cells {
         &self.fields
     }
 
-    pub fn attach_write<'data>(
+    pub fn attach_write<'array, 'data>(
         &'data self,
-        b: WriteBuilder<'data>,
-    ) -> TileDBResult<WriteBuilder<'data>> {
+        b: WriteBuilder<'array, 'data>,
+    ) -> TileDBResult<WriteBuilder<'array, 'data>> {
         let mut b = b;
         for f in self.fields.iter() {
             b = typed_field_data_go!(f.1, data, b.data_typed(f.0, data))?;
@@ -775,12 +775,12 @@ impl Cells {
         Ok(b)
     }
 
-    pub fn attach_read<'data, B>(
+    pub fn attach_read<'array, 'data, B>(
         &self,
         b: B,
     ) -> TileDBResult<CallbackVarArgReadBuilder<'data, RawResultCallback, B>>
     where
-        B: ReadQueryBuilder<'data>,
+        B: ReadQueryBuilder<'array, 'data>,
     {
         let field_order = self.fields.keys().cloned().collect::<Vec<_>>();
         let handles = {

--- a/tiledb/api/src/query/write/mod.rs
+++ b/tiledb/api/src/query/write/mod.rs
@@ -22,50 +22,50 @@ struct RawWriteInput<'data> {
 
 type InputMap<'data> = HashMap<String, RawWriteInput<'data>>;
 
-pub struct WriteQuery<'data> {
-    base: QueryBase,
+pub struct WriteQuery<'array, 'data> {
+    base: QueryBase<'array>,
 
     /// Hold on to query inputs to ensure they live long enough
     _inputs: InputMap<'data>,
 }
 
-impl<'data> ContextBound for WriteQuery<'data> {
+impl<'array, 'data> ContextBound for WriteQuery<'array, 'data> {
     fn context(&self) -> Context {
         self.base.context()
     }
 }
 
-impl<'data> Query for WriteQuery<'data> {
-    fn base(&self) -> &QueryBase {
+impl<'array, 'data> Query<'array> for WriteQuery<'array, 'data> {
+    fn base(&self) -> &QueryBase<'array> {
         self.base.base()
     }
 
-    fn finalize(self) -> TileDBResult<Array> {
+    fn finalize(self) -> TileDBResult<()> {
         self.base.finalize()
     }
 }
 
-impl<'data> WriteQuery<'data> {
+impl<'array, 'data> WriteQuery<'array, 'data> {
     pub fn submit(&self) -> TileDBResult<()> {
         self.base.do_submit()
     }
 }
 
-pub struct WriteBuilder<'data> {
-    base: BuilderBase,
+pub struct WriteBuilder<'array, 'data> {
+    base: BuilderBase<'array>,
     inputs: InputMap<'data>,
 }
 
-impl<'data> ContextBound for WriteBuilder<'data> {
+impl<'array, 'data> ContextBound for WriteBuilder<'array, 'data> {
     fn context(&self) -> Context {
         self.base.context()
     }
 }
 
-impl<'data> QueryBuilder for WriteBuilder<'data> {
-    type Query = WriteQuery<'data>;
+impl<'array, 'data> QueryBuilder<'array> for WriteBuilder<'array, 'data> {
+    type Query = WriteQuery<'array, 'data>;
 
-    fn base(&self) -> &BuilderBase {
+    fn base(&self) -> &BuilderBase<'array> {
         &self.base
     }
 
@@ -77,8 +77,8 @@ impl<'data> QueryBuilder for WriteBuilder<'data> {
     }
 }
 
-impl<'data> WriteBuilder<'data> {
-    pub fn new(array: Array) -> TileDBResult<Self> {
+impl<'array, 'data> WriteBuilder<'array, 'data> {
+    pub fn new(array: &'array mut Array) -> TileDBResult<Self> {
         let base = BuilderBase::new(array, QueryType::Write)?;
 
         {

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -79,10 +79,10 @@ pub struct DenseWriteInput {
 
 impl DenseWriteInput {
     /// Prepares a write query to insert data from this write.
-    pub fn attach_write<'data>(
+    pub fn attach_write<'array, 'data>(
         &'data self,
-        b: WriteBuilder<'data>,
-    ) -> TileDBResult<WriteBuilder<'data>> {
+        b: WriteBuilder<'array, 'data>,
+    ) -> TileDBResult<WriteBuilder<'array, 'data>> {
         let mut subarray = self.data.attach_write(b)?.start_subarray()?;
 
         for i in 0..self.subarray.len() {
@@ -94,7 +94,7 @@ impl DenseWriteInput {
 
     /// Prepares a read query to read the fields written by this operation
     /// restricted to the subarray represented by this write.
-    pub fn attach_read<'data, B>(
+    pub fn attach_read<'array, 'data, B>(
         &'data self,
         b: B,
     ) -> TileDBResult<
@@ -105,7 +105,7 @@ impl DenseWriteInput {
         >,
     >
     where
-        B: ReadQueryBuilder<'data>,
+        B: ReadQueryBuilder<'array, 'data>,
     {
         let mut subarray = b.start_subarray()?;
 
@@ -517,15 +517,15 @@ impl SparseWriteInput {
     }
 
     /// Prepares a write query to insert data from this write operation.
-    pub fn attach_write<'data>(
+    pub fn attach_write<'array, 'data>(
         &'data self,
-        b: WriteBuilder<'data>,
-    ) -> TileDBResult<WriteBuilder<'data>> {
+        b: WriteBuilder<'array, 'data>,
+    ) -> TileDBResult<WriteBuilder<'array, 'data>> {
         self.data.attach_write(b)
     }
 
     /// Prepares a read query to read the fields written by this operation.
-    pub fn attach_read<'data, B>(
+    pub fn attach_read<'array, 'data, B>(
         &'data self,
         b: B,
     ) -> TileDBResult<
@@ -536,7 +536,7 @@ impl SparseWriteInput {
         >,
     >
     where
-        B: ReadQueryBuilder<'data>,
+        B: ReadQueryBuilder<'array, 'data>,
     {
         Ok(self.data.attach_read(b)?.map(CellsConstructor::new()))
     }
@@ -813,10 +813,10 @@ impl WriteInput {
     }
 
     /// Prepares a write queryto insert data from this write operation.
-    pub fn attach_write<'data>(
+    pub fn attach_write<'array, 'data>(
         &'data self,
-        b: WriteBuilder<'data>,
-    ) -> TileDBResult<WriteBuilder<'data>> {
+        b: WriteBuilder<'array, 'data>,
+    ) -> TileDBResult<WriteBuilder<'array, 'data>> {
         match self {
             Self::Dense(ref d) => d.attach_write(b),
             Self::Sparse(ref s) => s.attach_write(b),
@@ -824,7 +824,7 @@ impl WriteInput {
     }
 
     /// Prepares a read query to read the fields written by this operation.
-    pub fn attach_read<'data, B>(
+    pub fn attach_read<'array, 'data, B>(
         &'data self,
         b: B,
     ) -> TileDBResult<
@@ -835,7 +835,7 @@ impl WriteInput {
         >,
     >
     where
-        B: ReadQueryBuilder<'data>,
+        B: ReadQueryBuilder<'array, 'data>,
     {
         match self {
             Self::Dense(ref d) => d.attach_read(b),
@@ -885,10 +885,10 @@ impl<'a> WriteInputRef<'a> {
     }
 
     /// Prepares a write queryto insert data from this write operation.
-    pub fn attach_write<'data>(
+    pub fn attach_write<'array, 'data>(
         &'data self,
-        b: WriteBuilder<'data>,
-    ) -> TileDBResult<WriteBuilder<'data>> {
+        b: WriteBuilder<'array, 'data>,
+    ) -> TileDBResult<WriteBuilder<'array, 'data>> {
         match self {
             Self::Dense(d) => d.attach_write(b),
             Self::Sparse(s) => s.attach_write(b),
@@ -896,7 +896,7 @@ impl<'a> WriteInputRef<'a> {
     }
 
     /// Prepares a read query to read the fields written by this operation.
-    pub fn attach_read<'data, B>(
+    pub fn attach_read<'array, 'data, B>(
         &'data self,
         b: B,
     ) -> TileDBResult<
@@ -907,7 +907,7 @@ impl<'a> WriteInputRef<'a> {
         >,
     >
     where
-        B: ReadQueryBuilder<'data>,
+        B: ReadQueryBuilder<'array, 'data>,
     {
         match self {
             Self::Dense(d) => d.attach_read(b),
@@ -1185,7 +1185,7 @@ mod tests {
             self.write = Some(write)
         }
 
-        pub fn attach_read<'data, B>(
+        pub fn attach_read<'array, 'data, B>(
             &'data self,
             b: B,
         ) -> TileDBResult<
@@ -1196,7 +1196,7 @@ mod tests {
             >,
         >
         where
-            B: ReadQueryBuilder<'data>,
+            B: ReadQueryBuilder<'array, 'data>,
         {
             // TODO: this is not correct as we accumulate multiple writes
             self.write.as_ref().unwrap().attach_read(b)
@@ -1249,7 +1249,7 @@ mod tests {
             }
         }
 
-        pub fn attach_read<'data, B>(
+        pub fn attach_read<'array, 'data, B>(
             &'data self,
             b: B,
         ) -> TileDBResult<
@@ -1260,7 +1260,7 @@ mod tests {
             >,
         >
         where
-            B: ReadQueryBuilder<'data>,
+            B: ReadQueryBuilder<'array, 'data>,
         {
             Ok(self.cells().attach_read(b)?.map(CellsConstructor::new()))
         }
@@ -1307,7 +1307,7 @@ mod tests {
             }
         }
 
-        pub fn attach_read<'data, B>(
+        pub fn attach_read<'array, 'data, B>(
             &'data self,
             b: B,
         ) -> TileDBResult<
@@ -1318,7 +1318,7 @@ mod tests {
             >,
         >
         where
-            B: ReadQueryBuilder<'data>,
+            B: ReadQueryBuilder<'array, 'data>,
         {
             match self {
                 Self::Dense(ref d) => d.attach_read(b),
@@ -1365,12 +1365,12 @@ mod tests {
         for write in write_sequence {
             /* write data and preserve ranges for sanity check */
             let write_ranges = {
-                let array = Array::open(ctx, &uri, Mode::Write)
+                let mut array = Array::open(ctx, &uri, Mode::Write)
                     .expect("Error opening array");
 
                 let write_query = write
                     .attach_write(
-                        WriteBuilder::new(array)
+                        WriteBuilder::new(&mut array)
                             .expect("Error building write query"),
                     )
                     .expect("Error building write query")
@@ -1392,7 +1392,7 @@ mod tests {
                     None
                 };
 
-                let _ = write_query
+                write_query
                     .finalize()
                     .expect("Error finalizing write query");
 
@@ -1452,7 +1452,7 @@ mod tests {
                     .unwrap();
 
                 let mut read = write
-                    .attach_read(ReadBuilder::new(array).unwrap())
+                    .attach_read(ReadBuilder::new(&array).unwrap())
                     .unwrap()
                     .build();
 
@@ -1471,7 +1471,7 @@ mod tests {
                     assert_eq!(write_sorted, cells);
                 }
 
-                array = read.finalize().unwrap();
+                read.finalize().expect("Error finalizing query");
             }
 
             /* finally, check that everything written up until now is correct */
@@ -1502,7 +1502,7 @@ mod tests {
 
                 let cells = {
                     let mut read = accumulated_write
-                        .attach_read(ReadBuilder::new(array).unwrap())
+                        .attach_read(ReadBuilder::new(&array).unwrap())
                         .unwrap()
                         .build();
 

--- a/tiledb/api/tests/array/sync.rs
+++ b/tiledb/api/tests/array/sync.rs
@@ -1,0 +1,32 @@
+extern crate tiledb;
+
+use tiledb::array::Array;
+
+/// Fails to compile unless `T` is `Sync`.
+fn require_sync<T>()
+where
+    T: Sync,
+{
+}
+
+/// Check whether `Array` is `Sync`.
+///
+/// This is expected to fail because `Array` must not be `Sync`
+/// for the query API to be thread-safe.
+///
+/// In core it is not safe to submit multiple queries concurrently
+/// against the same open array. The Rust API therefore must
+/// prevent multiple concurrent calls to `tiledb_query_submit`
+/// occurring concurrently for the same `Array` instance.
+///
+/// This can be preventing using `&mut Array` in the query API,
+/// and while that feels right for write queries, it does not
+/// feel right for read queries. To enable `&Array` for read
+/// queries, instead we must require:
+/// 1) we do not support async query submit
+/// 2) we cannot share an `Array` between multiple threads
+///
+/// This test will intentionally fail to compile as long as (2) is true,
+fn main() {
+    require_sync::<Array>();
+}

--- a/tiledb/api/tests/array/sync.stderr
+++ b/tiledb/api/tests/array/sync.stderr
@@ -1,0 +1,51 @@
+error[E0277]: `Rc<context::RawContext>` cannot be shared between threads safely
+  --> tests/array/sync.rs:31:20
+   |
+31 |     require_sync::<Array>();
+   |                    ^^^^^ `Rc<context::RawContext>` cannot be shared between threads safely
+   |
+   = help: within `tiledb::Array`, the trait `Sync` is not implemented for `Rc<context::RawContext>`, which is required by `tiledb::Array: Sync`
+note: required because it appears within the type `tiledb::Context`
+  --> src/context.rs
+   |
+   | pub struct Context {
+   |            ^^^^^^^
+note: required because it appears within the type `tiledb::Array`
+  --> src/array/mod.rs
+   |
+   | pub struct Array {
+   |            ^^^^^
+note: required by a bound in `require_sync`
+  --> tests/array/sync.rs:8:8
+   |
+6  | fn require_sync<T>()
+   |    ------------ required by a bound in this function
+7  | where
+8  |     T: Sync,
+   |        ^^^^ required by this bound in `require_sync`
+
+error[E0277]: `*mut tiledb_sys::types::tiledb_array_t` cannot be shared between threads safely
+  --> tests/array/sync.rs:31:20
+   |
+31 |     require_sync::<Array>();
+   |                    ^^^^^ `*mut tiledb_sys::types::tiledb_array_t` cannot be shared between threads safely
+   |
+   = help: within `tiledb::Array`, the trait `Sync` is not implemented for `*mut tiledb_sys::types::tiledb_array_t`, which is required by `tiledb::Array: Sync`
+note: required because it appears within the type `RawArray`
+  --> src/array/mod.rs
+   |
+   | pub enum RawArray {
+   |          ^^^^^^^^
+note: required because it appears within the type `tiledb::Array`
+  --> src/array/mod.rs
+   |
+   | pub struct Array {
+   |            ^^^^^
+note: required by a bound in `require_sync`
+  --> tests/array/sync.rs:8:8
+   |
+6  | fn require_sync<T>()
+   |    ------------ required by a bound in this function
+7  | where
+8  |     T: Sync,
+   |        ^^^^ required by this bound in `require_sync`

--- a/tiledb/api/tests/compile_fail.rs
+++ b/tiledb/api/tests/compile_fail.rs
@@ -1,0 +1,7 @@
+extern crate trybuild;
+
+#[test]
+fn compile_fail() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/array/*.rs");
+}


### PR DESCRIPTION
This pull request changes the query API to borrow an Array rather than consume it.  The entry points of `ReadBuilder::new(array: Array)` and `WriteBuilder::new(array: Array)` are changed to `ReadBuilder::new(array: &Array)` and `WriteBuilder::new(array: &mut Array)` respectively.

This change is intended to make it easier to submit multiple queries over an iteration. Moving the array into and out of each iteration is a bit of a pain.

The reason that the API originally consumed the Array is because it is unsafe to submit multiple queries against the same open array in parallel in the core library.
https://app.shortcut.com/tiledb-inc/story/35602/add-c-multithreaded-query-example
This story is about that (though it may not contain that detail directly, one of the linked stories might instead).

Since `WriteBuilder::new` now takes an exclusive reference, the array it borrows cannot be used as long as the query object is in scope - this satisfies the safety guarantee we want.

`ReadBuilder::new` takes a shared reference, which does allow construction of multiple `ReadBuilder` objects borrowing the same array.  Multiple concurrent executions of `tiledb_query_submit` from the same thread are not possible since there is no async query support from core (there is an API but we do not currently wrap it and I think Paul suggested it is not stable for some reason?).  Multiple concurrent executions of `tiledb_query_submit` from different threads are only possible if `Array` is `Sync`, so we add a test which ensures that `Array` is not `Sync`.