### PR TITLE
Fix nightly lint 'first doc comment paragraph is too long'

### DIFF
--- a/tiledb/api/examples/using_tiledb_stats.rs
+++ b/tiledb/api/examples/using_tiledb_stats.rs
@@ -11,9 +11,10 @@ use tiledb::{Array, Result as TileDBResult};
 const ARRAY_NAME: &str = "using_tiledb_stats";
 const ATTRIBUTE_NAME: &str = "a";
 
-/// Function that takes a vector of tiledb::stats::Metrics struct and prints
-/// the data. The Metrics struct has two public fields: a HashMap<String, f64>
-/// with relevant timers, and a HashMap<String, u64> with relevant counters.
+/// Prints tiledb statistics.
+///
+/// The `Metrics` struct has two public fields: a `HashMap<String, f64>`
+/// with relevant timers, and a `HashMap<String, u64>` with relevant counters.
 pub fn print_metrics(metrics: &[tiledb::stats::Metrics]) {
     println!("Printing query metrics...");
     for metric in metrics.iter() {
@@ -28,6 +29,7 @@ pub fn print_metrics(metrics: &[tiledb::stats::Metrics]) {
 }
 
 /// Creates a dense array at URI `ARRAY_NAME()`.
+///
 /// The array has two i32 dimensions ["row", "col"] with a single int32
 /// attribute "a" stored in each cell.
 /// Both "row" and "col" dimensions range from 1 to 12000, and the tiles
@@ -92,6 +94,7 @@ pub fn create_array(
 }
 
 /// Writes data into the array in row-major order from a 1D-array buffer.
+///
 /// After the write, the contents of the array will be:
 /// [[ 0, 1 ... 11999],
 ///  [ 12000, 12001, ... 23999],

--- a/tiledb/api/src/array/schema/arrow.rs
+++ b/tiledb/api/src/array/schema/arrow.rs
@@ -153,6 +153,7 @@ fn tiledb_metadata(schema: &ArrowSchema) -> TileDBResult<SchemaMetadata> {
 }
 
 /// Construct a TileDB schema from an Arrow schema.
+///
 /// A TileDB schema must have domain and dimension details.
 /// These are expected to be in the schema `metadata` beneath the key `tiledb`.
 /// This metadata is expected to be a JSON object with the following fields:

--- a/tiledb/api/src/filter/strategy.rs
+++ b/tiledb/api/src/filter/strategy.rs
@@ -442,6 +442,7 @@ pub fn prop_filter(
 }
 
 /// Value tree to search through the complexity space of some filter pipeline.
+///
 /// A filter pipeline has a bit more structure than just a list of filters,
 /// because the output of each filter feeds into the next one.
 /// The input type is fixed, but the final output can be any data type.

--- a/tiledb/api/src/query/read/output/mod.rs
+++ b/tiledb/api/src/query/read/output/mod.rs
@@ -668,6 +668,7 @@ impl<'data, C> TryFrom<RawReadOutput<'data, C>>
 }
 
 /// A set of `QueryBuffers` which can be correctly used by `FixedDataIterator`.
+///
 /// A `QueryBuffers` instance can be wrapped this way if it has
 /// `cell_structure: CellStructure::Fixed(nz)` for some `1 < nz < u32::MAX`,
 /// and also does not own the `data` buffer.
@@ -681,6 +682,7 @@ impl<'data, C> QueryBuffersFixedDataIterable<'data, C> {
 }
 
 /// A set of `QueryBuffers` which can be correctly used by `VarDataIterator`.
+///
 /// A `QueryBuffers` instance can be wrapped this way if it has
 /// `cell_structure: CellStructure::Var(_)`
 /// and also does not own the `data` buffer.

--- a/tiledb/api/src/query/read/raw.rs
+++ b/tiledb/api/src/query/read/raw.rs
@@ -434,6 +434,7 @@ typed_read_handle!(Int8: i8, Int16: i16, Int32: i32, Int64: i64);
 typed_read_handle!(Float32: f32, Float64: f64);
 
 /// Reads query results into a raw buffer.
+///
 /// This is the most flexible way to read data but also the most cumbersome.
 /// Recommended usage is to run the query one step at a time, and borrow
 /// the buffers between each step to process intermediate results.
@@ -557,6 +558,7 @@ where
 }
 
 /// Reads query results into raw buffers.
+///
 /// This is the most flexible way to read data but also the most cumbersome.
 /// Recommended usage is to run the query one step at a time, and borrow
 /// the buffers between each step to process intermediate results.

--- a/tiledb/api/src/query/strategy.rs
+++ b/tiledb/api/src/query/strategy.rs
@@ -31,6 +31,7 @@ use crate::{
 };
 
 /// Represents the write query input for a single field.
+///
 /// For each variant, the outer Vec is the collection of records, and the interior is value in the
 /// cell for the record. Fields with cell val num of 1 are flat, and other cell values use the
 /// inner Vec. For fixed-size attributes, the inner Vecs shall all have the same length; for

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -24,7 +24,9 @@ use crate::{
 type BoxedValueTree<T> = Box<dyn ValueTree<Value = T>>;
 
 /// Returns a base set of requirements for filters to be used
-/// in write queries. Requirements are chosen to either avoid
+/// in write queries.
+///
+/// Requirements are chosen to either avoid
 /// constraints on input (e.g. positive delta filtering requires
 /// sorted input, float scale filtering is not invertible)
 /// or to avoid issues in the tiledb core library in as
@@ -46,6 +48,7 @@ pub fn query_write_filter_requirements() -> FilterRequirements {
 }
 
 /// Returns a base set of schema requirements for running a query.
+///
 /// Requirements are chosen to either avoid constraints on write input
 /// or to avoid issues in the tiledb core library in as many scenarios as possible.
 pub fn query_write_schema_requirements(

--- a/tiledb/sys/ignored.rs
+++ b/tiledb/sys/ignored.rs
@@ -24,6 +24,12 @@ extern "C" {
         out: *mut FILE,
     ) -> i32;
 
+    pub fn tiledb_array_schema_dump(
+        ctx: *mut tiledb_ctx_t,
+        array_schema: *const tiledb_array_schema_t,
+        out: *mut FILE,
+    ) -> i32;
+
     pub fn tiledb_as_built_dump(
         out: *mut *mut tiledb_string_t,
     ) -> capi_return_t;

--- a/tiledb/sys/ignored.rs
+++ b/tiledb/sys/ignored.rs
@@ -28,7 +28,7 @@ extern "C" {
         ctx: *mut tiledb_ctx_t,
         array_schema: *const tiledb_array_schema_t,
         out: *mut FILE,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_as_built_dump(
         out: *mut *mut tiledb_string_t,

--- a/tiledb/sys/ignored.rs
+++ b/tiledb/sys/ignored.rs
@@ -24,12 +24,6 @@ extern "C" {
         out: *mut FILE,
     ) -> i32;
 
-    pub fn tiledb_array_schema_dump(
-        ctx: *mut tiledb_ctx_t,
-        array_schema: *const tiledb_array_schema_t,
-        out: *mut FILE,
-    ) -> i32;
-
     pub fn tiledb_as_built_dump(
         out: *mut *mut tiledb_string_t,
     ) -> capi_return_t;

--- a/tiledb/sys/src/array_type.rs
+++ b/tiledb/sys/src/array_type.rs
@@ -1,13 +1,14 @@
 use crate::capi_enum::tiledb_array_type_t;
+use crate::types::capi_return_t;
 
 extern "C" {
     pub fn tiledb_array_type_to_str(
         array_type: tiledb_array_type_t,
         str_: *mut *const ::std::os::raw::c_char,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_type_from_str(
         str_: *const ::std::os::raw::c_char,
         array_type: *mut tiledb_array_type_t,
-    ) -> i32;
+    ) -> capi_return_t;
 }

--- a/tiledb/sys/src/schema.rs
+++ b/tiledb/sys/src/schema.rs
@@ -2,8 +2,8 @@ use crate::capi_enum::{
     tiledb_array_type_t, tiledb_encryption_type_t, tiledb_layout_t,
 };
 use crate::types::{
-    tiledb_array_schema_t, tiledb_attribute_t, tiledb_ctx_t, tiledb_domain_t,
-    tiledb_filter_list_t,
+    capi_return_t, tiledb_array_schema_t, tiledb_attribute_t, tiledb_ctx_t,
+    tiledb_domain_t, tiledb_filter_list_t,
 };
 
 extern "C" {
@@ -11,7 +11,7 @@ extern "C" {
         ctx: *mut tiledb_ctx_t,
         array_type: tiledb_array_type_t,
         array_schema: *mut *mut tiledb_array_schema_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_free(
         array_schema: *mut *mut tiledb_array_schema_t,
@@ -21,78 +21,78 @@ extern "C" {
         ctx: *mut tiledb_ctx_t,
         array_schema: *mut tiledb_array_schema_t,
         attr: *mut tiledb_attribute_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_set_allows_dups(
         ctx: *mut tiledb_ctx_t,
         array_schema: *mut tiledb_array_schema_t,
         allows_dups: ::std::os::raw::c_int,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_get_allows_dups(
         ctx: *mut tiledb_ctx_t,
         array_schema: *mut tiledb_array_schema_t,
         allows_dups: *mut ::std::os::raw::c_int,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_get_version(
         ctx: *mut tiledb_ctx_t,
         array_schema: *mut tiledb_array_schema_t,
         version: *mut u32,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_set_domain(
         ctx: *mut tiledb_ctx_t,
         array_schema: *mut tiledb_array_schema_t,
         domain: *mut tiledb_domain_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_set_capacity(
         ctx: *mut tiledb_ctx_t,
         array_schema: *mut tiledb_array_schema_t,
         capacity: u64,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_set_cell_order(
         ctx: *mut tiledb_ctx_t,
         array_schema: *mut tiledb_array_schema_t,
         cell_order: tiledb_layout_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_set_tile_order(
         ctx: *mut tiledb_ctx_t,
         array_schema: *mut tiledb_array_schema_t,
         tile_order: tiledb_layout_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_set_coords_filter_list(
         ctx: *mut tiledb_ctx_t,
         array_schema: *mut tiledb_array_schema_t,
         filter_list: *mut tiledb_filter_list_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_set_offsets_filter_list(
         ctx: *mut tiledb_ctx_t,
         array_schema: *mut tiledb_array_schema_t,
         filter_list: *mut tiledb_filter_list_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_set_validity_filter_list(
         ctx: *mut tiledb_ctx_t,
         array_schema: *mut tiledb_array_schema_t,
         filter_list: *mut tiledb_filter_list_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_check(
         ctx: *mut tiledb_ctx_t,
         array_schema: *mut tiledb_array_schema_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_load(
         ctx: *mut tiledb_ctx_t,
         array_uri: *const ::std::os::raw::c_char,
         array_schema: *mut *mut tiledb_array_schema_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_load_with_key(
         ctx: *mut tiledb_ctx_t,
@@ -107,74 +107,74 @@ extern "C" {
         ctx: *mut tiledb_ctx_t,
         array_schema: *const tiledb_array_schema_t,
         array_type: *mut tiledb_array_type_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_get_capacity(
         ctx: *mut tiledb_ctx_t,
         array_schema: *const tiledb_array_schema_t,
         capacity: *mut u64,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_get_cell_order(
         ctx: *mut tiledb_ctx_t,
         array_schema: *const tiledb_array_schema_t,
         cell_order: *mut tiledb_layout_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_get_coords_filter_list(
         ctx: *mut tiledb_ctx_t,
         array_schema: *mut tiledb_array_schema_t,
         filter_list: *mut *mut tiledb_filter_list_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_get_offsets_filter_list(
         ctx: *mut tiledb_ctx_t,
         array_schema: *mut tiledb_array_schema_t,
         filter_list: *mut *mut tiledb_filter_list_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_get_validity_filter_list(
         ctx: *mut tiledb_ctx_t,
         array_schema: *mut tiledb_array_schema_t,
         filter_list: *mut *mut tiledb_filter_list_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_get_domain(
         ctx: *mut tiledb_ctx_t,
         array_schema: *const tiledb_array_schema_t,
         domain: *mut *mut tiledb_domain_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_get_tile_order(
         ctx: *mut tiledb_ctx_t,
         array_schema: *const tiledb_array_schema_t,
         tile_order: *mut tiledb_layout_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_get_attribute_num(
         ctx: *mut tiledb_ctx_t,
         array_schema: *const tiledb_array_schema_t,
         attribute_num: *mut u32,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_get_attribute_from_index(
         ctx: *mut tiledb_ctx_t,
         array_schema: *const tiledb_array_schema_t,
         index: u32,
         attr: *mut *mut tiledb_attribute_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_get_attribute_from_name(
         ctx: *mut tiledb_ctx_t,
         array_schema: *const tiledb_array_schema_t,
         name: *const ::std::os::raw::c_char,
         attr: *mut *mut tiledb_attribute_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_schema_has_attribute(
         ctx: *mut tiledb_ctx_t,
         array_schema: *const tiledb_array_schema_t,
         name: *const ::std::os::raw::c_char,
         has_attr: *mut i32,
-    ) -> i32;
+    ) -> capi_return_t;
 }

--- a/tiledb/test-utils/src/strategy/records.rs
+++ b/tiledb/test-utils/src/strategy/records.rs
@@ -11,7 +11,9 @@ use proptest::strategy::{NewTree, ValueTree};
 use proptest::test_runner::TestRunner;
 
 /// Create a strategy to generate `Vec`s containing elements drawn from `element` and with a size
-/// range given by `size`.  In contrast to `proptest::collection::vec`, value trees produced by
+/// range given by `size`.
+///
+/// In contrast to `proptest::collection::vec`, value trees produced by
 /// this strategy do not attempt to shrink any of the elements of the vector, instead shrinking
 /// by more rapidly searching for the minimum set of elements needed to produce a failure.
 pub fn vec_records_strategy<T>(

--- a/tiledb/utils/src/option.rs
+++ b/tiledb/utils/src/option.rs
@@ -1,6 +1,7 @@
 use std::num::*;
 
 /// Trait for comparing types which can express optional data.
+///
 /// The `option_subset` method should return true if it finds that all required data
 /// of two objects are equal, and the non-required data are either equal or not set
 /// for the method receiver.  For objects which only have required data, this should be


### PR DESCRIPTION
This lint was introduced into Rust nightly recently.

https://rust-lang.github.io/rust-clippy/master/index.html#/too_long_first_doc_paragraph

"Documentation will show the first paragraph of the doscstring in the summary page of a module, so having a nice, short summary in the first paragraph is part of writing good docs."