### PR TITLE
Configure array schema proptest constants using environment; and some incidentals

### DIFF
--- a/tiledb/api/src/array/domain/strategy.rs
+++ b/tiledb/api/src/array/domain/strategy.rs
@@ -25,7 +25,7 @@ impl Requirements {
     }
 
     pub fn max_dimensions_default() -> usize {
-        const DEFAULT_MAX_DIMENSIONS: usize = 1;
+        const DEFAULT_MAX_DIMENSIONS: usize = 3;
 
         let env = "TILEDB_STRATEGY_DOMAIN_PARAMETERS_DIMENSIONS_MAX";
         crate::tests::env::<usize>(env).unwrap_or(DEFAULT_MAX_DIMENSIONS)

--- a/tiledb/api/src/array/domain/strategy.rs
+++ b/tiledb/api/src/array/domain/strategy.rs
@@ -17,6 +17,11 @@ pub struct Requirements {
 }
 
 impl Requirements {
+    pub fn env_max_dimensions() -> Option<usize> {
+        let env = "TILEDB_STRATEGY_DOMAIN_PARAMETERS_DIMENSIONS_MAX";
+        crate::env::parse::<usize>(env)
+    }
+
     pub fn min_dimensions_default() -> usize {
         const DEFAULT_MIN_DIMENSIONS: usize = 1;
 
@@ -25,10 +30,8 @@ impl Requirements {
     }
 
     pub fn max_dimensions_default() -> usize {
-        const DEFAULT_MAX_DIMENSIONS: usize = 2;
-
-        let env = "TILEDB_STRATEGY_DOMAIN_PARAMETERS_DIMENSIONS_MAX";
-        crate::env::parse::<usize>(env).unwrap_or(DEFAULT_MAX_DIMENSIONS)
+        const DEFAULT_MAX_DIMENSIONS: usize = 8;
+        Self::env_max_dimensions().unwrap_or(DEFAULT_MAX_DIMENSIONS)
     }
 
     pub fn cells_per_tile_limit_default() -> usize {

--- a/tiledb/api/src/array/domain/strategy.rs
+++ b/tiledb/api/src/array/domain/strategy.rs
@@ -21,21 +21,21 @@ impl Requirements {
         const DEFAULT_MIN_DIMENSIONS: usize = 1;
 
         let env = "TILEDB_STRATEGY_DOMAIN_PARAMETERS_DIMENSIONS_MIN";
-        crate::tests::env::<usize>(env).unwrap_or(DEFAULT_MIN_DIMENSIONS)
+        crate::env::parse::<usize>(env).unwrap_or(DEFAULT_MIN_DIMENSIONS)
     }
 
     pub fn max_dimensions_default() -> usize {
-        const DEFAULT_MAX_DIMENSIONS: usize = 3;
+        const DEFAULT_MAX_DIMENSIONS: usize = 2;
 
         let env = "TILEDB_STRATEGY_DOMAIN_PARAMETERS_DIMENSIONS_MAX";
-        crate::tests::env::<usize>(env).unwrap_or(DEFAULT_MAX_DIMENSIONS)
+        crate::env::parse::<usize>(env).unwrap_or(DEFAULT_MAX_DIMENSIONS)
     }
 
     pub fn cells_per_tile_limit_default() -> usize {
         const DEFAULT_CELLS_PER_TILE_LIMIT: usize = 1024 * 32;
 
         let env = "TILEDB_STRATEGY_DOMAIN_PARAMETERS_CELLS_PER_TILE_LIMIT";
-        crate::tests::env::<usize>(env).unwrap_or(DEFAULT_CELLS_PER_TILE_LIMIT)
+        crate::env::parse::<usize>(env).unwrap_or(DEFAULT_CELLS_PER_TILE_LIMIT)
     }
 }
 

--- a/tiledb/api/src/array/domain/strategy.rs
+++ b/tiledb/api/src/array/domain/strategy.rs
@@ -17,19 +17,35 @@ pub struct Requirements {
 }
 
 impl Requirements {
-    pub const DEFAULT_MIN_DIMENSIONS: usize = 1;
-    pub const DEFAULT_MAX_DIMENSIONS: usize = 8;
+    pub fn min_dimensions_default() -> usize {
+        const DEFAULT_MIN_DIMENSIONS: usize = 1;
 
-    pub const DEFAULT_CELLS_PER_TILE_LIMIT: usize = 1024 * 32;
+        let env = "TILEDB_STRATEGY_DOMAIN_PARAMETERS_DIMENSIONS_MIN";
+        crate::tests::env::<usize>(env).unwrap_or(DEFAULT_MIN_DIMENSIONS)
+    }
+
+    pub fn max_dimensions_default() -> usize {
+        const DEFAULT_MAX_DIMENSIONS: usize = 1;
+
+        let env = "TILEDB_STRATEGY_DOMAIN_PARAMETERS_DIMENSIONS_MAX";
+        crate::tests::env::<usize>(env).unwrap_or(DEFAULT_MAX_DIMENSIONS)
+    }
+
+    pub fn cells_per_tile_limit_default() -> usize {
+        const DEFAULT_CELLS_PER_TILE_LIMIT: usize = 1024 * 32;
+
+        let env = "TILEDB_STRATEGY_DOMAIN_PARAMETERS_CELLS_PER_TILE_LIMIT";
+        crate::tests::env::<usize>(env).unwrap_or(DEFAULT_CELLS_PER_TILE_LIMIT)
+    }
 }
 
 impl Default for Requirements {
     fn default() -> Self {
         Requirements {
             array_type: None,
-            num_dimensions: Self::DEFAULT_MIN_DIMENSIONS
-                ..=Self::DEFAULT_MAX_DIMENSIONS,
-            cells_per_tile_limit: Self::DEFAULT_CELLS_PER_TILE_LIMIT,
+            num_dimensions: Self::min_dimensions_default()
+                ..=Self::max_dimensions_default(),
+            cells_per_tile_limit: Self::cells_per_tile_limit_default(),
             dimension: None,
         }
     }
@@ -179,6 +195,6 @@ mod tests {
         }
         let last = value.current();
         assert_ne!(init, last);
-        assert_eq!(Requirements::DEFAULT_MIN_DIMENSIONS, last.dimension.len());
+        assert_eq!(1, last.dimension.len());
     }
 }

--- a/tiledb/api/src/array/schema/strategy.rs
+++ b/tiledb/api/src/array/schema/strategy.rs
@@ -40,7 +40,7 @@ impl Requirements {
     }
 
     pub fn max_attributes_default() -> usize {
-        const DEFAULT_MAX_ATTRIBUTES: usize = 32;
+        const DEFAULT_MAX_ATTRIBUTES: usize = 8;
 
         let env = "TILEDB_STRATEGY_SCHEMA_PARAMETERS_ATTRIBUTES_MAX";
         crate::tests::env::<usize>(env).unwrap_or(DEFAULT_MAX_ATTRIBUTES)

--- a/tiledb/api/src/array/schema/strategy.rs
+++ b/tiledb/api/src/array/schema/strategy.rs
@@ -36,27 +36,27 @@ impl Requirements {
         const DEFAULT_MIN_ATTRIBUTES: usize = 1;
 
         let env = "TILEDB_STRATEGY_SCHEMA_PARAMETERS_ATTRIBUTES_MIN";
-        crate::tests::env::<usize>(env).unwrap_or(DEFAULT_MIN_ATTRIBUTES)
+        crate::env::parse::<usize>(env).unwrap_or(DEFAULT_MIN_ATTRIBUTES)
     }
 
     pub fn max_attributes_default() -> usize {
         const DEFAULT_MAX_ATTRIBUTES: usize = 8;
 
         let env = "TILEDB_STRATEGY_SCHEMA_PARAMETERS_ATTRIBUTES_MAX";
-        crate::tests::env::<usize>(env).unwrap_or(DEFAULT_MAX_ATTRIBUTES)
+        crate::env::parse::<usize>(env).unwrap_or(DEFAULT_MAX_ATTRIBUTES)
     }
 
     pub fn min_sparse_tile_capacity_default() -> u64 {
         pub const DEFAULT_MIN_SPARSE_TILE_CAPACITY: u64 = 1;
 
         let env = "TILEDB_STRATEGY_SCHEMA_PARAMETERS_SPARSE_TILE_CAPACITY_MIN";
-        crate::tests::env::<u64>(env)
+        crate::env::parse::<u64>(env)
             .unwrap_or(DEFAULT_MIN_SPARSE_TILE_CAPACITY)
     }
 
     pub fn max_sparse_tile_capacity_default() -> u64 {
         let env = "TILEDB_STRATEGY_SCHEMA_PARAMETERS_SPARSE_TILE_CAPACITY_MIN";
-        crate::tests::env::<u64>(env)
+        crate::env::parse::<u64>(env)
             .unwrap_or(DomainRequirements::cells_per_tile_limit_default() as u64)
     }
 }

--- a/tiledb/api/src/array/schema/strategy.rs
+++ b/tiledb/api/src/array/schema/strategy.rs
@@ -47,7 +47,7 @@ impl Requirements {
     }
 
     pub fn min_sparse_tile_capacity_default() -> u64 {
-        pub const DEFAULT_MIN_SPARSE_TILE_CAPACITY: u64 = 1;
+        const DEFAULT_MIN_SPARSE_TILE_CAPACITY: u64 = 1;
 
         let env = "TILEDB_STRATEGY_SCHEMA_PARAMETERS_SPARSE_TILE_CAPACITY_MIN";
         crate::env::parse::<u64>(env)

--- a/tiledb/api/src/array/schema/strategy.rs
+++ b/tiledb/api/src/array/schema/strategy.rs
@@ -32,26 +32,47 @@ pub struct Requirements {
 }
 
 impl Requirements {
-    pub const DEFAULT_MIN_ATTRIBUTES: usize = 1;
-    pub const DEFAULT_MAX_ATTRIBUTES: usize = 32;
+    pub fn min_attributes_default() -> usize {
+        const DEFAULT_MIN_ATTRIBUTES: usize = 1;
 
-    pub const DEFAULT_MIN_SPARSE_TILE_CAPACITY: u64 = 1;
-    pub const DEFAULT_MAX_SPARSE_TILE_CAPACITY: u64 =
-        DomainRequirements::DEFAULT_CELLS_PER_TILE_LIMIT as u64;
+        let env = "TILEDB_STRATEGY_SCHEMA_PARAMETERS_ATTRIBUTES_MIN";
+        crate::tests::env::<usize>(env).unwrap_or(DEFAULT_MIN_ATTRIBUTES)
+    }
+
+    pub fn max_attributes_default() -> usize {
+        const DEFAULT_MAX_ATTRIBUTES: usize = 32;
+
+        let env = "TILEDB_STRATEGY_SCHEMA_PARAMETERS_ATTRIBUTES_MAX";
+        crate::tests::env::<usize>(env).unwrap_or(DEFAULT_MAX_ATTRIBUTES)
+    }
+
+    pub fn min_sparse_tile_capacity_default() -> u64 {
+        pub const DEFAULT_MIN_SPARSE_TILE_CAPACITY: u64 = 1;
+
+        let env = "TILEDB_STRATEGY_SCHEMA_PARAMETERS_SPARSE_TILE_CAPACITY_MIN";
+        crate::tests::env::<u64>(env)
+            .unwrap_or(DEFAULT_MIN_SPARSE_TILE_CAPACITY)
+    }
+
+    pub fn max_sparse_tile_capacity_default() -> u64 {
+        let env = "TILEDB_STRATEGY_SCHEMA_PARAMETERS_SPARSE_TILE_CAPACITY_MIN";
+        crate::tests::env::<u64>(env)
+            .unwrap_or(DomainRequirements::cells_per_tile_limit_default() as u64)
+    }
 }
 
 impl Default for Requirements {
     fn default() -> Self {
         Requirements {
             domain: None,
-            num_attributes: Self::DEFAULT_MIN_ATTRIBUTES
-                ..=Self::DEFAULT_MAX_ATTRIBUTES,
+            num_attributes: Self::min_attributes_default()
+                ..=Self::max_attributes_default(),
             attribute_filters: None,
             coordinates_filters: None,
             offsets_filters: None,
             validity_filters: None,
-            sparse_tile_capacity: Self::DEFAULT_MIN_SPARSE_TILE_CAPACITY
-                ..=Self::DEFAULT_MAX_SPARSE_TILE_CAPACITY,
+            sparse_tile_capacity: Self::min_sparse_tile_capacity_default()
+                ..=Self::max_sparse_tile_capacity_default(),
         }
     }
 }

--- a/tiledb/api/src/filter/strategy.rs
+++ b/tiledb/api/src/filter/strategy.rs
@@ -54,6 +54,7 @@ pub struct Requirements {
     pub allow_compression_rle: bool,
     pub allow_compression_dict: bool,
     pub allow_compression_delta: bool,
+    pub allow_webp: bool,
 }
 
 impl Requirements {
@@ -100,6 +101,7 @@ impl Default for Requirements {
             allow_compression_rle: true,
             allow_compression_dict: true,
             allow_compression_delta: true,
+            allow_webp: true,
         }
     }
 }
@@ -288,6 +290,10 @@ fn prop_scalefloat() -> impl Strategy<Value = FilterData> {
 fn prop_webp(
     requirements: &Rc<Requirements>,
 ) -> Option<impl Strategy<Value = FilterData>> {
+    if !requirements.allow_webp {
+        return None;
+    }
+
     if let Some(StrategyContext::SchemaAttribute(
         attribute_type,
         _,

--- a/tiledb/api/src/lib.rs
+++ b/tiledb/api/src/lib.rs
@@ -108,10 +108,10 @@ mod private {
 }
 
 #[cfg(any(test, feature = "proptest-strategies"))]
-pub(crate) mod tests {
+pub(crate) mod env {
     use std::str::FromStr;
 
-    pub fn env<T>(env: &str) -> Option<T>
+    pub fn parse<T>(env: &str) -> Option<T>
     where
         T: FromStr,
     {

--- a/tiledb/api/src/lib.rs
+++ b/tiledb/api/src/lib.rs
@@ -106,3 +106,21 @@ mod private {
 
     pub(crate) use sealed;
 }
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use std::str::FromStr;
+
+    pub fn env<T>(env: &str) -> Option<T>
+    where
+        T: FromStr,
+    {
+        match std::env::var(env) {
+            Ok(value) => Some(
+                T::from_str(&value)
+                    .unwrap_or_else(|_| panic!("Invalid value for {}", env)),
+            ),
+            Err(_) => None,
+        }
+    }
+}

--- a/tiledb/api/src/lib.rs
+++ b/tiledb/api/src/lib.rs
@@ -107,7 +107,7 @@ mod private {
     pub(crate) use sealed;
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "proptest-strategies"))]
 pub(crate) mod tests {
     use std::str::FromStr;
 

--- a/tiledb/api/src/query/strategy.rs
+++ b/tiledb/api/src/query/strategy.rs
@@ -1561,24 +1561,47 @@ pub struct CellsParameters {
     pub schema: Option<CellsStrategySchema>,
     pub min_records: usize,
     pub max_records: usize,
-    pub value_min_var_size: usize,
-    pub value_max_var_size: usize,
+    pub cell_min_var_size: usize,
+    pub cell_max_var_size: usize,
+}
+
+impl CellsParameters {
+    pub fn min_records_default() -> usize {
+        const CELLS_MIN_RECORDS: usize = 0;
+        let env_min = "TILEDB_STRATEGY_CELLS_PARAMETERS_NUM_RECORDS_MIN";
+        crate::tests::env::<usize>(env_min).unwrap_or(CELLS_MIN_RECORDS)
+    }
+
+    pub fn max_records_default() -> usize {
+        let env_max = "TILEDB_STRATEGY_CELLS_PARAMETERS_NUM_RECORDS_MAX";
+        const CELLS_MAX_RECORDS: usize = 16;
+
+        crate::tests::env::<usize>(env_max).unwrap_or(CELLS_MAX_RECORDS)
+    }
+
+    pub fn cell_min_var_size_default() -> usize {
+        const CELLS_CELL_VAR_SIZE_MIN: usize = 0;
+
+        let env_min = "TILEDB_STRATEGY_CELLS_PARAMETERS_CELL_VAR_SIZE_MIN";
+        crate::tests::env::<usize>(env_min).unwrap_or(CELLS_CELL_VAR_SIZE_MIN)
+    }
+
+    pub fn cell_max_var_size_default() -> usize {
+        const CELLS_CELL_VAR_SIZE_MAX: usize = 0;
+        let env_max = "TILEDB_STRATEGY_CELLS_PARAMETERS_CELL_VAR_SIZE_MAX";
+
+        crate::tests::env::<usize>(env_max).unwrap_or(CELLS_CELL_VAR_SIZE_MAX)
+    }
 }
 
 impl Default for CellsParameters {
     fn default() -> Self {
-        const WRITE_QUERY_MIN_RECORDS: usize = 0;
-        const WRITE_QUERY_MAX_RECORDS: usize = 16;
-
-        const WRITE_QUERY_MIN_VAR_SIZE: usize = 0;
-        const WRITE_QUERY_MAX_VAR_SIZE: usize = 8;
-
         CellsParameters {
             schema: None,
-            min_records: WRITE_QUERY_MIN_RECORDS,
-            max_records: WRITE_QUERY_MAX_RECORDS,
-            value_min_var_size: WRITE_QUERY_MIN_VAR_SIZE,
-            value_max_var_size: WRITE_QUERY_MAX_VAR_SIZE,
+            min_records: Self::min_records_default(),
+            max_records: Self::max_records_default(),
+            cell_min_var_size: Self::cell_min_var_size_default(),
+            cell_max_var_size: Self::cell_max_var_size_default(),
         }
     }
 }

--- a/tiledb/api/src/query/strategy.rs
+++ b/tiledb/api/src/query/strategy.rs
@@ -1569,28 +1569,28 @@ impl CellsParameters {
     pub fn min_records_default() -> usize {
         const CELLS_MIN_RECORDS: usize = 0;
         let env_min = "TILEDB_STRATEGY_CELLS_PARAMETERS_NUM_RECORDS_MIN";
-        crate::tests::env::<usize>(env_min).unwrap_or(CELLS_MIN_RECORDS)
+        crate::env::parse::<usize>(env_min).unwrap_or(CELLS_MIN_RECORDS)
     }
 
     pub fn max_records_default() -> usize {
         let env_max = "TILEDB_STRATEGY_CELLS_PARAMETERS_NUM_RECORDS_MAX";
         const CELLS_MAX_RECORDS: usize = 16;
 
-        crate::tests::env::<usize>(env_max).unwrap_or(CELLS_MAX_RECORDS)
+        crate::env::parse::<usize>(env_max).unwrap_or(CELLS_MAX_RECORDS)
     }
 
     pub fn cell_min_var_size_default() -> usize {
         const CELLS_CELL_VAR_SIZE_MIN: usize = 0;
 
         let env_min = "TILEDB_STRATEGY_CELLS_PARAMETERS_CELL_VAR_SIZE_MIN";
-        crate::tests::env::<usize>(env_min).unwrap_or(CELLS_CELL_VAR_SIZE_MIN)
+        crate::env::parse::<usize>(env_min).unwrap_or(CELLS_CELL_VAR_SIZE_MIN)
     }
 
     pub fn cell_max_var_size_default() -> usize {
         const CELLS_CELL_VAR_SIZE_MAX: usize = 0;
         let env_max = "TILEDB_STRATEGY_CELLS_PARAMETERS_CELL_VAR_SIZE_MAX";
 
-        crate::tests::env::<usize>(env_max).unwrap_or(CELLS_CELL_VAR_SIZE_MAX)
+        crate::env::parse::<usize>(env_max).unwrap_or(CELLS_CELL_VAR_SIZE_MAX)
     }
 }
 

--- a/tiledb/api/src/query/strategy.rs
+++ b/tiledb/api/src/query/strategy.rs
@@ -1567,30 +1567,33 @@ pub struct CellsParameters {
 
 impl CellsParameters {
     pub fn min_records_default() -> usize {
-        const CELLS_MIN_RECORDS: usize = 0;
+        const DEFAULT_CELLS_MIN_RECORDS: usize = 0;
+
         let env_min = "TILEDB_STRATEGY_CELLS_PARAMETERS_NUM_RECORDS_MIN";
-        crate::env::parse::<usize>(env_min).unwrap_or(CELLS_MIN_RECORDS)
+        crate::env::parse::<usize>(env_min).unwrap_or(DEFAULT_CELLS_MIN_RECORDS)
     }
 
     pub fn max_records_default() -> usize {
-        let env_max = "TILEDB_STRATEGY_CELLS_PARAMETERS_NUM_RECORDS_MAX";
-        const CELLS_MAX_RECORDS: usize = 16;
+        const DEFAULT_CELLS_MAX_RECORDS: usize = 16;
 
-        crate::env::parse::<usize>(env_max).unwrap_or(CELLS_MAX_RECORDS)
+        let env_max = "TILEDB_STRATEGY_CELLS_PARAMETERS_NUM_RECORDS_MAX";
+        crate::env::parse::<usize>(env_max).unwrap_or(DEFAULT_CELLS_MAX_RECORDS)
     }
 
     pub fn cell_min_var_size_default() -> usize {
-        const CELLS_CELL_VAR_SIZE_MIN: usize = 0;
+        const DEFAULT_CELLS_CELL_VAR_SIZE_MIN: usize = 0;
 
         let env_min = "TILEDB_STRATEGY_CELLS_PARAMETERS_CELL_VAR_SIZE_MIN";
-        crate::env::parse::<usize>(env_min).unwrap_or(CELLS_CELL_VAR_SIZE_MIN)
+        crate::env::parse::<usize>(env_min)
+            .unwrap_or(DEFAULT_CELLS_CELL_VAR_SIZE_MIN)
     }
 
     pub fn cell_max_var_size_default() -> usize {
-        const CELLS_CELL_VAR_SIZE_MAX: usize = 0;
+        const DEFAULT_CELLS_CELL_VAR_SIZE_MAX: usize = 0;
         let env_max = "TILEDB_STRATEGY_CELLS_PARAMETERS_CELL_VAR_SIZE_MAX";
 
-        crate::env::parse::<usize>(env_max).unwrap_or(CELLS_CELL_VAR_SIZE_MAX)
+        crate::env::parse::<usize>(env_max)
+            .unwrap_or(DEFAULT_CELLS_CELL_VAR_SIZE_MAX)
     }
 }
 

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -135,11 +135,7 @@ impl DenseWriteParameters {
         const MEMORY_LIMIT_DEFAULT: usize = 16 * 1024; // chosen arbitrarily
 
         let env = "TILEDB_STRATEGY_DENSE_WRITE_PARAMETERS_MEMORY_LIMIT";
-        match std::env::var(env) {
-            Ok(limit) => usize::from_str(&limit)
-                .unwrap_or_else(|_| panic!("Invalid value for {}", env)),
-            Err(_) => MEMORY_LIMIT_DEFAULT,
-        }
+        crate::tests::env::<usize>(env).unwrap_or(MEMORY_LIMIT_DEFAULT)
     }
 }
 
@@ -994,11 +990,7 @@ impl<W> WriteSequenceParametersImpl<W> {
         pub const DEFAULT_MIN_WRITES: usize = 1;
 
         let env = "TILEDB_STRATEGY_WRITE_SEQUENCE_PARAMETERS_MIN_WRITES";
-        match std::env::var(env) {
-            Ok(limit) => usize::from_str(&limit)
-                .unwrap_or_else(|_| panic!("Invalid value for {}", env)),
-            Err(_) => DEFAULT_MIN_WRITES,
-        }
+        crate::tests::env::<usize>(env).unwrap_or(DEFAULT_MIN_WRITES)
     }
 
     pub fn max_writes_default() -> usize {

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -872,8 +872,8 @@ impl<'a> WriteInputRef<'a> {
 
     pub fn cloned(&self) -> WriteInput {
         match self {
-            Self::Dense(ref dense) => WriteInput::Dense((*dense).clone()),
-            Self::Sparse(ref sparse) => WriteInput::Sparse((*sparse).clone()),
+            Self::Dense(dense) => WriteInput::Dense((*dense).clone()),
+            Self::Sparse(sparse) => WriteInput::Sparse((*sparse).clone()),
         }
     }
 

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -134,7 +134,7 @@ impl DenseWriteParameters {
     pub fn memory_limit_default() -> usize {
         const MEMORY_LIMIT_DEFAULT: usize = 16 * 1024; // chosen arbitrarily
 
-        let env = "DENSE_WRITE_PARAMETERS_MEMORY_LIMIT";
+        let env = "TILEDB_STRATEGY_DENSE_WRITE_PARAMETERS_MEMORY_LIMIT";
         match std::env::var(env) {
             Ok(limit) => usize::from_str(&limit)
                 .unwrap_or_else(|_| panic!("Invalid value for {}", env)),
@@ -993,7 +993,7 @@ impl<W> WriteSequenceParametersImpl<W> {
     pub fn min_writes_default() -> usize {
         pub const DEFAULT_MIN_WRITES: usize = 1;
 
-        let env = "WRITE_SEQUENCE_PARAMETERS_MIN_WRITES";
+        let env = "TILEDB_STRATEGY_WRITE_SEQUENCE_PARAMETERS_MIN_WRITES";
         match std::env::var(env) {
             Ok(limit) => usize::from_str(&limit)
                 .unwrap_or_else(|_| panic!("Invalid value for {}", env)),
@@ -1004,7 +1004,7 @@ impl<W> WriteSequenceParametersImpl<W> {
     pub fn max_writes_default() -> usize {
         pub const DEFAULT_MAX_WRITES: usize = 8;
 
-        let env = "WRITE_SEQUENCE_PARAMETERS_MAX_WRITES";
+        let env = "TILEDB_STRATEGY_WRITE_SEQUENCE_PARAMETERS_MAX_WRITES";
         match std::env::var(env) {
             Ok(limit) => usize::from_str(&limit)
                 .unwrap_or_else(|_| panic!("Invalid value for {}", env)),

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -55,9 +55,16 @@ pub fn query_write_filter_requirements() -> FilterRequirements {
 pub fn query_write_schema_requirements(
     array_type: Option<ArrayType>,
 ) -> crate::array::schema::strategy::Requirements {
+    // NB: 1 is the highest number that passes all cases (so don't use the value given by
+    // `DomainRequirements::default()`) but we want to enable environmental override.
+    use crate::array::domain::strategy::Requirements as DomainRequirements;
+    let env_max_dimensions =
+        DomainRequirements::env_max_dimensions().unwrap_or(1);
+
     crate::array::schema::strategy::Requirements {
         domain: Some(Rc::new(crate::array::domain::strategy::Requirements {
             array_type,
+            num_dimensions: 1..=env_max_dimensions,
             dimension: Some(crate::array::dimension::strategy::Requirements {
                 filters: Some(Rc::new(query_write_filter_requirements())),
                 ..Default::default()

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -58,14 +58,12 @@ pub fn query_write_schema_requirements(
     crate::array::schema::strategy::Requirements {
         domain: Some(Rc::new(crate::array::domain::strategy::Requirements {
             array_type,
-            num_dimensions: 1..=1,
             dimension: Some(crate::array::dimension::strategy::Requirements {
                 filters: Some(Rc::new(query_write_filter_requirements())),
                 ..Default::default()
             }),
             ..Default::default()
         })),
-        num_attributes: 1..=1,
         attribute_filters: Some(Rc::new(query_write_filter_requirements())),
         coordinates_filters: Some(Rc::new(query_write_filter_requirements())),
         offsets_filters: Some(Rc::new(query_write_filter_requirements())),

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -44,6 +44,7 @@ pub fn query_write_filter_requirements() -> FilterRequirements {
         allow_compression_rle: false, // probably can be enabled but nontrivial
         allow_compression_dict: false, // probably can be enabled but nontrivial
         allow_compression_delta: false, // SC-47328
+        allow_webp: false,            // SC-51250
         ..Default::default()
     }
 }

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -134,7 +134,7 @@ impl DenseWriteParameters {
         const MEMORY_LIMIT_DEFAULT: usize = 16 * 1024; // chosen arbitrarily
 
         let env = "TILEDB_STRATEGY_DENSE_WRITE_PARAMETERS_MEMORY_LIMIT";
-        crate::tests::env::<usize>(env).unwrap_or(MEMORY_LIMIT_DEFAULT)
+        crate::env::parse::<usize>(env).unwrap_or(MEMORY_LIMIT_DEFAULT)
     }
 }
 
@@ -996,7 +996,7 @@ impl<W> WriteSequenceParametersImpl<W> {
         pub const DEFAULT_MIN_WRITES: usize = 1;
 
         let env = "TILEDB_STRATEGY_WRITE_SEQUENCE_PARAMETERS_MIN_WRITES";
-        crate::tests::env::<usize>(env).unwrap_or(DEFAULT_MIN_WRITES)
+        crate::env::parse::<usize>(env).unwrap_or(DEFAULT_MIN_WRITES)
     }
 
     pub fn max_writes_default() -> usize {

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -1,7 +1,6 @@
 use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::ops::{Deref, RangeInclusive};
 use std::rc::Rc;
-use std::str::FromStr;
 
 use proptest::prelude::*;
 use proptest::strategy::{NewTree, ValueTree};
@@ -993,21 +992,17 @@ pub type SparseWriteSequenceParameters =
 
 impl<W> WriteSequenceParametersImpl<W> {
     pub fn min_writes_default() -> usize {
-        pub const DEFAULT_MIN_WRITES: usize = 1;
+        const DEFAULT_MIN_WRITES: usize = 1;
 
         let env = "TILEDB_STRATEGY_WRITE_SEQUENCE_PARAMETERS_MIN_WRITES";
         crate::env::parse::<usize>(env).unwrap_or(DEFAULT_MIN_WRITES)
     }
 
     pub fn max_writes_default() -> usize {
-        pub const DEFAULT_MAX_WRITES: usize = 8;
+        const DEFAULT_MAX_WRITES: usize = 8;
 
         let env = "TILEDB_STRATEGY_WRITE_SEQUENCE_PARAMETERS_MAX_WRITES";
-        match std::env::var(env) {
-            Ok(limit) => usize::from_str(&limit)
-                .unwrap_or_else(|_| panic!("Invalid value for {}", env)),
-            Err(_) => DEFAULT_MAX_WRITES,
-        }
+        crate::env::parse::<usize>(env).unwrap_or(DEFAULT_MAX_WRITES)
     }
 }
 

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -990,8 +990,27 @@ pub type SparseWriteSequenceParameters =
     WriteSequenceParametersImpl<SparseWriteParameters>;
 
 impl<W> WriteSequenceParametersImpl<W> {
-    pub const DEFAULT_MIN_WRITES: usize = 1;
-    pub const DEFAULT_MAX_WRITES: usize = 8;
+    pub fn min_writes_default() -> usize {
+        pub const DEFAULT_MIN_WRITES: usize = 1;
+
+        let env = "WRITE_SEQUENCE_PARAMETERS_MIN_WRITES";
+        match std::env::var(env) {
+            Ok(limit) => usize::from_str(&limit)
+                .unwrap_or_else(|_| panic!("Invalid value for {}", env)),
+            Err(_) => DEFAULT_MIN_WRITES,
+        }
+    }
+
+    pub fn max_writes_default() -> usize {
+        pub const DEFAULT_MAX_WRITES: usize = 8;
+
+        let env = "WRITE_SEQUENCE_PARAMETERS_MAX_WRITES";
+        match std::env::var(env) {
+            Ok(limit) => usize::from_str(&limit)
+                .unwrap_or_else(|_| panic!("Invalid value for {}", env)),
+            Err(_) => DEFAULT_MAX_WRITES,
+        }
+    }
 }
 
 impl<W> Default for WriteSequenceParametersImpl<W>
@@ -1001,8 +1020,8 @@ where
     fn default() -> Self {
         WriteSequenceParametersImpl {
             write: Rc::new(Default::default()),
-            min_writes: Self::DEFAULT_MIN_WRITES,
-            max_writes: Self::DEFAULT_MAX_WRITES,
+            min_writes: Self::min_writes_default(),
+            max_writes: Self::max_writes_default(),
         }
     }
 }
@@ -1021,16 +1040,16 @@ impl WriteSequenceParameters {
                     schema: Some(schema),
                     ..Default::default()
                 }),
-                min_writes: DenseWriteSequenceParameters::DEFAULT_MIN_WRITES,
-                max_writes: DenseWriteSequenceParameters::DEFAULT_MAX_WRITES,
+                min_writes: DenseWriteSequenceParameters::min_writes_default(),
+                max_writes: DenseWriteSequenceParameters::max_writes_default(),
             }),
             ArrayType::Sparse => Self::Sparse(SparseWriteSequenceParameters {
                 write: Rc::new(SparseWriteParameters {
                     schema: Some(schema),
                     ..Default::default()
                 }),
-                min_writes: SparseWriteSequenceParameters::DEFAULT_MIN_WRITES,
-                max_writes: SparseWriteSequenceParameters::DEFAULT_MAX_WRITES,
+                min_writes: SparseWriteSequenceParameters::min_writes_default(),
+                max_writes: SparseWriteSequenceParameters::max_writes_default(),
             }),
         }
     }

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -871,6 +871,13 @@ impl<'a> WriteInputRef<'a> {
         }
     }
 
+    pub fn cloned(&self) -> WriteInput {
+        match self {
+            Self::Dense(ref dense) => WriteInput::Dense((*dense).clone()),
+            Self::Sparse(ref sparse) => WriteInput::Sparse((*sparse).clone()),
+        }
+    }
+
     /// Returns the minimum bounding rectangle containing
     /// the coordinates of this write operation.
     pub fn domain(&self) -> Option<NonEmptyDomain> {


### PR DESCRIPTION
A goal we haven't focused on much yet is configuring our nightly runs to generate more complicated inputs and test cases in our proptests.

This pull request implements one step towards this goal - adding environment variables for overriding the default values used in our array schema tests.

Toying with some of these environment variables exposed some bugs which are also incidentally addressed here, such as SC-51250

We also `impl Arbitrary for EnumerationData` along the way to this change.