### PR TITLE
chore: [sc-55233] [rs] panic in RecordsValueTree::simplify prevents proptest from dumping seed which led to bad input

### DIFF
--- a/tiledb/test-utils/src/strategy/meta.rs
+++ b/tiledb/test-utils/src/strategy/meta.rs
@@ -1,0 +1,228 @@
+use std::fmt::{Debug, Formatter, Result as FmtResult};
+use std::rc::Rc;
+
+use proptest::prelude::*;
+use proptest::strategy::{NewTree, ValueTree};
+use proptest::test_runner::{Config as ProptestConfig, TestRunner};
+
+use crate::strategy::sequence::SequenceValueTree;
+
+/// Strategy to create [ValueTree] objects for a wrapped [Strategy].
+///
+/// ```
+/// # use proptest::prelude::*;
+/// # use tiledb_test_utils::strategy::meta::ValueTreeStrategy;
+///
+/// proptest! {
+///     #[test]
+///     fn value_tree_test(value_tree in ValueTreeStrategy(any::<u64>())) {
+///         // binary search should always simplify
+///         assert!(value_tree.simplify());
+///     }
+/// }
+/// ```
+/// This can be used to write tests about how a [ValueTree] created by
+/// a custom [Strategy] responds to shrinking.
+#[derive(Debug)]
+pub struct ValueTreeStrategy<S>(pub(super) S);
+
+impl<S> Strategy for ValueTreeStrategy<S>
+where
+    S: Strategy,
+    <S as Strategy>::Tree: Clone + Debug,
+{
+    type Tree = ValueTreeWrapper<S::Tree>;
+    type Value = S::Tree;
+
+    fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
+        Ok(ValueTreeWrapper(self.0.new_tree(runner)?))
+    }
+}
+
+/// [ValueTree] corresponding to [ValueTreeStrategy].
+///
+/// The values of this `[ValueTree]` are [ValueTree]s created by
+/// some other strategy. The shrinking process shrinks the wrapped
+/// [ValueTree].
+pub struct ValueTreeWrapper<VT>(VT);
+
+impl<VT> ValueTree for ValueTreeWrapper<VT>
+where
+    VT: Clone + Debug + ValueTree,
+{
+    type Value = VT;
+
+    fn current(&self) -> Self::Value {
+        self.0.clone()
+    }
+
+    fn simplify(&mut self) -> bool {
+        self.0.simplify()
+    }
+
+    fn complicate(&mut self) -> bool {
+        self.0.complicate()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ShrinkAction {
+    Simplify,
+    Complicate,
+}
+
+impl ShrinkAction {
+    pub fn apply<VT>(&self, vt: &mut VT) -> bool
+    where
+        VT: ValueTree,
+    {
+        match self {
+            Self::Simplify => vt.simplify(),
+            Self::Complicate => vt.complicate(),
+        }
+    }
+}
+
+/// Strategy to create sequences of shrinking steps.
+///
+/// This is useful with [ValueTreeStrategy] to write
+/// tests which assert properties about how a [ValueTree]
+/// responds to shrinking.
+///
+/// Sequences produced by this [Strategy] ensure that the
+/// number of complications does not exceed the number
+/// of simplifications up to that point in the sequence.
+#[derive(Debug)]
+pub struct ShrinkSequenceStrategy {
+    pub max_length: usize,
+}
+
+impl Default for ShrinkSequenceStrategy {
+    fn default() -> Self {
+        ShrinkSequenceStrategy {
+            max_length: std::cmp::min(
+                1024,
+                ProptestConfig::default().max_shrink_iters as usize,
+            ),
+        }
+    }
+}
+
+impl Strategy for ShrinkSequenceStrategy {
+    type Tree = ShrinkSequenceValueTree;
+    type Value = <<Self as Strategy>::Tree as ValueTree>::Value;
+
+    fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
+        let desired_length =
+            proptest::num::sample_uniform_incl(runner, 0, self.max_length);
+        if desired_length == 0 {
+            return Ok(SequenceValueTree::new(Vec::new()));
+        }
+
+        let mut steps = vec![];
+
+        let mut num_shrinks = 0;
+        while steps.len() < desired_length {
+            if num_shrinks == 0 {
+                num_shrinks += 1;
+                steps.push(ShrinkAction::Simplify);
+            } else {
+                // choose randomly whether to continue simplifying or to complicate.
+                // avoid early thrashing by making complication more likely
+                // as the number of Simplify actions grows.
+                let value = proptest::num::sample_uniform_incl(
+                    runner,
+                    0,
+                    self.max_length - num_shrinks,
+                );
+                steps.push(if value == 0 {
+                    num_shrinks -= 1;
+                    ShrinkAction::Complicate
+                } else {
+                    num_shrinks += 1;
+                    ShrinkAction::Simplify
+                });
+            }
+        }
+        Ok(SequenceValueTree::new(steps))
+    }
+}
+
+pub type ShrinkSequenceValueTree = SequenceValueTree<ShrinkAction>;
+
+/// Strategy adapter to transform [ValueTree]s.
+///
+/// Where [prop_map] transforms the [Strategy], this adapter transforms
+/// the [ValueTree]s produced by the source [Strategy].
+///
+/// One way to use this would be to implement custom shrinking strategies
+/// for strategies built using existing adapters, without changing
+/// the way that the strategy is constructed.
+#[derive(Clone)]
+pub struct MapValueTree<S, F> {
+    source: S,
+    transform: Rc<F>,
+}
+
+impl<S, F> MapValueTree<S, F> {
+    pub(super) fn new(source: S, transform: F) -> Self {
+        MapValueTree {
+            source,
+            transform: Rc::new(transform),
+        }
+    }
+}
+
+impl<S, F> Debug for MapValueTree<S, F>
+where
+    S: Debug,
+{
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        f.debug_struct("MapValueTree")
+            .field("source", &self.source)
+            .field("transform", &std::any::type_name::<F>())
+            .finish()
+    }
+}
+
+impl<S, F, VT> Strategy for MapValueTree<S, F>
+where
+    S: Strategy,
+    F: Fn(S::Tree) -> VT,
+    VT: Debug + ValueTree,
+{
+    type Tree = VT;
+    type Value = VT::Value;
+
+    fn new_tree(&self, runner: &mut TestRunner) -> NewTree<Self> {
+        Ok((self.transform)(self.source.new_tree(runner)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    proptest! {
+        #[test]
+        fn valid_shrink_sequence(sequence in ShrinkSequenceStrategy::default()) {
+            assert_valid_shrink_sequence(sequence)
+        }
+    }
+
+    fn assert_valid_shrink_sequence(sequence: Vec<ShrinkAction>) {
+        let mut simplify_run_length: isize = 0;
+
+        for action in sequence {
+            match action {
+                ShrinkAction::Simplify => {
+                    simplify_run_length += 1;
+                }
+                ShrinkAction::Complicate => {
+                    assert!(simplify_run_length > 0);
+                    simplify_run_length -= 1;
+                }
+            }
+        }
+    }
+}

--- a/tiledb/test-utils/src/strategy/mod.rs
+++ b/tiledb/test-utils/src/strategy/mod.rs
@@ -1,1 +1,34 @@
+pub mod meta;
 pub mod records;
+pub mod sequence;
+
+use proptest::strategy::{Strategy, ValueTree};
+
+pub trait StrategyExt: Strategy {
+    /// Returns a strategy which produces the [ValueTree]s returned by [self].
+    ///
+    /// This additional indirection can be used to test the [ValueTree]
+    /// associated with this [Strategy].
+    fn prop_indirect(self) -> meta::ValueTreeStrategy<Self>
+    where
+        Self: Sized,
+    {
+        meta::ValueTreeStrategy(self)
+    }
+
+    /// Returns a strategy which produces values transformed by
+    /// the [ValueTree] mapping function `transform`.
+    ///
+    /// This is similar to [prop_map] but also enables changing the way
+    /// that values produced by [self] are shrunk.
+    fn value_tree_map<F, VT>(self, transform: F) -> meta::MapValueTree<Self, F>
+    where
+        Self: Sized,
+        F: Fn(<Self as Strategy>::Tree) -> VT,
+        VT: ValueTree,
+    {
+        meta::MapValueTree::new(self, transform)
+    }
+}
+
+impl<S> StrategyExt for S where S: Strategy {}

--- a/tiledb/test-utils/src/strategy/sequence.rs
+++ b/tiledb/test-utils/src/strategy/sequence.rs
@@ -1,0 +1,83 @@
+use std::fmt::Debug;
+
+use proptest::strategy::ValueTree;
+
+/// [ValueTree] representing a logical sequence of ordered steps.
+///
+/// Shrinking truncates or re-grows values at the end of the sequence
+/// so that the order of steps is always preserved.
+#[derive(Clone, Debug)]
+pub struct SequenceValueTree<Element> {
+    initial_sequence: Vec<Element>,
+    current_length: usize,
+}
+
+impl<Element> SequenceValueTree<Element> {
+    pub fn new(initial_sequence: impl IntoIterator<Item = Element>) -> Self {
+        let collected = initial_sequence.into_iter().collect::<Vec<Element>>();
+        let init_len = collected.len();
+        SequenceValueTree {
+            initial_sequence: collected,
+            current_length: init_len,
+        }
+    }
+}
+
+impl<Element> ValueTree for SequenceValueTree<Element>
+where
+    Element: Clone + Debug,
+{
+    type Value = Vec<Element>;
+
+    fn current(&self) -> Self::Value {
+        self.initial_sequence[0..self.current_length].to_vec()
+    }
+
+    fn simplify(&mut self) -> bool {
+        if self.current_length > 0 {
+            self.current_length /= 2;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn complicate(&mut self) -> bool {
+        if self.current_length < self.initial_sequence.len() {
+            self.current_length += 1;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::collection::vec as strat_vec;
+    use proptest::prelude::*;
+
+    use super::*;
+    use crate::strategy::meta::ShrinkSequenceStrategy;
+    use crate::strategy::StrategyExt;
+
+    proptest! {
+        /// Ensure that the sequence strategy always returns a subsequence
+        /// which starts from the beginning of the initial input
+        #[test]
+        fn sequence_shrinking(
+            vt in strat_vec(any::<u64>(), 0..=1024)
+                .value_tree_map(|vt| SequenceValueTree::new(vt.current()))
+                .prop_indirect(),
+            shrinks in ShrinkSequenceStrategy::default())
+        {
+            let init = vt.current();
+            let mut vt = vt;
+
+            for action in shrinks {
+                action.apply(&mut vt);
+                assert_eq!(&init[0.. vt.current_length], vt.current());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Story details: https://app.shortcut.com/tiledb-inc/story/55233

`RecordsValueTree` is an alternative to `proptest::collection::VecValueTree` for shrinking down a collection of values.

We have observed a few times in our tests which use this a panic during the shrinking process tracing to `RecordsValueTree`.  When we have such a panic, proptest shrinking iterations abort without printing the seed used to generate the failing input (or the current failing input).

`RecordsValueTree`'s shrinking logic was panicking in the expression `self.explore_results[i].take().unwrap()`.  This turned out to be a logical out-of-bounds access.  `i` was previously bounded by `self.explore_results.len()`, but not all of the indices would be filled in if there were fewer records than `explore_results`.

The fix is simple: bound `i` by the minimum of the number of records and the number of explorations.

# Testing

The test generates `RecordsValueTree`s together with arbitrary sequences of shrink steps (`ShrinkSequence`) and ensures that applying the arbitrary sequence does not result in a panic.
