### PR TITLE
Refactor into `tests/examples/quickstart.rs`

### DIFF
--- a/tiledb/api/src/array/dimension/mod.rs
+++ b/tiledb/api/src/array/dimension/mod.rs
@@ -307,6 +307,23 @@ dimension_constraints_impl!(UInt8: u8, UInt16: u16, UInt32: u32, UInt64: u64);
 dimension_constraints_impl!(Float32: f32, Float64: f64);
 
 impl DimensionConstraints {
+    /// Returns a [Datatype] which represents the physical type of this constraint.
+    pub fn physical_datatype(&self) -> Datatype {
+        match self {
+            Self::UInt8(_, _) => Datatype::UInt8,
+            Self::UInt16(_, _) => Datatype::UInt16,
+            Self::UInt32(_, _) => Datatype::UInt32,
+            Self::UInt64(_, _) => Datatype::UInt64,
+            Self::Int8(_, _) => Datatype::Int8,
+            Self::Int16(_, _) => Datatype::Int16,
+            Self::Int32(_, _) => Datatype::Int32,
+            Self::Int64(_, _) => Datatype::Int64,
+            Self::Float32(_, _) => Datatype::Float32,
+            Self::Float64(_, _) => Datatype::Float64,
+            Self::StringAscii => Datatype::StringAscii,
+        }
+    }
+
     pub fn cell_val_num(&self) -> CellValNum {
         match self {
             DimensionConstraints::StringAscii => CellValNum::Var,

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -940,34 +940,10 @@ pub mod tests {
         test_uri: &dyn TestArrayUri,
         ctx: &Context,
     ) -> TileDBResult<String> {
-        let schema = SchemaData {
-            array_type: ArrayType::Sparse,
-            domain: DomainData {
-                dimension: vec![
-                    DimensionData {
-                        name: "rows".to_owned(),
-                        datatype: Datatype::StringAscii,
-                        constraints: DimensionConstraints::StringAscii,
-                        filters: None,
-                    },
-                    DimensionData {
-                        name: "cols".to_owned(),
-                        datatype: Datatype::Int32,
-                        constraints: ([1i32, 4], 4i32).into(),
-                        filters: None,
-                    },
-                ],
-            },
-            attributes: vec![AttributeData {
-                name: "a".to_owned(),
-                datatype: Datatype::Int32,
-                ..Default::default()
-            }],
-            tile_order: Some(TileOrder::RowMajor),
-            cell_order: Some(CellOrder::RowMajor),
-
-            ..Default::default()
-        };
+        let schema =
+            crate::tests::examples::quickstart::Builder::new(ArrayType::Sparse)
+                .with_rows(DimensionConstraints::StringAscii)
+                .build();
 
         let schema = schema.create(ctx)?;
 

--- a/tiledb/api/src/tests/examples/mod.rs
+++ b/tiledb/api/src/tests/examples/mod.rs
@@ -10,9 +10,7 @@ use crate::tests::prelude::*;
 use crate::tests::strategy::prelude::*;
 use crate::{Context, Factory, Result as TileDBResult};
 
-/// Provides methods for creating a schema which can optionally have
-/// one dimension of each allowed datatype and one attribute of each
-/// allowed `(Datatype, CellValNum, Nullability)` tuple.
+pub mod quickstart;
 pub mod sparse_all;
 
 pub struct TestArray {

--- a/tiledb/api/src/tests/examples/quickstart.rs
+++ b/tiledb/api/src/tests/examples/quickstart.rs
@@ -1,0 +1,60 @@
+//! Provides methods for creating the "quickstart" example schema.
+
+use crate::tests::prelude::*;
+
+pub struct Builder {
+    array_type: ArrayType,
+    rows: DimensionConstraints,
+    cols: DimensionConstraints,
+}
+
+impl Builder {
+    pub fn new(array_type: ArrayType) -> Self {
+        Builder {
+            array_type,
+            rows: DimensionConstraints::Int32([1, 4], Some(4)),
+            cols: DimensionConstraints::Int32([1, 4], Some(4)),
+        }
+    }
+
+    pub fn with_rows(mut self, domain: DimensionConstraints) -> Self {
+        self.rows = domain;
+        self
+    }
+
+    pub fn with_cols(mut self, domain: DimensionConstraints) -> Self {
+        self.cols = domain;
+        self
+    }
+
+    pub fn build(self) -> SchemaData {
+        SchemaData {
+            array_type: self.array_type,
+            domain: DomainData {
+                dimension: vec![
+                    DimensionData {
+                        name: "rows".to_owned(),
+                        datatype: self.rows.physical_datatype(),
+                        constraints: self.rows,
+                        filters: None,
+                    },
+                    DimensionData {
+                        name: "cols".to_owned(),
+                        datatype: self.cols.physical_datatype(),
+                        constraints: self.cols,
+                        filters: None,
+                    },
+                ],
+            },
+            attributes: vec![AttributeData {
+                name: "a".to_owned(),
+                datatype: Datatype::Int32,
+                ..Default::default()
+            }],
+            tile_order: Some(TileOrder::RowMajor),
+            cell_order: Some(CellOrder::RowMajor),
+
+            ..Default::default()
+        }
+    }
+}

--- a/tiledb/api/src/tests/examples/sparse_all.rs
+++ b/tiledb/api/src/tests/examples/sparse_all.rs
@@ -1,3 +1,7 @@
+//! Provides methods for creating a schema which can optionally have
+//! one dimension of each allowed datatype and one attribute of each
+//! allowed `(Datatype, CellValNum, Nullability)` tuple.
+
 use std::rc::Rc;
 
 use crate::array::{

--- a/tiledb/api/src/tests/mod.rs
+++ b/tiledb/api/src/tests/mod.rs
@@ -1,14 +1,19 @@
 pub mod examples;
 
 pub mod prelude {
-    pub use crate::array::attribute::Builder as AttributeBuilder;
-    pub use crate::array::dimension::Builder as DimensionBuilder;
-    pub use crate::array::domain::Builder as DomainBuilder;
-    pub use crate::array::schema::Builder as SchemaBuilder;
-    pub use crate::array::{
-        Array, ArrayType, Attribute, CellValNum, Dimension, Domain, Mode,
-        Schema,
+    pub use crate::array::attribute::{
+        AttributeData, Builder as AttributeBuilder,
     };
+    pub use crate::array::dimension::{
+        Builder as DimensionBuilder, DimensionConstraints, DimensionData,
+    };
+    pub use crate::array::domain::{Builder as DomainBuilder, DomainData};
+    pub use crate::array::schema::{Builder as SchemaBuilder, SchemaData};
+    pub use crate::array::{
+        Array, ArrayType, Attribute, CellOrder, CellValNum, Dimension, Domain,
+        Mode, Schema, TileOrder,
+    };
+    pub use crate::Datatype;
 
     pub use crate::query::{
         Query, QueryBuilder, QueryLayout, ReadBuilder, ReadQuery, WriteBuilder,


### PR DESCRIPTION
This is similar to what we have done in `tables`, i.e. put this example schema in a place where it is easy to re-use throughout our many test modules.