### PR TITLE
impl Eq and Hash for SubarrayData and QueryConditionExpr

### DIFF
--- a/tiledb/api/src/datatype/physical.rs
+++ b/tiledb/api/src/datatype/physical.rs
@@ -343,31 +343,3 @@ where
         self.0.bits_cmp(&other.0)
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use std::hash::DefaultHasher;
-
-    use proptest::prelude::*;
-
-    use super::*;
-
-    #[test]
-    fn bits_eq_hash_consistency() {
-        proptest!(|(f1 in any::<f32>(), f2 in any::<f32>())| {
-            if f1.bits_eq(&f2) {
-                let f1_hash = {
-                    let mut h = DefaultHasher::default();
-                    f1.bits_hash(&mut h);
-                    h.finish()
-                };
-                let f2_hash = {
-                    let mut h = DefaultHasher::default();
-                    f2.bits_hash(&mut h);
-                    h.finish()
-                };
-                assert_eq!(f1_hash, f2_hash);
-            }
-        });
-    }
-}

--- a/tiledb/api/src/datatype/physical.rs
+++ b/tiledb/api/src/datatype/physical.rs
@@ -343,3 +343,31 @@ where
         self.0.bits_cmp(&other.0)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::hash::DefaultHasher;
+
+    use proptest::prelude::*;
+
+    use super::*;
+
+    #[test]
+    fn bits_eq_hash_consistency() {
+        proptest!(|(f1 in any::<f32>(), f2 in any::<f32>())| {
+            if f1.bits_eq(&f2) {
+                let f1_hash = {
+                    let mut h = DefaultHasher::default();
+                    f1.bits_hash(&mut h);
+                    h.finish()
+                };
+                let f2_hash = {
+                    let mut h = DefaultHasher::default();
+                    f2.bits_hash(&mut h);
+                    h.finish()
+                };
+                assert_eq!(f1_hash, f2_hash);
+            }
+        });
+    }
+}

--- a/tiledb/api/src/datatype/physical.rs
+++ b/tiledb/api/src/datatype/physical.rs
@@ -167,6 +167,19 @@ where
     }
 }
 
+impl<T> BitsHash for [T]
+where
+    T: BitsHash,
+{
+    fn bits_hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        let adapted = self.iter().map(BitsKeyAdapter).collect::<Vec<_>>();
+        adapted.hash(state)
+    }
+}
+
 impl<T> BitsHash for Vec<T>
 where
     T: BitsHash,

--- a/tiledb/api/src/query/conditions.rs
+++ b/tiledb/api/src/query/conditions.rs
@@ -175,6 +175,7 @@ impl Display for Literal {
     }
 }
 
+/// Uses the [BitsHash] implementation of the wrapped value.
 impl Hash for Literal {
     fn hash<H>(&self, state: &mut H)
     where
@@ -218,6 +219,9 @@ impl PartialEq for Literal {
     }
 }
 
+/// The [PartialEq] implementation of [Literal] compares the
+/// floating-point variants using [BitsEq],
+/// and as such is an equivalence relation.
 impl Eq for Literal {}
 
 macro_rules! literal_from_impl {
@@ -368,6 +372,7 @@ impl Display for SetMembers {
     }
 }
 
+/// Uses the [BitsHash] implementation of the wrapped values.
 impl Hash for SetMembers {
     fn hash<H>(&self, state: &mut H)
     where
@@ -412,6 +417,9 @@ impl PartialEq for SetMembers {
     }
 }
 
+/// The [PartialEq] implementation of [SetMembers] compares the
+/// floating-point variants using [BitsEq],
+/// and as such is an equivalence relation.
 impl Eq for SetMembers {}
 
 macro_rules! set_member_value_impl {

--- a/tiledb/api/src/query/subarray.rs
+++ b/tiledb/api/src/query/subarray.rs
@@ -372,7 +372,7 @@ where
 }
 
 /// Encapsulates data for a subarray.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct SubarrayData {
     /// List of requested ranges on each dimension.
     /// The outer `Vec` is the list of dimensions and the inner `Vec`

--- a/tiledb/api/src/range.rs
+++ b/tiledb/api/src/range.rs
@@ -1,4 +1,5 @@
 use std::fmt::{Debug, Formatter, Result as FmtResult};
+use std::hash::{Hash, Hasher};
 use std::num::NonZeroU32;
 use std::ops::Deref;
 
@@ -7,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::array::CellValNum;
-use crate::datatype::physical::BitsOrd;
+use crate::datatype::physical::{BitsEq, BitsHash, BitsOrd};
 use crate::datatype::Datatype;
 use crate::error::{DatatypeErrorKind, Error};
 use crate::physical_type_go;
@@ -78,7 +79,7 @@ where
     Some((lower, upper))
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum SingleValueRange {
     UInt8(u8, u8),
     UInt16(u16, u16),
@@ -183,6 +184,36 @@ impl SingleValueRange {
                 panic!("`SingleValueRange::intersection` on non-matching datatypes: `self` = {:?}, `other` = {:?}", self, other)
             }
         )
+    }
+}
+
+impl PartialEq for SingleValueRange {
+    fn eq(&self, other: &Self) -> bool {
+        crate::single_value_range_cmp!(
+            self,
+            other,
+            _DT,
+            lstart,
+            lend,
+            rstart,
+            rend,
+            lstart.bits_eq(rstart) && lend.bits_eq(rend),
+            false
+        )
+    }
+}
+
+impl Eq for SingleValueRange {}
+
+impl Hash for SingleValueRange {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        crate::single_value_range_go!(self, _DT, start, end, {
+            start.bits_hash(state);
+            end.bits_hash(state);
+        })
     }
 }
 
@@ -476,7 +507,7 @@ impl TryFrom<SingleValueRange> for std::ops::RangeInclusive<i128> {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum MultiValueRange {
     UInt8(Box<[u8]>, Box<[u8]>),
     UInt16(Box<[u16]>, Box<[u16]>),
@@ -625,6 +656,36 @@ impl MultiValueRange {
                     upper.to_vec().into_boxed_slice())).unwrap())
             },
             panic!("`MultiValueRange::union` on non-matching datatypes: `self` = {:?}, `other` = {:?}", self, other))
+    }
+}
+
+impl PartialEq for MultiValueRange {
+    fn eq(&self, other: &Self) -> bool {
+        crate::multi_value_range_cmp!(
+            self,
+            other,
+            _DT,
+            lstart,
+            lend,
+            rstart,
+            rend,
+            lstart.bits_eq(rstart) && lend.bits_eq(rend),
+            false
+        )
+    }
+}
+
+impl Eq for MultiValueRange {}
+
+impl Hash for MultiValueRange {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        crate::multi_value_range_go!(self, _DT, start, end, {
+            start.bits_hash(state);
+            end.bits_hash(state);
+        })
     }
 }
 
@@ -888,7 +949,7 @@ macro_rules! multi_value_range_cmp {
     }};
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum VarValueRange {
     UInt8(Box<[u8]>, Box<[u8]>),
     UInt16(Box<[u16]>, Box<[u16]>),
@@ -951,6 +1012,36 @@ impl VarValueRange {
                 Some(VarValueRange::from((lower.to_vec().into_boxed_slice(), upper.to_vec().into_boxed_slice())))
             },
             panic!("`VarValueRange::union` on non-matching datatypes: `self` = {:?}, `other` = {:?}", self, other))
+    }
+}
+
+impl PartialEq for VarValueRange {
+    fn eq(&self, other: &Self) -> bool {
+        crate::var_value_range_cmp!(
+            self,
+            other,
+            _DT,
+            lstart,
+            lend,
+            rstart,
+            rend,
+            lstart.bits_eq(rstart) && lend.bits_eq(rend),
+            false
+        )
+    }
+}
+
+impl Eq for VarValueRange {}
+
+impl Hash for VarValueRange {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        crate::var_value_range_go!(self, _DT, start, end, {
+            start.bits_hash(state);
+            end.bits_hash(state);
+        })
     }
 }
 
@@ -1187,7 +1278,7 @@ macro_rules! var_value_range_cmp {
     }};
 }
 
-#[derive(Clone, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Deserialize, Serialize, Eq, Hash, PartialEq)]
 pub enum Range {
     Single(SingleValueRange),
     Multi(MultiValueRange),

--- a/tiledb/api/src/range.rs
+++ b/tiledb/api/src/range.rs
@@ -203,8 +203,12 @@ impl PartialEq for SingleValueRange {
     }
 }
 
+/// The [PartialEq] implementation of [SingleValueRange] compares the
+/// floating-point variants using [BitsEq],
+/// and as such is an equivalence relation.
 impl Eq for SingleValueRange {}
 
+/// Uses the [BitsHash] implementation of the wrapped values.
 impl Hash for SingleValueRange {
     fn hash<H>(&self, state: &mut H)
     where
@@ -675,8 +679,12 @@ impl PartialEq for MultiValueRange {
     }
 }
 
+/// The [PartialEq] implementation of [MultiValueRange] compares the
+/// floating-point variants using [BitsEq],
+/// and as such is an equivalence relation.
 impl Eq for MultiValueRange {}
 
+/// Uses the [BitsHash] implementation of the wrapped values.
 impl Hash for MultiValueRange {
     fn hash<H>(&self, state: &mut H)
     where
@@ -1031,8 +1039,12 @@ impl PartialEq for VarValueRange {
     }
 }
 
+/// The [PartialEq] implementation of [VarValueRange] compares the
+/// floating-point variants using [BitsEq],
+/// and as such is an equivalence relation.
 impl Eq for VarValueRange {}
 
+/// Uses the [BitsHash] implementation of the wrapped values.
 impl Hash for VarValueRange {
     fn hash<H>(&self, state: &mut H)
     where


### PR DESCRIPTION
The purpose of this PR is to enable deriving Eq and Hash for ArrayScanFilterPushDown in the tables repo.

We need to do *that* so that we can put ArrayScanFilterPushDown into custom logical plan nodes, which must impl Eq and Hash.

We need to write custom logical plan nodes which embed ArrayScanFilterPushDown in order to push down aggregates (this is not exactly 100% true but it does lead to a nice implementation).

The only philosophical issue at hand is whether it is correct to do this because of the floating-point variants.  These are handled using our `BitsEq` and `BitsHash` traits respectively, which I claim accounts for correctness.  So, philosophically: floating point numbers do not impl Eq or Hash due to NaN.  I don't anticipate that we particularly care about propagating `NaN != NaN` as we might see it in predicates, ranges, or query conditions; we sacrifice some mathematical purity for significant improvements to usability.