### PR TITLE
Disable bit and byte shuffle filters for writes

### DIFF
--- a/tiledb/api/src/filter/strategy.rs
+++ b/tiledb/api/src/filter/strategy.rs
@@ -48,6 +48,8 @@ pub struct Requirements {
     pub context: Option<StrategyContext>,
     pub pipeline_position: Option<usize>,
     pub allow_bit_reduction: bool,
+    pub allow_bit_shuffle: bool,
+    pub allow_byte_shuffle: bool,
     pub allow_positive_delta: bool,
     pub allow_scale_float: bool,
     pub allow_xor: bool,
@@ -95,6 +97,8 @@ impl Default for Requirements {
             context: None,
             pipeline_position: None,
             allow_bit_reduction: true,
+            allow_bit_shuffle: true,
+            allow_byte_shuffle: true,
             allow_positive_delta: true,
             allow_scale_float: true,
             allow_xor: true,
@@ -375,8 +379,6 @@ pub fn prop_filter(
     requirements: Rc<Requirements>,
 ) -> impl Strategy<Value = FilterData> {
     let mut filter_strategies = vec![
-        Just(FilterData::BitShuffle).boxed(),
-        Just(FilterData::ByteShuffle).boxed(),
         Just(FilterData::Checksum(ChecksumType::Md5)).boxed(),
         Just(FilterData::Checksum(ChecksumType::Sha256)).boxed(),
     ];
@@ -393,6 +395,14 @@ pub fn prop_filter(
         };
     if ok_bit_reduction {
         filter_strategies.push(prop_bitwidthreduction().boxed());
+    }
+
+    if requirements.allow_bit_shuffle {
+        filter_strategies.push(Just(FilterData::BitShuffle).boxed())
+    }
+
+    if requirements.allow_byte_shuffle {
+        filter_strategies.push(Just(FilterData::ByteShuffle).boxed())
     }
 
     let ok_positive_delta = requirements.allow_positive_delta

--- a/tiledb/api/src/query/write/strategy.rs
+++ b/tiledb/api/src/query/write/strategy.rs
@@ -37,6 +37,8 @@ type BoxedValueTree<T> = Box<dyn ValueTree<Value = T>>;
 pub fn query_write_filter_requirements() -> FilterRequirements {
     FilterRequirements {
         allow_bit_reduction: false,     // SC-47560
+        allow_bit_shuffle: false,       // SC-48409
+        allow_byte_shuffle: false,      // SC-48409
         allow_positive_delta: false,    // nothing yet to ensure sort order
         allow_scale_float: false,       // not invertible due to precision loss
         allow_xor: false,               // SC-47328

--- a/tiledb/sys/ignored.rs
+++ b/tiledb/sys/ignored.rs
@@ -270,5 +270,5 @@ extern "C" {
         array: *mut tiledb_array_t,
         domain: *mut ::std::os::raw::c_void,
         is_empty: *mut i32,
-    ) -> i32;
+    ) -> capi_return_t;
 }

--- a/tiledb/sys/src/array.rs
+++ b/tiledb/sys/src/array.rs
@@ -10,7 +10,7 @@ extern "C" {
         ctx: *mut tiledb_ctx_t,
         array_uri: *const ::std::os::raw::c_char,
         array: *mut *mut tiledb_array_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_free(array: *mut *mut tiledb_array_t);
 
@@ -18,47 +18,47 @@ extern "C" {
         ctx: *mut tiledb_ctx_t,
         array_uri: *const ::std::os::raw::c_char,
         array_schema: *const tiledb_array_schema_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_open(
         ctx: *mut tiledb_ctx_t,
         array: *mut tiledb_array_t,
         query_type: tiledb_query_type_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_is_open(
         ctx: *mut tiledb_ctx_t,
         array: *mut tiledb_array_t,
         is_open: *mut i32,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_reopen(
         ctx: *mut tiledb_ctx_t,
         array: *mut tiledb_array_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_set_config(
         ctx: *mut tiledb_ctx_t,
         array: *mut tiledb_array_t,
         config: *mut tiledb_config_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_get_config(
         ctx: *mut tiledb_ctx_t,
         array: *mut tiledb_array_t,
         config: *mut *mut tiledb_config_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_close(
         ctx: *mut tiledb_ctx_t,
         array: *mut tiledb_array_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_get_schema(
         ctx: *mut tiledb_ctx_t,
         array: *mut tiledb_array_t,
         array_schema: *mut *mut tiledb_array_schema_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_put_metadata(
         ctx: *mut tiledb_ctx_t,
@@ -67,13 +67,13 @@ extern "C" {
         value_type: tiledb_datatype_t,
         value_num: u32,
         value: *const ::std::os::raw::c_void,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_delete_metadata(
         ctx: *mut tiledb_ctx_t,
         array: *mut tiledb_array_t,
         key: *const ::std::os::raw::c_char,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_get_metadata(
         ctx: *mut tiledb_ctx_t,
@@ -82,13 +82,13 @@ extern "C" {
         value_type: *mut tiledb_datatype_t,
         value_num: *mut u32,
         value: *mut *const ::std::os::raw::c_void,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_get_metadata_num(
         ctx: *mut tiledb_ctx_t,
         array: *mut tiledb_array_t,
         num: *mut u64,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_get_metadata_from_index(
         ctx: *mut tiledb_ctx_t,
@@ -99,7 +99,7 @@ extern "C" {
         value_type: *mut tiledb_datatype_t,
         value_num: *mut u32,
         value: *mut *const ::std::os::raw::c_void,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_has_metadata_key(
         ctx: *mut tiledb_ctx_t,
@@ -107,7 +107,7 @@ extern "C" {
         key: *const ::std::os::raw::c_char,
         value_type: *mut tiledb_datatype_t,
         has_key: *mut i32,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_get_non_empty_domain(
         ctx: *mut tiledb_ctx_t,
@@ -122,7 +122,7 @@ extern "C" {
         idx: u32,
         domain: *mut ::std::os::raw::c_void,
         is_empty: *mut i32,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_get_non_empty_domain_from_name(
         ctx: *mut tiledb_ctx_t,
@@ -130,7 +130,7 @@ extern "C" {
         name: *const ::std::os::raw::c_char,
         domain: *mut ::std::os::raw::c_void,
         is_empty: *mut i32,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_get_non_empty_domain_var_size_from_index(
         ctx: *mut tiledb_ctx_t,
@@ -139,7 +139,7 @@ extern "C" {
         start_size: *mut u64,
         end_size: *mut u64,
         is_empty: *mut i32,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_get_non_empty_domain_var_size_from_name(
         ctx: *mut tiledb_ctx_t,
@@ -148,7 +148,7 @@ extern "C" {
         start_size: *mut u64,
         end_size: *mut u64,
         is_empty: *mut i32,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_get_non_empty_domain_var_from_index(
         ctx: *mut tiledb_ctx_t,
@@ -157,7 +157,7 @@ extern "C" {
         start: *mut ::std::os::raw::c_void,
         end: *mut ::std::os::raw::c_void,
         is_empty: *mut i32,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_get_non_empty_domain_var_from_name(
         ctx: *mut tiledb_ctx_t,
@@ -166,49 +166,49 @@ extern "C" {
         start: *mut ::std::os::raw::c_void,
         end: *mut ::std::os::raw::c_void,
         is_empty: *mut i32,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_set_open_timestamp_start(
         ctx: *mut tiledb_ctx_t,
         array: *mut tiledb_array_t,
         timestamp_start: u64,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_set_open_timestamp_end(
         ctx: *mut tiledb_ctx_t,
         array: *mut tiledb_array_t,
         timestamp_end: u64,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_get_open_timestamp_start(
         ctx: *mut tiledb_ctx_t,
         array: *mut tiledb_array_t,
         timestamp_start: *mut u64,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_get_open_timestamp_end(
         ctx: *mut tiledb_ctx_t,
         array: *mut tiledb_array_t,
         timestamp_end: *mut u64,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_vacuum(
         ctx: *mut tiledb_ctx_t,
         array_uri: *const ::std::os::raw::c_char,
         config: *mut tiledb_config_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_upgrade_version(
         ctx: *mut tiledb_ctx_t,
         array_uri: *const ::std::os::raw::c_char,
         config: *mut tiledb_config_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_consolidate(
         ctx: *mut tiledb_ctx_t,
         array_uri: *const ::std::os::raw::c_char,
         config: *mut tiledb_config_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_consolidate_fragments(
         ctx: *mut tiledb_ctx_t,
@@ -216,12 +216,12 @@ extern "C" {
         fragment_uris: *mut *const ::std::os::raw::c_char,
         num_fragments: u64,
         config: *mut tiledb_config_t,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_delete(
         ctx: *mut tiledb_ctx_t,
         uri: *const ::std::os::raw::c_char,
-    ) -> i32;
+    ) -> capi_return_t;
 
     pub fn tiledb_array_get_enumeration(
         ctx: *mut tiledb_ctx_t,

--- a/tools/api-coverage/src/main.rs
+++ b/tools/api-coverage/src/main.rs
@@ -427,6 +427,7 @@ impl Processor {
                     util::unparse_signature(sys_def.unwrap())
                 );
                 println!("</table>");
+                println!();
             }
 
             if wrapped {


### PR DESCRIPTION
These filters coupled with a checksum filter can produce an array that breaks when read. See SC-48409