### PR TITLE
Move proptest strategy configurations into a single file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.80"
 version = "0.1.0"
 
 [workspace.dependencies]

--- a/tiledb/api/src/array/domain/strategy.rs
+++ b/tiledb/api/src/array/domain/strategy.rs
@@ -18,27 +18,19 @@ pub struct Requirements {
 
 impl Requirements {
     pub fn env_max_dimensions() -> Option<usize> {
-        let env = "TILEDB_STRATEGY_DOMAIN_PARAMETERS_DIMENSIONS_MAX";
-        crate::env::parse::<usize>(env)
+        crate::strategy::config::TILEDB_STRATEGY_DOMAIN_PARAMETERS_DIMENSIONS_MAX.environmental()
     }
 
     pub fn min_dimensions_default() -> usize {
-        const DEFAULT_MIN_DIMENSIONS: usize = 1;
-
-        let env = "TILEDB_STRATEGY_DOMAIN_PARAMETERS_DIMENSIONS_MIN";
-        crate::env::parse::<usize>(env).unwrap_or(DEFAULT_MIN_DIMENSIONS)
+        **crate::strategy::config::TILEDB_STRATEGY_DOMAIN_PARAMETERS_DIMENSIONS_MIN
     }
 
     pub fn max_dimensions_default() -> usize {
-        const DEFAULT_MAX_DIMENSIONS: usize = 8;
-        Self::env_max_dimensions().unwrap_or(DEFAULT_MAX_DIMENSIONS)
+        **crate::strategy::config::TILEDB_STRATEGY_DOMAIN_PARAMETERS_DIMENSIONS_MAX
     }
 
     pub fn cells_per_tile_limit_default() -> usize {
-        const DEFAULT_CELLS_PER_TILE_LIMIT: usize = 1024 * 32;
-
-        let env = "TILEDB_STRATEGY_DOMAIN_PARAMETERS_CELLS_PER_TILE_LIMIT";
-        crate::env::parse::<usize>(env).unwrap_or(DEFAULT_CELLS_PER_TILE_LIMIT)
+        **crate::strategy::config::TILEDB_STRATEGY_DOMAIN_PARAMETERS_CELLS_PER_TILE_LIMIT
     }
 }
 

--- a/tiledb/api/src/array/enumeration/strategy.rs
+++ b/tiledb/api/src/array/enumeration/strategy.rs
@@ -76,19 +76,11 @@ pub struct Parameters {
 
 impl Parameters {
     fn min_variants_default() -> usize {
-        const DEFAULT_MIN_ENUMERATION_VALUES: usize = 1;
-
-        let env = "TILEDB_STRATEGY_ENUMERATION_PARAMETERS_NUM_VARIANTS_MIN";
-        crate::env::parse::<usize>(env)
-            .unwrap_or(DEFAULT_MIN_ENUMERATION_VALUES)
+        **crate::strategy::config::TILEDB_STRATEGY_ENUMERATION_PARAMETERS_NUM_VARIANTS_MIN
     }
 
     fn max_variants_default() -> usize {
-        const DEFAULT_MAX_ENUMERATION_VALUES: usize = 1024;
-
-        let env = "TILEDB_STRATEGY_ENUMERATION_PARAMETERS_NUM_VARIANTS_MAX";
-        crate::env::parse::<usize>(env)
-            .unwrap_or(DEFAULT_MAX_ENUMERATION_VALUES)
+        **crate::strategy::config::TILEDB_STRATEGY_ENUMERATION_PARAMETERS_NUM_VARIANTS_MAX
     }
 }
 

--- a/tiledb/api/src/array/schema/strategy.rs
+++ b/tiledb/api/src/array/schema/strategy.rs
@@ -33,31 +33,19 @@ pub struct Requirements {
 
 impl Requirements {
     pub fn min_attributes_default() -> usize {
-        const DEFAULT_MIN_ATTRIBUTES: usize = 1;
-
-        let env = "TILEDB_STRATEGY_SCHEMA_PARAMETERS_ATTRIBUTES_MIN";
-        crate::env::parse::<usize>(env).unwrap_or(DEFAULT_MIN_ATTRIBUTES)
+        **crate::strategy::config::TILEDB_STRATEGY_SCHEMA_PARAMETERS_ATTRIBUTES_MIN
     }
 
     pub fn max_attributes_default() -> usize {
-        const DEFAULT_MAX_ATTRIBUTES: usize = 8;
-
-        let env = "TILEDB_STRATEGY_SCHEMA_PARAMETERS_ATTRIBUTES_MAX";
-        crate::env::parse::<usize>(env).unwrap_or(DEFAULT_MAX_ATTRIBUTES)
+        **crate::strategy::config::TILEDB_STRATEGY_SCHEMA_PARAMETERS_ATTRIBUTES_MAX
     }
 
     pub fn min_sparse_tile_capacity_default() -> u64 {
-        const DEFAULT_MIN_SPARSE_TILE_CAPACITY: u64 = 1;
-
-        let env = "TILEDB_STRATEGY_SCHEMA_PARAMETERS_SPARSE_TILE_CAPACITY_MIN";
-        crate::env::parse::<u64>(env)
-            .unwrap_or(DEFAULT_MIN_SPARSE_TILE_CAPACITY)
+        **crate::strategy::config::TILEDB_STRATEGY_SCHEMA_PARAMETERS_SPARSE_TILE_CAPACITY_MIN
     }
 
     pub fn max_sparse_tile_capacity_default() -> u64 {
-        let env = "TILEDB_STRATEGY_SCHEMA_PARAMETERS_SPARSE_TILE_CAPACITY_MIN";
-        crate::env::parse::<u64>(env)
-            .unwrap_or(DomainRequirements::cells_per_tile_limit_default() as u64)
+        **crate::strategy::config::TILEDB_STRATEGY_SCHEMA_PARAMETERS_SPARSE_TILE_CAPACITY_MIN
     }
 }
 

--- a/tiledb/api/src/lib.rs
+++ b/tiledb/api/src/lib.rs
@@ -109,21 +109,3 @@ mod private {
 
 #[cfg(any(test, feature = "proptest-strategies"))]
 pub mod strategy;
-
-#[cfg(any(test, feature = "proptest-strategies"))]
-pub(crate) mod env {
-    use std::str::FromStr;
-
-    pub fn parse<T>(env: &str) -> Option<T>
-    where
-        T: FromStr,
-    {
-        match std::env::var(env) {
-            Ok(value) => Some(
-                T::from_str(&value)
-                    .unwrap_or_else(|_| panic!("Invalid value for {}", env)),
-            ),
-            Err(_) => None,
-        }
-    }
-}

--- a/tiledb/api/src/lib.rs
+++ b/tiledb/api/src/lib.rs
@@ -108,6 +108,9 @@ mod private {
 }
 
 #[cfg(any(test, feature = "proptest-strategies"))]
+pub mod strategy;
+
+#[cfg(any(test, feature = "proptest-strategies"))]
 pub(crate) mod env {
     use std::str::FromStr;
 

--- a/tiledb/api/src/query/strategy.rs
+++ b/tiledb/api/src/query/strategy.rs
@@ -1574,33 +1574,19 @@ pub struct CellsParameters {
 
 impl CellsParameters {
     pub fn min_records_default() -> usize {
-        const DEFAULT_CELLS_MIN_RECORDS: usize = 0;
-
-        let env_min = "TILEDB_STRATEGY_CELLS_PARAMETERS_NUM_RECORDS_MIN";
-        crate::env::parse::<usize>(env_min).unwrap_or(DEFAULT_CELLS_MIN_RECORDS)
+        **crate::strategy::config::TILEDB_STRATEGY_CELLS_PARAMETERS_NUM_RECORDS_MIN
     }
 
     pub fn max_records_default() -> usize {
-        const DEFAULT_CELLS_MAX_RECORDS: usize = 16;
-
-        let env_max = "TILEDB_STRATEGY_CELLS_PARAMETERS_NUM_RECORDS_MAX";
-        crate::env::parse::<usize>(env_max).unwrap_or(DEFAULT_CELLS_MAX_RECORDS)
+        **crate::strategy::config::TILEDB_STRATEGY_CELLS_PARAMETERS_NUM_RECORDS_MAX
     }
 
     pub fn cell_min_var_size_default() -> usize {
-        const DEFAULT_CELLS_CELL_VAR_SIZE_MIN: usize = 0;
-
-        let env_min = "TILEDB_STRATEGY_CELLS_PARAMETERS_CELL_VAR_SIZE_MIN";
-        crate::env::parse::<usize>(env_min)
-            .unwrap_or(DEFAULT_CELLS_CELL_VAR_SIZE_MIN)
+        **crate::strategy::config::TILEDB_STRATEGY_CELLS_PARAMETERS_CELL_VAR_SIZE_MIN
     }
 
     pub fn cell_max_var_size_default() -> usize {
-        const DEFAULT_CELLS_CELL_VAR_SIZE_MAX: usize = 0;
-        let env_max = "TILEDB_STRATEGY_CELLS_PARAMETERS_CELL_VAR_SIZE_MAX";
-
-        crate::env::parse::<usize>(env_max)
-            .unwrap_or(DEFAULT_CELLS_CELL_VAR_SIZE_MAX)
+        **crate::strategy::config::TILEDB_STRATEGY_CELLS_PARAMETERS_CELL_VAR_SIZE_MAX
     }
 }
 

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -137,10 +137,7 @@ pub struct DenseWriteParameters {
 
 impl DenseWriteParameters {
     pub fn memory_limit_default() -> usize {
-        const MEMORY_LIMIT_DEFAULT: usize = 16 * 1024; // chosen arbitrarily
-
-        let env = "TILEDB_STRATEGY_DENSE_WRITE_PARAMETERS_MEMORY_LIMIT";
-        crate::env::parse::<usize>(env).unwrap_or(MEMORY_LIMIT_DEFAULT)
+        **crate::strategy::config::TILEDB_STRATEGY_DENSE_WRITE_PARAMETERS_MEMORY_LIMIT
     }
 }
 
@@ -1027,17 +1024,11 @@ pub type SparseWriteSequenceParameters =
 
 impl<W> WriteSequenceParametersImpl<W> {
     pub fn min_writes_default() -> usize {
-        const DEFAULT_MIN_WRITES: usize = 1;
-
-        let env = "TILEDB_STRATEGY_WRITE_SEQUENCE_PARAMETERS_MIN_WRITES";
-        crate::env::parse::<usize>(env).unwrap_or(DEFAULT_MIN_WRITES)
+        **crate::strategy::config::TILEDB_STRATEGY_WRITE_SEQUENCE_PARAMETERS_MIN_WRITES
     }
 
     pub fn max_writes_default() -> usize {
-        const DEFAULT_MAX_WRITES: usize = 8;
-
-        let env = "TILEDB_STRATEGY_WRITE_SEQUENCE_PARAMETERS_MAX_WRITES";
-        crate::env::parse::<usize>(env).unwrap_or(DEFAULT_MAX_WRITES)
+        **crate::strategy::config::TILEDB_STRATEGY_WRITE_SEQUENCE_PARAMETERS_MAX_WRITES
     }
 }
 

--- a/tiledb/api/src/strategy.rs
+++ b/tiledb/api/src/strategy.rs
@@ -1,0 +1,58 @@
+pub mod config {
+    use std::ops::Deref;
+    use std::sync::LazyLock;
+
+    /// The value of a strategy configuration parameter and its provenance.
+    pub enum Configuration<T> {
+        Default(T),
+        Environmental(T),
+    }
+
+    impl<T> Configuration<T> {
+        /// Converts to [Option<T>], returning the wrapped value
+        /// if this is [Environmental] and [None] otherwise.
+        pub fn environmental(&self) -> Option<T>
+        where
+            T: Copy,
+        {
+            match self {
+                Self::Default(_) => None,
+                Self::Environmental(value) => Some(*value),
+            }
+        }
+    }
+
+    impl<T> Deref for Configuration<T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            match self {
+                Self::Default(ref value) => value,
+                Self::Environmental(ref value) => value,
+            }
+        }
+    }
+
+    macro_rules! config_param {
+        ($name:ident, $type:ty, $default:expr) => {
+            pub static $name: LazyLock<Configuration<$type>> =
+                LazyLock::new(|| {
+                    if let Some(value) =
+                        crate::env::parse::<$type>(stringify!($name))
+                    {
+                        Configuration::Environmental(value)
+                    } else {
+                        Configuration::Default($default)
+                    }
+                });
+        };
+    }
+
+    config_param!(TILEDB_STRATEGY_DOMAIN_PARAMETERS_DIMENSIONS_MIN, usize, 1);
+    config_param!(TILEDB_STRATEGY_DOMAIN_PARAMETERS_DIMENSIONS_MAX, usize, 8);
+    config_param!(
+        TILEDB_STRATEGY_DOMAIN_PARAMETERS_CELLS_PER_TILE_LIMIT,
+        usize,
+        1024 * 32
+    );
+}


### PR DESCRIPTION
As requested in [this comment](https://github.com/TileDB-Inc/tiledb-rs/pull/157#pullrequestreview-2287147756), moving all the proptest strategy configuration to a single file is useful for maintainability/discoverability.

Note that the usage of `LazyLock` requires rust version 1.80.