### PR TITLE
chore: [sc-56223] [rs] implement custom proptest ValueTree for schema

### DIFF
--- a/tiledb/api/src/array/attribute/strategy.rs
+++ b/tiledb/api/src/array/attribute/strategy.rs
@@ -188,8 +188,8 @@ impl ValueTree for AttributeValueTree {
     fn current(&self) -> Self::Value {
         AttributeData {
             name: self.name.clone(),
-            datatype: self.datatype.clone(),
-            nullability: self.nullability.clone(),
+            datatype: self.datatype,
+            nullability: self.nullability,
             cell_val_num: self.cell_val_num.current(),
             fill: self.fill.current(),
             filters: self.filters.current(),

--- a/tiledb/api/src/array/attribute/strategy.rs
+++ b/tiledb/api/src/array/attribute/strategy.rs
@@ -1,12 +1,16 @@
 use std::rc::Rc;
 
 use proptest::prelude::*;
+use proptest::strategy::ValueTree;
+use tiledb_test_utils::strategy::StrategyExt;
 
 use crate::array::{
     attribute::FillData, ArrayType, AttributeData, CellValNum, DomainData,
 };
 use crate::filter::list::FilterListData;
-use crate::filter::strategy::Requirements as FilterRequirements;
+use crate::filter::strategy::{
+    FilterPipelineValueTree, Requirements as FilterRequirements,
+};
 use crate::{physical_type_go, Datatype};
 
 #[derive(Clone)]
@@ -147,9 +151,58 @@ pub fn prop_attribute(
         .map(|d| Just(d).boxed())
         .unwrap_or(any::<Datatype>());
 
-    datatype.prop_flat_map(move |datatype| {
-        prop_attribute_for_datatype(datatype, requirements.clone())
-    })
+    datatype
+        .prop_flat_map(move |datatype| {
+            prop_attribute_for_datatype(datatype, requirements.clone())
+        })
+        .value_tree_map(|vt| AttributeValueTree::new(vt.current()))
+        .boxed()
+}
+
+#[derive(Clone, Debug)]
+pub struct AttributeValueTree {
+    name: String,
+    datatype: Datatype,
+    nullability: Option<bool>,
+    cell_val_num: Just<Option<CellValNum>>, // TODO: enable shrinking, will help identify if Var is necessary for example
+    fill: Just<Option<FillData>>,           // TODO: enable shrinking
+    filters: FilterPipelineValueTree,
+}
+
+impl AttributeValueTree {
+    pub fn new(attr: AttributeData) -> Self {
+        Self {
+            name: attr.name,
+            datatype: attr.datatype,
+            nullability: attr.nullability,
+            cell_val_num: Just(attr.cell_val_num),
+            fill: Just(attr.fill),
+            filters: FilterPipelineValueTree::new(attr.filters),
+        }
+    }
+}
+
+impl ValueTree for AttributeValueTree {
+    type Value = AttributeData;
+
+    fn current(&self) -> Self::Value {
+        AttributeData {
+            name: self.name.clone(),
+            datatype: self.datatype.clone(),
+            nullability: self.nullability.clone(),
+            cell_val_num: self.cell_val_num.current(),
+            fill: self.fill.current(),
+            filters: self.filters.current(),
+        }
+    }
+
+    fn simplify(&mut self) -> bool {
+        self.filters.simplify()
+    }
+
+    fn complicate(&mut self) -> bool {
+        self.filters.complicate()
+    }
 }
 
 #[cfg(test)]

--- a/tiledb/api/src/array/dimension/strategy.rs
+++ b/tiledb/api/src/array/dimension/strategy.rs
@@ -281,7 +281,7 @@ impl DimensionValueTree {
             name: dimension.name,
             datatype: dimension.datatype,
             constraints: Just(dimension.constraints),
-            filters: dimension.filters.map(|p| FilterPipelineValueTree::new(p)),
+            filters: dimension.filters.map(FilterPipelineValueTree::new),
         }
     }
 }
@@ -292,7 +292,7 @@ impl ValueTree for DimensionValueTree {
     fn current(&self) -> Self::Value {
         DimensionData {
             name: self.name.clone(),
-            datatype: self.datatype.clone(),
+            datatype: self.datatype,
             constraints: self.constraints.current(),
             filters: self.filters.as_ref().map(|p| p.current()),
         }

--- a/tiledb/api/src/array/domain/strategy.rs
+++ b/tiledb/api/src/array/domain/strategy.rs
@@ -154,7 +154,7 @@ impl DomainValueTree {
             all_dimensions: domain
                 .dimension
                 .into_iter()
-                .map(|d| DimensionValueTree::new(d))
+                .map(DimensionValueTree::new)
                 .collect::<Vec<_>>(),
             selected_dimensions: RecordsValueTree::new(
                 1,

--- a/tiledb/api/src/array/schema/strategy.rs
+++ b/tiledb/api/src/array/schema/strategy.rs
@@ -367,7 +367,7 @@ impl SchemaValueTree {
             all_attributes: schema
                 .attributes
                 .into_iter()
-                .map(|a| AttributeValueTree::new(a))
+                .map(AttributeValueTree::new)
                 .collect::<Vec<_>>(),
             selected_attributes: RecordsValueTree::new(
                 1,
@@ -391,7 +391,7 @@ impl ValueTree for SchemaValueTree {
 
     fn current(&self) -> Self::Value {
         SchemaData {
-            array_type: self.array_type.clone(),
+            array_type: self.array_type,
             domain: self.domain.current(),
             capacity: self.capacity.current(),
             cell_order: self.cell_order.current(),

--- a/tiledb/api/src/array/schema/strategy.rs
+++ b/tiledb/api/src/array/schema/strategy.rs
@@ -493,6 +493,9 @@ mod tests {
         let minimal = vt.current();
         assert_eq!(1, minimal.attributes.len());
         assert_eq!(1, minimal.domain.dimension.len());
+
+        // check contract of ValueTree
+        assert!(!vt.complicate());
     }
 
     proptest! {

--- a/tiledb/api/src/filter/list.rs
+++ b/tiledb/api/src/filter/list.rs
@@ -188,6 +188,12 @@ impl Builder {
 )]
 pub struct FilterListData(Vec<FilterData>);
 
+impl FilterListData {
+    pub fn into_inner(self) -> Vec<FilterData> {
+        self.0
+    }
+}
+
 impl Deref for FilterListData {
     type Target = Vec<FilterData>;
 

--- a/tiledb/api/src/filter/strategy.rs
+++ b/tiledb/api/src/filter/strategy.rs
@@ -462,7 +462,7 @@ pub fn prop_filter(
 /// 1) the filters themselves are basically scalars, so we don't need to shrink them
 /// 2) we must preserve the soundness of the pipeline with contiguous elements,
 ///    so our only option is to delete from (or restore) the back of the pipeline
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct FilterPipelineValueTree {
     initial_pipeline: FilterListData,
     sublen: usize,

--- a/tiledb/test-utils/src/strategy/mod.rs
+++ b/tiledb/test-utils/src/strategy/mod.rs
@@ -2,6 +2,8 @@ pub mod meta;
 pub mod records;
 pub mod sequence;
 
+use std::fmt::Debug;
+
 use proptest::strategy::{Strategy, ValueTree};
 
 pub trait StrategyExt: Strategy {
@@ -12,6 +14,7 @@ pub trait StrategyExt: Strategy {
     fn prop_indirect(self) -> meta::ValueTreeStrategy<Self>
     where
         Self: Sized,
+        Self::Tree: Clone + Debug,
     {
         meta::ValueTreeStrategy(self)
     }


### PR DESCRIPTION
Story details: https://app.shortcut.com/tiledb-inc/story/56223

This pull request adds custom `proptest::strategy::ValueTree` implementations for `SchemaData` and friends.  This is beneficial for taking control of the shrinking algorithm but also allows us to construct a shrinkable ValueTree from a SchemaData, which will be very useful for debugging issues which originate outside of proptest.

The implementations ended up surprisingly simple: each `ThingValueTree` struct has fields which roughly correspond to `ThingData`.  `ValueTree::current` becomes trivial; `ValueTree::simplify` and `ValueTree::complicate` simply attempt to simplify or complicate fields in the order that we write them down.

Consider `SchemaValueTree`.  The first way we would want to shrink a schema is by identifying the set of necessary attributes.  `SchemaValueTree::simplify` and `complicate` begin by trying `selected_attributes.simplify` and `complicate` respectively.  This will converge the set of attributes, then move on to the next field to simplify/complicate.  This assumes that repeated calls to `simplify` and `complicate` are idempotent once the minimal set is found.  This property is required by `ValueTree`:

> The main invariants here are that the “high” value always corresponds to a failing test case, and that repeated calls to complicate() will return false only once the “current” value has returned to what it was before the last call to simplify().

although of course it needs proof for each `ValueTree` implementation.

`RecordsValueTree` abides this contract; `SequenceValueTree` does not and so this pull request updates it to do so.