### PR TITLE
Pull out testing / generally useful code from the aggregate API PR

### DIFF
--- a/tiledb/api/src/array/attribute/mod.rs
+++ b/tiledb/api/src/array/attribute/mod.rs
@@ -740,6 +740,9 @@ mod test {
             };
             let attr = spec.create(&ctx).unwrap();
             assert_eq!(CellValNum::single(), attr.cell_val_num().unwrap());
+
+            // not nullable by default
+            assert!(!attr.is_nullable().unwrap());
         }
         {
             let spec = AttributeData {
@@ -749,6 +752,9 @@ mod test {
             };
             let attr = spec.create(&ctx).unwrap();
             assert_eq!(CellValNum::single(), attr.cell_val_num().unwrap());
+
+            // not nullable by default
+            assert!(!attr.is_nullable().unwrap());
         }
     }
 

--- a/tiledb/api/src/array/domain/strategy.rs
+++ b/tiledb/api/src/array/domain/strategy.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use proptest::prelude::*;
+use proptest::sample::select;
 
 use crate::array::dimension::strategy::Requirements as DimensionRequirements;
 use crate::array::{ArrayType, DimensionData, DomainData};
@@ -112,6 +113,13 @@ impl Arbitrary for DomainData {
 
     fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
         prop_domain(args.clone()).boxed()
+    }
+}
+
+impl DomainData {
+    /// Returns a strategy which chooses any dimension from `self.`
+    pub fn strat_dimension(&self) -> impl Strategy<Value = DimensionData> {
+        select(self.dimension.clone())
     }
 }
 

--- a/tiledb/api/src/error.rs
+++ b/tiledb/api/src/error.rs
@@ -200,6 +200,7 @@ pub enum Error {
 }
 
 impl Error {
+    #[cfg(test)]
     pub(crate) fn physical_type_mismatch<T, U>() -> Self {
         Self::Datatype(DatatypeErrorKind::PhysicalTypeMismatch {
             requested_type: std::any::type_name::<T>().to_owned(),

--- a/tiledb/api/src/error.rs
+++ b/tiledb/api/src/error.rs
@@ -33,6 +33,10 @@ pub enum DatatypeErrorKind {
         user_type: String,
         tiledb_type: Datatype,
     },
+    PhysicalTypeMismatch {
+        requested_type: String,
+        actual_type: String,
+    },
     UnexpectedCellStructure {
         context: Option<String>,
         found: CellValNum,
@@ -62,6 +66,16 @@ impl Display for DatatypeErrorKind {
                     f,
                     "Type mismatch: requested {}, but found {}",
                     user_type, tiledb_type
+                )
+            }
+            DatatypeErrorKind::PhysicalTypeMismatch {
+                requested_type,
+                actual_type,
+            } => {
+                write!(
+                    f,
+                    "Physical type mismatch: requested {}, but found {}",
+                    requested_type, actual_type
                 )
             }
             DatatypeErrorKind::UnexpectedCellStructure {
@@ -183,6 +197,15 @@ pub enum Error {
     /// Any error which cannot be categorized as any of the above
     #[error("{0}")]
     Other(String),
+}
+
+impl Error {
+    pub(crate) fn physical_type_mismatch<T, U>() -> Self {
+        Self::Datatype(DatatypeErrorKind::PhysicalTypeMismatch {
+            requested_type: std::any::type_name::<T>().to_owned(),
+            actual_type: std::any::type_name::<U>().to_owned(),
+        })
+    }
 }
 
 impl From<RawError> for Error {

--- a/tiledb/api/src/error.rs
+++ b/tiledb/api/src/error.rs
@@ -200,7 +200,6 @@ pub enum Error {
 }
 
 impl Error {
-    #[cfg(test)]
     pub(crate) fn physical_type_mismatch<T, U>() -> Self {
         Self::Datatype(DatatypeErrorKind::PhysicalTypeMismatch {
             requested_type: std::any::type_name::<T>().to_owned(),

--- a/tiledb/api/src/lib.rs
+++ b/tiledb/api/src/lib.rs
@@ -60,6 +60,9 @@ pub mod vfs;
 #[cfg(feature = "arrow")]
 pub mod arrow;
 
+#[cfg(test)]
+pub mod tests;
+
 pub fn version() -> (i32, i32, i32) {
     let mut major: i32 = 0;
     let mut minor: i32 = 0;

--- a/tiledb/api/src/query/strategy.rs
+++ b/tiledb/api/src/query/strategy.rs
@@ -177,10 +177,12 @@ impl Records for FieldData {
 #[macro_export]
 macro_rules! typed_field_data_go {
     ($field:expr, $data:pat, $then:expr) => {
-        typed_field_data_go!($field, _DT, $data, $then, $then)
+        $crate::typed_field_data_go!($field, _DT, $data, $then, $then)
     };
     ($field:expr, $DT:ident, $data:pat, $fixed:expr, $var:expr) => {
-        typed_field_data_go!($field, $DT, $data, $fixed, $var, $fixed, $var)
+        $crate::typed_field_data_go!(
+            $field, $DT, $data, $fixed, $var, $fixed, $var
+        )
     };
     ($field:expr, $DT:ident, $data:pat, $integral_fixed:expr, $integral_var:expr, $float_fixed:expr, $float_var:expr) => {{
         use $crate::query::strategy::FieldData;

--- a/tiledb/api/src/query/strategy.rs
+++ b/tiledb/api/src/query/strategy.rs
@@ -16,6 +16,7 @@ use tiledb_test_utils::strategy::records::{Records, RecordsValueTree};
 use crate::array::schema::FieldData as SchemaField;
 use crate::array::{ArrayType, CellValNum, SchemaData};
 use crate::datatype::physical::{BitsEq, BitsOrd, IntegralType};
+use crate::error::Error;
 use crate::query::read::output::{
     CellStructureSingleIterator, FixedDataIterator, RawReadOutput,
     TypedRawReadOutput, VarDataIterator,
@@ -72,6 +73,24 @@ macro_rules! typed_field_data {
                 fn from(value: Vec<Vec<$U>>) -> Self {
                     paste! {
                         FieldData::[< Vec $V >](value)
+                    }
+                }
+            }
+
+            impl TryFrom<FieldData> for Vec<$U> {
+                type Error = Error;
+
+                fn try_from(value: FieldData) -> Result<Self, Self::Error> {
+                    if let FieldData::$V(values) = value {
+                        Ok(values)
+                    } else {
+                        crate::typed_field_data_go!(value, DT, _,
+                            {
+                                Err(Error::physical_type_mismatch::<$U, DT>())
+                            },
+                            {
+                                Err(Error::physical_type_mismatch::<$U, Vec<DT>>())
+                            })
                     }
                 }
             }

--- a/tiledb/api/src/tests/examples/mod.rs
+++ b/tiledb/api/src/tests/examples/mod.rs
@@ -6,9 +6,8 @@ use tiledb_test_utils::TestArrayUri;
 
 use crate::array::schema::SchemaData;
 use crate::error::Error;
-use crate::tests::prelude::array::*;
-use crate::tests::prelude::query::strategy::*;
-use crate::tests::prelude::query::*;
+use crate::tests::prelude::*;
+use crate::tests::strategy::prelude::*;
 use crate::{Context, Factory, Result as TileDBResult};
 
 /// Provides methods for creating a schema which can optionally have

--- a/tiledb/api/src/tests/examples/mod.rs
+++ b/tiledb/api/src/tests/examples/mod.rs
@@ -1,0 +1,84 @@
+use std::rc::Rc;
+
+use proptest::prelude::*;
+use proptest::test_runner::TestRunner;
+use tiledb_test_utils::TestArrayUri;
+
+use crate::array::schema::SchemaData;
+use crate::error::Error;
+use crate::tests::prelude::array::*;
+use crate::tests::prelude::query::strategy::*;
+use crate::tests::prelude::query::*;
+use crate::{Context, Factory, Result as TileDBResult};
+
+/// Provides methods for creating a schema which can optionally have
+/// one dimension of each allowed datatype and one attribute of each
+/// allowed `(Datatype, CellValNum, Nullability)` tuple.
+pub mod sparse_all;
+
+pub struct TestArray {
+    _location: Box<dyn TestArrayUri>,
+    pub uri: String,
+    pub context: Context,
+    pub schema: Rc<SchemaData>,
+}
+
+impl TestArray {
+    pub fn new(name: &str, schema: Rc<SchemaData>) -> TileDBResult<Self> {
+        let test_uri = tiledb_test_utils::get_uri_generator()
+            .map_err(|e| Error::Other(e.to_string()))?;
+        let uri = test_uri
+            .with_path(name)
+            .map_err(|e| Error::Other(e.to_string()))?;
+
+        let context = Context::new()?;
+        {
+            let s = schema.create(&context)?;
+            Array::create(&context, &uri, s)?;
+        }
+
+        Ok(TestArray {
+            _location: Box::new(test_uri),
+            uri,
+            context,
+            schema,
+        })
+    }
+
+    fn open(&self, mode: Mode) -> TileDBResult<Array> {
+        Array::open(&self.context, &self.uri, mode)
+    }
+
+    pub fn for_read(&self) -> TileDBResult<Array> {
+        self.open(Mode::Read)
+    }
+
+    pub fn for_write(&mut self) -> TileDBResult<Array> {
+        self.open(Mode::Write)
+    }
+
+    pub fn arbitrary_input(&self, runner: &mut TestRunner) -> WriteInput {
+        match self.schema.array_type {
+            ArrayType::Sparse => {
+                let strat_input =
+                    any_with::<SparseWriteInput>(SparseWriteParameters {
+                        schema: Some(Rc::clone(&self.schema)),
+                        ..Default::default()
+                    });
+
+                WriteInput::Sparse(
+                    strat_input.new_tree(runner).unwrap().current(),
+                )
+            }
+            ArrayType::Dense => todo!(), // probably just mimic the above
+        }
+    }
+
+    pub fn try_insert(&mut self, input: &WriteInput) -> TileDBResult<Array> {
+        let w = input
+            .attach_write(WriteBuilder::new(self.for_write()?)?)?
+            .build();
+        w.submit()?;
+        w.finalize()
+    }
+}

--- a/tiledb/api/src/tests/examples/sparse_all.rs
+++ b/tiledb/api/src/tests/examples/sparse_all.rs
@@ -1,0 +1,148 @@
+use std::rc::Rc;
+
+use crate::array::{
+    ArrayType, AttributeData, CellValNum, DimensionConstraints, DimensionData,
+    DomainData, SchemaData,
+};
+use crate::{physical_type_go, Datatype};
+
+pub type FnAcceptDimension = dyn Fn(&Parameters, Datatype) -> bool;
+pub type FnAcceptAttribute =
+    dyn Fn(&Parameters, Datatype, CellValNum, bool) -> bool;
+
+/// Configures construction of the `sparse_all` schema.
+#[derive(Clone)]
+pub struct Parameters {
+    /// Function which determines whether to add a dimension to the schema.
+    ///
+    /// By default, all types are added as dimensions except `Datatype::StringAscii`.
+    pub fn_accept_dimension: Rc<FnAcceptDimension>,
+
+    /// Function which determines whether to add an attribute to the schema.
+    ///
+    /// By default, all attributes are accepted.
+    pub fn_accept_attribute: Rc<FnAcceptAttribute>,
+}
+
+impl Parameters {
+    fn try_dimension(&self, dt: Datatype) -> bool {
+        if dt == Datatype::StringAscii {
+            // FIXME: "Offsets buffer is not set" for some reason
+            false
+        } else {
+            dt.is_allowed_dimension_type_sparse()
+        }
+    }
+
+    fn try_attribute(
+        &self,
+        _dt: Datatype,
+        _cell_val_num: CellValNum,
+        _is_nullable: bool,
+    ) -> bool {
+        true
+    }
+
+    fn default_accept_dimension(params: &Self, dt: Datatype) -> bool {
+        params.try_dimension(dt)
+    }
+
+    fn default_accept_attribute(
+        params: &Self,
+        dt: Datatype,
+        cell_val_num: CellValNum,
+        is_nullable: bool,
+    ) -> bool {
+        params.try_attribute(dt, cell_val_num, is_nullable)
+    }
+}
+
+impl Default for Parameters {
+    fn default() -> Self {
+        Parameters {
+            fn_accept_dimension: Rc::new(Self::default_accept_dimension),
+            fn_accept_attribute: Rc::new(Self::default_accept_attribute),
+        }
+    }
+}
+
+/// Returns a sparse array schema which contains up to one dimension for each
+/// allowed datatype and up to one attribute for each allowed
+/// `Datatype`, `CellValNum`, and nullability.
+pub fn schema(params: Parameters) -> SchemaData {
+    // build a schema with one dimension/attribute of all possible types
+    let mut dims = vec![];
+    let mut atts = vec![];
+    for dt in Datatype::iter() {
+        if (params.fn_accept_dimension)(&params, dt) {
+            let constraints = if dt != Datatype::StringAscii {
+                physical_type_go!(dt, DT, {
+                    DimensionConstraints::from((&[0 as DT, 100 as DT], None))
+                })
+            } else {
+                DimensionConstraints::StringAscii
+            };
+            dims.push(DimensionData {
+                name: format!("d_{}", dt),
+                datatype: dt,
+                cell_val_num: None,
+                filters: None,
+                constraints,
+            });
+        }
+
+        let mut attfunc = |cell_val_num, is_nullable| {
+            let tag_cvn = match cell_val_num {
+                CellValNum::Fixed(nz) if nz.get() == 1 => "single".to_owned(),
+                CellValNum::Fixed(nz) => format!("fixed@{}", nz),
+                CellValNum::Var => "var".to_owned(),
+            };
+            let tag_nullable = if is_nullable {
+                "nullable"
+            } else {
+                "not_nullable"
+            };
+
+            atts.push(AttributeData {
+                name: format!("a_{}_{}_{}", dt, tag_cvn, tag_nullable),
+                datatype: dt,
+                nullability: Some(is_nullable),
+                cell_val_num: Some(cell_val_num),
+                fill: None,
+                filters: Default::default(),
+            });
+        };
+
+        if (params.fn_accept_attribute)(
+            &params,
+            dt,
+            CellValNum::single(),
+            false,
+        ) {
+            attfunc(CellValNum::single(), false);
+        }
+        if (params.fn_accept_attribute)(&params, dt, CellValNum::single(), true)
+        {
+            attfunc(CellValNum::single(), true);
+        }
+        if (params.fn_accept_attribute)(&params, dt, CellValNum::Var, false) {
+            attfunc(CellValNum::Var, false);
+        }
+        if (params.fn_accept_attribute)(&params, dt, CellValNum::Var, true) {
+            attfunc(CellValNum::Var, true);
+        }
+    }
+
+    SchemaData {
+        array_type: ArrayType::Sparse,
+        domain: DomainData { dimension: dims },
+        capacity: None,
+        cell_order: None,
+        tile_order: None,
+        allow_duplicates: None,
+        attributes: atts,
+        coordinate_filters: Default::default(),
+        offsets_filters: Default::default(),
+        nullity_filters: Default::default(),
+    }
+}

--- a/tiledb/api/src/tests/mod.rs
+++ b/tiledb/api/src/tests/mod.rs
@@ -1,0 +1,29 @@
+pub mod examples;
+
+pub mod prelude {
+    pub mod array {
+        pub use crate::array::attribute::Builder as AttributeBuilder;
+        pub use crate::array::dimension::Builder as DimensionBuilder;
+        pub use crate::array::domain::Builder as DomainBuilder;
+        pub use crate::array::schema::Builder as SchemaBuilder;
+        pub use crate::array::{
+            Array, ArrayType, Attribute, CellValNum, Dimension, Domain, Mode,
+            Schema,
+        };
+    }
+
+    pub mod query {
+        pub use crate::query::{
+            Query, QueryBuilder, QueryLayout, ReadBuilder, ReadQuery,
+            WriteBuilder, WriteQuery,
+        };
+
+        pub mod strategy {
+            pub use crate::query::strategy::{Cells, FieldData};
+            pub use crate::query::write::strategy::{
+                DenseWriteInput, DenseWriteParameters, SparseWriteInput,
+                SparseWriteParameters, WriteInput,
+            };
+        }
+    }
+}

--- a/tiledb/api/src/tests/mod.rs
+++ b/tiledb/api/src/tests/mod.rs
@@ -1,29 +1,30 @@
 pub mod examples;
 
 pub mod prelude {
-    pub mod array {
-        pub use crate::array::attribute::Builder as AttributeBuilder;
-        pub use crate::array::dimension::Builder as DimensionBuilder;
-        pub use crate::array::domain::Builder as DomainBuilder;
-        pub use crate::array::schema::Builder as SchemaBuilder;
-        pub use crate::array::{
-            Array, ArrayType, Attribute, CellValNum, Dimension, Domain, Mode,
-            Schema,
-        };
-    }
+    pub use crate::array::attribute::Builder as AttributeBuilder;
+    pub use crate::array::dimension::Builder as DimensionBuilder;
+    pub use crate::array::domain::Builder as DomainBuilder;
+    pub use crate::array::schema::Builder as SchemaBuilder;
+    pub use crate::array::{
+        Array, ArrayType, Attribute, CellValNum, Dimension, Domain, Mode,
+        Schema,
+    };
 
-    pub mod query {
-        pub use crate::query::{
-            Query, QueryBuilder, QueryLayout, ReadBuilder, ReadQuery,
-            WriteBuilder, WriteQuery,
-        };
+    pub use crate::query::{
+        Query, QueryBuilder, QueryLayout, ReadBuilder, ReadQuery, WriteBuilder,
+        WriteQuery,
+    };
+}
 
-        pub mod strategy {
-            pub use crate::query::strategy::{Cells, FieldData};
-            pub use crate::query::write::strategy::{
-                DenseWriteInput, DenseWriteParameters, SparseWriteInput,
-                SparseWriteParameters, WriteInput,
-            };
-        }
+pub mod strategy {
+    pub mod prelude {
+        // NB: this is hardly exhaustive, feel free to add stuff, this is just what has been needed
+        // so far
+
+        pub use crate::query::strategy::{Cells, FieldData};
+        pub use crate::query::write::strategy::{
+            DenseWriteInput, DenseWriteParameters, SparseWriteInput,
+            SparseWriteParameters, WriteInput,
+        };
     }
 }


### PR DESCRIPTION
The commits in this PR are essentially unrelated to each other, the common theme merely being that these are all changes I made while working on #113 .  I decided to pull them out so aggregates will take up a greater percentage of the lines of code in their introductory PR.

Anyway, looking at this commit-by-commit is not a bad idea; notes on each below.

[Add asserts to attribute_default about nullability](https://github.com/TileDB-Inc/tiledb-rs/commit/70fb2cfccb2636f46317b242178df5fd1e853e71) - we make assumptions about default core library behavior in a few places, so let's make sure if it ever changes we get a concise alert.

[strat_dimension, strat_attribute, strat_field](https://github.com/TileDB-Inc/tiledb-rs/commit/04a381ae9c2d693296d75e57ff5e0a5ac75a88eb) - proptest strategies for picking random schema fields

[impl TryFrom<FieldData> for Vec<_>](https://github.com/TileDB-Inc/tiledb-rs/commit/07617231cf1b33a14740d2188d62c47e6d83a7b2) - for making generic programming with the test data structures a bit easier

[Error::physical_type_mismatch](https://github.com/TileDB-Inc/tiledb-rs/commit/2e950f6e7a0a9b878357ecbf55df958432770a0d) - we have a `TypeMismatch` variant already for matching an incorrect physical type with a `Datatype`, but we don't always have a `Datatype`.

[API crate add module for internal test utilities](https://github.com/TileDB-Inc/tiledb-rs/commit/532449026fab518e2ad6a011804f6b31ab0d6516) - this is the largest change here, our test code has tons of common imports and boilerplate.  We have a bunch of test utils crates, but we need to have something inside the `api` crate in order to avoid circular dependencies.  The `sparse_all` schema is one I will use soon in the aggregates PR and the `TestArray` struct was helpful for avoiding large duplicated code paragraphs that ultimately distract from the actual goal of the tests.