### PR TITLE
ignore domain_shrinking test

### DIFF
--- a/tiledb/api/src/array/domain/strategy.rs
+++ b/tiledb/api/src/array/domain/strategy.rs
@@ -155,6 +155,7 @@ mod tests {
         });
     }
 
+    #[ignore = "takes a long time due to shrink iters on name, we should do custom shrink strategy"]
     #[test]
     fn domain_shrinking() {
         let strat = any::<DomainData>();


### PR DESCRIPTION
I'm not sure whether something changed recently, but I had a look at this test (whose goal is to ensure that shrinking a domain reduces the number of dimensions) and the way that it runs appears to spend most of the time shrinking the *name* of the domain.

I don't think that shrinking the name is something we should never do, but it certainly isn't worth waiting a minute for each time we run this test.

I've chosen to ignore this test rather than do something else because I think we should revisit the domain shrinking with a custom implementation and test that.  Removing the test also seems acceptable under this view.