### PR TITLE
Replace buffer management with Arrow buffers

### DIFF
--- a/tiledb/api/Cargo.toml
+++ b/tiledb/api/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-arrow = { version = "52.0.0", features = ["prettyprint"], optional = true }
+arrow = { version = "52.0.0", features = ["prettyprint"] }
 itertools = "0"
 num-traits = { version = "0.2", optional = true }
 paste = "1.0"
@@ -35,5 +35,9 @@ tiledb-utils = { workspace = true }
 
 [features]
 default = []
-proptest-strategies = ["dep:num-traits", "dep:proptest", "dep:proptest-derive", "dep:tiledb-test-utils"]
-arrow = ["dep:arrow"]
+proptest-strategies = [
+    "dep:num-traits",
+    "dep:proptest",
+    "dep:proptest-derive",
+    "dep:tiledb-test-utils",
+]

--- a/tiledb/api/examples/multi_range_subarray_arrow.rs
+++ b/tiledb/api/examples/multi_range_subarray_arrow.rs
@@ -1,0 +1,154 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use arrow::array as aa;
+use itertools::izip;
+
+use tiledb::array::{
+    Array, ArrayType, AttributeData, CellOrder, DimensionData, DomainData,
+    SchemaData, TileOrder,
+};
+use tiledb::context::Context;
+use tiledb::error::Error as TileDBError;
+use tiledb::query_arrow::{QueryBuilder, QueryLayout, QueryStatus, QueryType};
+use tiledb::Result as TileDBResult;
+use tiledb::{Datatype, Factory};
+
+const ARRAY_URI: &str = "multi_range_slicing";
+
+/// This example creates a 4x4 dense array with the contents:
+///
+/// Col:     1   2   3   4
+/// Row: 1   1   2   3   4
+///      2   5   6   7   8
+///      3   9  10  11  12
+///      4  13  14  15  16
+///
+/// The query run restricts rows to [1, 2, 4] and returns all columns which
+/// should produce these rows:
+///
+/// Row Col Value
+/// 1   1   1
+/// 1   2   2
+/// 1   3   3
+/// 1   4   4
+/// 2   1   5
+/// 2   2   6
+/// 2   3   7
+/// 2   4   8
+/// 4   1   13
+/// 4   2   14
+/// 4   3   15
+/// 4   4   16
+fn main() -> TileDBResult<()> {
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        let _ = std::env::set_current_dir(
+            PathBuf::from(manifest_dir).join("examples").join("output"),
+        );
+    }
+
+    let ctx = Context::new()?;
+    if Array::exists(&ctx, ARRAY_URI)? {
+        Array::delete(&ctx, ARRAY_URI)?;
+    }
+
+    create_array(&ctx)?;
+    write_array(&ctx)?;
+
+    let array = Array::open(&ctx, ARRAY_URI, tiledb::array::Mode::Read)?;
+    let mut query = QueryBuilder::new(array, QueryType::Read)
+        .with_layout(QueryLayout::RowMajor)
+        .start_fields()
+        .field("rows")
+        .field("cols")
+        .field("a")
+        .end_fields()
+        .start_subarray()
+        .add_range("rows", &[1, 2])
+        .add_range("rows", &[4, 4])
+        .add_range("cols", &[1, 4])
+        .end_subarray()
+        .build()
+        .map_err(|e| TileDBError::Other(format!("{e}")))?;
+
+    let status = query
+        .submit()
+        .map_err(|e| TileDBError::Other(format!("{e}")))?;
+
+    if !matches!(status, QueryStatus::Completed) {
+        return Err(TileDBError::Other("Make this better.".to_string()));
+    }
+
+    let buffers = query
+        .buffers()
+        .map_err(|e| TileDBError::Other(format!("{e}")))?;
+
+    let rows = buffers.get::<aa::Int32Array>("rows").unwrap();
+    let cols = buffers.get::<aa::Int32Array>("cols").unwrap();
+    let attr = buffers.get::<aa::Int32Array>("a").unwrap();
+
+    for (r, c, a) in izip!(rows.values(), cols.values(), attr.values()) {
+        println!("{} {} {}", r, c, a);
+    }
+
+    Ok(())
+}
+
+fn create_array(ctx: &Context) -> TileDBResult<()> {
+    let schema = SchemaData {
+        array_type: ArrayType::Dense,
+        domain: DomainData {
+            dimension: vec![
+                DimensionData {
+                    name: "rows".to_owned(),
+                    datatype: Datatype::Int32,
+                    constraints: ([1i32, 4], 4i32).into(),
+                    filters: None,
+                },
+                DimensionData {
+                    name: "cols".to_owned(),
+                    datatype: Datatype::Int32,
+                    constraints: ([1i32, 4], 4i32).into(),
+                    filters: None,
+                },
+            ],
+        },
+        attributes: vec![AttributeData {
+            name: "a".to_owned(),
+            datatype: Datatype::Int32,
+            ..Default::default()
+        }],
+        tile_order: Some(TileOrder::RowMajor),
+        cell_order: Some(CellOrder::RowMajor),
+
+        ..Default::default()
+    };
+
+    let schema = schema.create(ctx)?;
+    Array::create(ctx, ARRAY_URI, schema)?;
+    Ok(())
+}
+
+fn write_array(ctx: &Context) -> TileDBResult<()> {
+    let data = Arc::new(aa::Int32Array::from(vec![
+        1i32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    ]));
+
+    let array =
+        tiledb::Array::open(ctx, ARRAY_URI, tiledb::array::Mode::Write)?;
+
+    let mut query = QueryBuilder::new(array, QueryType::Write)
+        .with_layout(QueryLayout::RowMajor)
+        .start_fields()
+        .field_with_buffer("a", data)
+        .end_fields()
+        .build()
+        .map_err(|e| TileDBError::Other(format!("{e}")))?;
+
+    let (_, _) = query
+        .submit()
+        .and_then(|_| query.finalize())
+        .map_err(|e| TileDBError::Other(format!("{e}")))?;
+
+    Ok(())
+}

--- a/tiledb/api/examples/query_condition_dense_arrow.rs
+++ b/tiledb/api/examples/query_condition_dense_arrow.rs
@@ -1,0 +1,242 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use arrow::array as aa;
+use itertools::izip;
+
+use tiledb::array::{
+    Array, ArrayType, AttributeBuilder, DimensionBuilder, DomainBuilder,
+    SchemaBuilder,
+};
+use tiledb::error::Error as TileDBError;
+use tiledb::query::conditions::QueryConditionExpr as QC;
+use tiledb::query_arrow::{QueryBuilder, QueryLayout, QueryType};
+use tiledb::{Context, Datatype, Result as TileDBResult};
+
+const ARRAY_URI: &str = "query_condition_dense";
+const NUM_ELEMS: i32 = 10;
+const C_FILL_VALUE: i32 = -1;
+const D_FILL_VALUE: f32 = 0.0;
+
+/// Demonstrate reading dense arrays with query conditions.
+fn main() -> TileDBResult<()> {
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        let _ = std::env::set_current_dir(
+            PathBuf::from(manifest_dir).join("examples").join("output"),
+        );
+    }
+
+    let ctx = Context::new()?;
+    if Array::exists(&ctx, ARRAY_URI)? {
+        Array::delete(&ctx, ARRAY_URI)?;
+    }
+
+    create_array(&ctx)?;
+    write_array(&ctx)?;
+
+    println!("Reading the entire array:");
+    read_array(&ctx, None)?;
+
+    println!("Reading: a is null");
+    let qc = QC::field("a").is_null();
+    read_array(&ctx, Some(qc))?;
+
+    println!("Reading: b < \"eve\"");
+    let qc = QC::field("b").lt("eve");
+    read_array(&ctx, Some(qc))?;
+
+    println!("Reading: c >= 1");
+    let qc = QC::field("c").ge(1i32);
+    read_array(&ctx, Some(qc))?;
+
+    println!("Reading: 3.0 <= d <= 4.0");
+    let qc = QC::field("d").ge(3.0f32) & QC::field("d").le(4.0f32);
+    read_array(&ctx, Some(qc))?;
+
+    println!("Reading: (a is not null) && (b < \"eve\") && (3.0 <= d <= 4.0)");
+    let qc = QC::field("a").not_null()
+        & QC::field("b").lt("eve")
+        & QC::field("d").ge(3.0f32)
+        & QC::field("d").le(4.0f32);
+    read_array(&ctx, Some(qc))?;
+
+    Ok(())
+}
+
+/// Read the array with the optional query condition and print the results
+/// to stdout.
+fn read_array(ctx: &Context, qc: Option<QC>) -> TileDBResult<()> {
+    let array = tiledb::Array::open(ctx, ARRAY_URI, tiledb::array::Mode::Read)?;
+    let mut query = QueryBuilder::new(array, QueryType::Read)
+        .with_layout(QueryLayout::RowMajor)
+        .start_fields()
+        .field("index")
+        .field("a")
+        .field("b")
+        .field("c")
+        .field("d")
+        .end_fields()
+        .start_subarray()
+        .add_range("index", &[0i32, NUM_ELEMS - 1])
+        .end_subarray();
+
+    query = if let Some(qc) = qc {
+        query.with_query_condition(qc)
+    } else {
+        query
+    };
+
+    let mut query = query
+        .build()
+        .map_err(|e| TileDBError::Other(format!("{e}")))?;
+
+    let status = query
+        .submit()
+        .map_err(|e| TileDBError::Other(format!("{e}")))?;
+
+    if !status.is_complete() {
+        return Err(TileDBError::Other("Query incomplete.".to_string()));
+    }
+
+    let buffers = query.buffers().map_err(|e| {
+        TileDBError::Other(format!("Error getting buffers: {e}"))
+    })?;
+
+    let index = buffers.get::<aa::Int32Array>("index").unwrap();
+    let a = buffers.get::<aa::Int32Array>("a").unwrap();
+    let b = buffers.get::<aa::LargeStringArray>("b").unwrap();
+    let c = buffers.get::<aa::Int32Array>("c").unwrap();
+    let d = buffers.get::<aa::Float32Array>("d").unwrap();
+
+    for (index, a, b, c, d) in izip!(index, a, b, c, d) {
+        if a.is_some() {
+            println!(
+                "{}: '{}' '{}' '{}' '{}'",
+                index.unwrap(),
+                a.unwrap(),
+                b.unwrap(),
+                c.unwrap(),
+                d.unwrap()
+            );
+        } else {
+            println!(
+                "{}: null '{}' '{}' '{}'",
+                index.unwrap(),
+                b.unwrap(),
+                c.unwrap(),
+                d.unwrap()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Function to create the TileDB array used in this example.
+/// The array will be 1D with size 1 with dimension "index".
+/// The bounds on the index will be 0 through 9, inclusive.
+///
+/// The array has four attributes. The four attributes are
+///  - "a" (type i32)
+///  - "b" (type String)
+///  - "c" (type i32)
+///  - "d" (type f32)
+fn create_array(ctx: &Context) -> TileDBResult<()> {
+    let domain = {
+        let index = DimensionBuilder::new(
+            ctx,
+            "index",
+            Datatype::Int32,
+            ([0, NUM_ELEMS - 1], 4),
+        )?
+        .build();
+
+        DomainBuilder::new(ctx)?.add_dimension(index)?.build()
+    };
+
+    let attr_a = AttributeBuilder::new(ctx, "a", Datatype::Int32)?
+        .nullability(true)?
+        .build();
+
+    let attr_b = AttributeBuilder::new(ctx, "b", Datatype::StringAscii)?
+        .var_sized()?
+        .build();
+
+    let attr_c = AttributeBuilder::new(ctx, "c", Datatype::Int32)?
+        .fill_value(C_FILL_VALUE)?
+        .build();
+
+    let attr_d = AttributeBuilder::new(ctx, "d", Datatype::Float32)?
+        .fill_value(D_FILL_VALUE)?
+        .build();
+
+    let schema = SchemaBuilder::new(ctx, ArrayType::Dense, domain)?
+        .add_attribute(attr_a)?
+        .add_attribute(attr_b)?
+        .add_attribute(attr_c)?
+        .add_attribute(attr_d)?
+        .build()?;
+
+    Array::create(ctx, ARRAY_URI, schema)
+}
+
+/// Write the following data to the array:
+///
+/// index |  a   |   b   | c |  d
+/// -------------------------------
+///   0   | null | alice | 0 | 4.1
+///   1   | 2    | bob   | 0 | 3.4
+///   2   | null | craig | 0 | 5.6
+///   3   | 4    | dave  | 0 | 3.7
+///   4   | null | erin  | 0 | 2.3
+///   5   | 6    | frank | 0 | 1.7
+///   6   | null | grace | 1 | 3.8
+///   7   | 8    | heidi | 2 | 4.9
+///   8   | null | ivan  | 3 | 3.2
+///   9   | 10   | judy  | 4 | 3.1
+fn write_array(ctx: &Context) -> TileDBResult<()> {
+    let a_data = Arc::new(aa::Int32Array::from(vec![
+        None,
+        Some(2),
+        None,
+        Some(4),
+        None,
+        Some(6),
+        None,
+        Some(8),
+        None,
+        Some(10),
+    ]));
+    let b_data = Arc::new(aa::LargeStringArray::from(vec![
+        "alice", "bob", "craig", "daeve", "erin", "frank", "grace", "heidi",
+        "ivan", "judy",
+    ]));
+    let c_data =
+        Arc::new(aa::Int32Array::from(vec![0i32, 0, 0, 0, 0, 0, 1, 2, 3, 4]));
+    let d_data = Arc::new(aa::Float32Array::from(vec![
+        4.1f32, 3.4, 5.6, 3.7, 2.3, 1.7, 3.8, 4.9, 3.2, 3.1,
+    ]));
+
+    let array =
+        tiledb::Array::open(ctx, ARRAY_URI, tiledb::array::Mode::Write)?;
+
+    let mut query = QueryBuilder::new(array, QueryType::Write)
+        .start_fields()
+        .field_with_buffer("a", a_data)
+        .field_with_buffer("b", b_data)
+        .field_with_buffer("c", c_data)
+        .field_with_buffer("d", d_data)
+        .end_fields()
+        .start_subarray()
+        .add_range("index", &[0i32, NUM_ELEMS - 1])
+        .end_subarray()
+        .build()
+        .map_err(|e| TileDBError::Other(format!("{e}")))?;
+
+    query
+        .submit()
+        .and_then(|_| query.finalize())
+        .map_err(|e| TileDBError::Other(format!("{e}")))?;
+
+    Ok(())
+}

--- a/tiledb/api/examples/query_condition_sparse_arrow.rs
+++ b/tiledb/api/examples/query_condition_sparse_arrow.rs
@@ -1,0 +1,233 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use arrow::array as aa;
+use itertools::izip;
+
+use tiledb::array::{
+    Array, ArrayType, AttributeBuilder, CellOrder, DimensionBuilder,
+    DomainBuilder, SchemaBuilder,
+};
+use tiledb::error::Error as TileDBError;
+use tiledb::query::conditions::QueryConditionExpr as QC;
+use tiledb::query_arrow::{QueryBuilder, QueryLayout, QueryType};
+use tiledb::{Context, Datatype, Result as TileDBResult};
+
+const ARRAY_URI: &str = "query_condition_sparse";
+const NUM_ELEMS: i32 = 10;
+const C_FILL_VALUE: i32 = -1;
+const D_FILL_VALUE: f32 = 0.0;
+
+/// Demonstrate reading sparse arrays with query conditions.
+fn main() -> TileDBResult<()> {
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        let _ = std::env::set_current_dir(
+            PathBuf::from(manifest_dir).join("examples").join("output"),
+        );
+    }
+
+    let ctx = Context::new()?;
+    if Array::exists(&ctx, ARRAY_URI)? {
+        Array::delete(&ctx, ARRAY_URI)?;
+    }
+
+    create_array(&ctx)?;
+    write_array(&ctx)?;
+
+    println!("Reading the entire array:");
+    read_array(&ctx, None)?;
+
+    println!("Reading: a is null");
+    let qc = QC::field("a").is_null();
+    read_array(&ctx, Some(qc))?;
+
+    println!("Reading: b < \"eve\"");
+    let qc = QC::field("b").lt("eve");
+    read_array(&ctx, Some(qc))?;
+
+    println!("Reading: c >= 1");
+    let qc = QC::field("c").ge(1i32);
+    read_array(&ctx, Some(qc))?;
+
+    println!("Reading: 3.0 <= d <= 4.0");
+    let qc = QC::field("d").ge(3.0f32) & QC::field("d").le(4.0f32);
+    read_array(&ctx, Some(qc))?;
+
+    println!("Reading: (a is not null) && (b < \"eve\") && (3.0 <= d <= 4.0)");
+    let qc = QC::field("a").not_null()
+        & QC::field("b").lt("eve")
+        & QC::field("d").ge(3.0f32)
+        & QC::field("d").le(4.0f32);
+    read_array(&ctx, Some(qc))?;
+
+    Ok(())
+}
+
+/// Read the array with the optional query condition and print the results
+/// to stdout.
+fn read_array(ctx: &Context, qc: Option<QC>) -> TileDBResult<()> {
+    let array = tiledb::Array::open(ctx, ARRAY_URI, tiledb::array::Mode::Read)?;
+    let mut query = QueryBuilder::new(array, QueryType::Read)
+        .with_layout(QueryLayout::RowMajor)
+        .start_fields()
+        .field("index")
+        .field("a")
+        .field("b")
+        .field("c")
+        .field("d")
+        .end_fields()
+        .start_subarray()
+        .add_range("index", &[0i32, NUM_ELEMS - 1])
+        .end_subarray();
+
+    query = if let Some(qc) = qc {
+        query.with_query_condition(qc)
+    } else {
+        query
+    };
+
+    let mut query = query.build()?;
+    let status = query.submit()?;
+
+    if !status.is_complete() {
+        return Err(TileDBError::Other("Query did not complete.".to_string()));
+    }
+
+    let buffers = query.buffers()?;
+
+    let index = buffers.get::<aa::Int32Array>("index").unwrap();
+    let a = buffers.get::<aa::Int32Array>("a").unwrap();
+    let b = buffers.get::<aa::LargeStringArray>("b").unwrap();
+    let c = buffers.get::<aa::Int32Array>("c").unwrap();
+    let d = buffers.get::<aa::Float32Array>("d").unwrap();
+
+    for (index, a, b, c, d) in izip!(index, a, b, c, d) {
+        if a.is_some() {
+            println!(
+                "{}: '{}' '{}' '{}', '{}'",
+                index.unwrap(),
+                a.unwrap(),
+                b.unwrap(),
+                c.unwrap(),
+                d.unwrap()
+            )
+        } else {
+            println!(
+                "{}: null '{}', '{}', '{}'",
+                index.unwrap(),
+                b.unwrap(),
+                c.unwrap(),
+                d.unwrap()
+            )
+        }
+    }
+
+    Ok(())
+}
+
+/// Function to create the TileDB array used in this example.
+/// The array will be 1D with size 1 with dimension "index".
+/// The bounds on the index will be 0 through 9, inclusive.
+///
+/// The array has four attributes. The four attributes are
+///  - "a" (type i32)
+///  - "b" (type String)
+///  - "c" (type i32)
+///  - "d" (type f32)
+fn create_array(ctx: &Context) -> TileDBResult<()> {
+    let domain = {
+        let index = DimensionBuilder::new(
+            ctx,
+            "index",
+            Datatype::Int32,
+            ([0, NUM_ELEMS - 1], 4),
+        )?
+        .build();
+
+        DomainBuilder::new(ctx)?.add_dimension(index)?.build()
+    };
+
+    let attr_a = AttributeBuilder::new(ctx, "a", Datatype::Int32)?
+        .nullability(true)?
+        .build();
+
+    let attr_b = AttributeBuilder::new(ctx, "b", Datatype::StringAscii)?
+        .var_sized()?
+        .build();
+
+    let attr_c = AttributeBuilder::new(ctx, "c", Datatype::Int32)?
+        .fill_value(C_FILL_VALUE)?
+        .build();
+
+    let attr_d = AttributeBuilder::new(ctx, "d", Datatype::Float32)?
+        .fill_value(D_FILL_VALUE)?
+        .build();
+
+    let schema = SchemaBuilder::new(ctx, ArrayType::Sparse, domain)?
+        .cell_order(CellOrder::RowMajor)?
+        .add_attribute(attr_a)?
+        .add_attribute(attr_b)?
+        .add_attribute(attr_c)?
+        .add_attribute(attr_d)?
+        .build()?;
+
+    Array::create(ctx, ARRAY_URI, schema)
+}
+
+/// Write the following data to the array:
+///
+/// index |  a   |   b   | c |  d
+/// -------------------------------
+///   0   | null | alice | 0 | 4.1
+///   1   | 2    | bob   | 0 | 3.4
+///   2   | null | craig | 0 | 5.6
+///   3   | 4    | dave  | 0 | 3.7
+///   4   | null | erin  | 0 | 2.3
+///   5   | 6    | frank | 0 | 1.7
+///   6   | null | grace | 1 | 3.8
+///   7   | 8    | heidi | 2 | 4.9
+///   8   | null | ivan  | 3 | 3.2
+///   9   | 10   | judy  | 4 | 3.1
+fn write_array(ctx: &Context) -> TileDBResult<()> {
+    let index_data =
+        Arc::new(aa::Int32Array::from(vec![0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
+    let a_data = Arc::new(aa::Int32Array::from(vec![
+        None,
+        Some(2i32),
+        None,
+        Some(4),
+        None,
+        Some(6),
+        None,
+        Some(8),
+        None,
+        Some(10),
+    ]));
+    let b_data = Arc::new(aa::LargeStringArray::from(vec![
+        "alice", "bob", "craig", "dave", "erin", "frank", "grace", "heidi",
+        "ivan", "judy",
+    ]));
+    let c_data =
+        Arc::new(aa::Int32Array::from(vec![0i32, 0, 0, 0, 0, 0, 1, 2, 3, 4]));
+    let d_data = Arc::new(aa::Float32Array::from(vec![
+        4.1f32, 3.4, 5.6, 3.7, 2.3, 1.7, 3.8, 4.9, 3.2, 3.1,
+    ]));
+
+    let array =
+        tiledb::Array::open(ctx, ARRAY_URI, tiledb::array::Mode::Write)?;
+
+    let mut query = QueryBuilder::new(array, QueryType::Write)
+        .with_layout(QueryLayout::Unordered)
+        .start_fields()
+        .field_with_buffer("index", index_data)
+        .field_with_buffer("a", a_data)
+        .field_with_buffer("b", b_data)
+        .field_with_buffer("c", c_data)
+        .field_with_buffer("d", d_data)
+        .end_fields()
+        .build()?;
+
+    query.submit().and_then(|_| query.finalize())?;
+
+    Ok(())
+}

--- a/tiledb/api/examples/quickstart_dense_arrow.rs
+++ b/tiledb/api/examples/quickstart_dense_arrow.rs
@@ -1,0 +1,176 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use arrow::array::{Array as ArrowArray, Int32Array};
+use itertools::izip;
+
+use tiledb::array::{
+    Array, ArrayType, AttributeBuilder, Dimension, DimensionBuilder,
+    DomainBuilder, Mode as ArrayMode, SchemaBuilder,
+};
+use tiledb::context::Context;
+use tiledb::error::Error as TileDBError;
+use tiledb::query_arrow::{QueryBuilder, QueryLayout, QueryStatus, QueryType};
+use tiledb::Datatype;
+use tiledb::Result as TileDBResult;
+
+const QUICKSTART_DENSE_ARRAY_URI: &str = "quickstart_dense";
+const QUICKSTART_ATTRIBUTE_NAME: &str = "a";
+
+/// Returns whether the example array already exists
+fn array_exists() -> bool {
+    let tdb = match Context::new() {
+        Err(_) => return false,
+        Ok(tdb) => tdb,
+    };
+
+    Array::exists(&tdb, QUICKSTART_DENSE_ARRAY_URI)
+        .expect("Error checking array existence")
+}
+
+/// Creates a dense array at URI `QUICKSTART_DENSE_ARRAY_URI()`.
+/// The array has two i32 dimensions ["rows", "columns"] with a single int32
+/// attribute "a" stored in each cell.
+/// Both "rows" and "columns" dimensions range from 1 to 4, and the tiles
+/// span all 4 elements on each dimension.
+/// Hence we have 16 cells of data and a single tile for the whole array.
+fn create_array() -> TileDBResult<()> {
+    let tdb = Context::new()?;
+
+    let domain = {
+        let rows: tiledb::array::Dimension =
+            tiledb::array::DimensionBuilder::new(
+                &tdb,
+                "rows",
+                Datatype::Int32,
+                ([1, 4], 4),
+            )?
+            .build();
+        let cols: Dimension = DimensionBuilder::new(
+            &tdb,
+            "columns",
+            Datatype::Int32,
+            ([1, 4], 4),
+        )?
+        .build();
+
+        DomainBuilder::new(&tdb)?
+            .add_dimension(rows)?
+            .add_dimension(cols)?
+            .build()
+    };
+
+    let attribute_a = AttributeBuilder::new(
+        &tdb,
+        QUICKSTART_ATTRIBUTE_NAME,
+        Datatype::Int32,
+    )?
+    .build();
+
+    let schema = SchemaBuilder::new(&tdb, ArrayType::Dense, domain)?
+        .add_attribute(attribute_a)?
+        .build()?;
+
+    Array::create(&tdb, QUICKSTART_DENSE_ARRAY_URI, schema)
+}
+
+/// Writes data into the array in row-major order from a 1D-array buffer.
+/// After the write, the contents of the array will be:
+/// [[ 1,  2,  3,  4],
+///  [ 5,  6,  7,  8],
+///  [ 9, 10, 11, 12],
+///  [13, 14, 15, 16]]
+fn write_array() -> TileDBResult<()> {
+    let tdb = Context::new()?;
+
+    let array =
+        Array::open(&tdb, QUICKSTART_DENSE_ARRAY_URI, ArrayMode::Write)?;
+
+    let data: Arc<dyn ArrowArray> = Arc::new(Int32Array::from(vec![
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    ]));
+
+    let mut query = QueryBuilder::new(array, QueryType::Write)
+        .with_layout(QueryLayout::RowMajor)
+        .start_fields()
+        .field_with_buffer(QUICKSTART_ATTRIBUTE_NAME, data)
+        .end_fields()
+        .build()
+        // TODO: Make this not suck
+        .map_err(|e| TileDBError::Other(format!("{}", e)))?;
+
+    let status = query
+        .submit()
+        .map_err(|e| TileDBError::Other(format!("{}", e)))?;
+    if matches!(status, QueryStatus::Completed) {
+        return Ok(());
+    } else {
+        return Err(TileDBError::Other("Something better here.".to_string()));
+    }
+}
+
+/// Query back a slice of our array and print the results to stdout.
+/// The slice on "rows" is [1, 2] and on "columns" is [2, 4],
+/// so the returned data should look like:
+/// [[ _,  2,  3,  4],
+///  [ _,  6,  7,  8],
+///  [ _,  _,  _,  _],
+///  [ _,  _,  _,  _]]]
+/// Data is emitted in row-major order, so this will print "2 3 4 6 7 8".
+fn read_array() -> TileDBResult<()> {
+    let tdb = Context::new()?;
+
+    let array = Array::open(&tdb, QUICKSTART_DENSE_ARRAY_URI, ArrayMode::Read)?;
+
+    let mut query = QueryBuilder::new(array, QueryType::Read)
+        .with_layout(QueryLayout::RowMajor)
+        .start_fields()
+        .field("rows")
+        .field("columns")
+        .field(QUICKSTART_ATTRIBUTE_NAME)
+        .end_fields()
+        .start_subarray()
+        .add_range("rows", &[1i32, 2])
+        .add_range("columns", &[2i32, 4])
+        .end_subarray()
+        .build()
+        .map_err(|e| TileDBError::Other(format!("{}", e)))?;
+
+    let status = query
+        .submit()
+        .map_err(|e| TileDBError::Other(format!("{}", e)))?;
+
+    if !matches!(status, QueryStatus::Completed) {
+        return Err(TileDBError::Other("Make this better.".to_string()));
+    }
+
+    let buffers = query
+        .buffers()
+        .map_err(|e| TileDBError::Other(format!("{}", e)))?;
+    let rows = buffers.get::<Int32Array>("rows").unwrap();
+    let cols = buffers.get::<Int32Array>("columns").unwrap();
+    let attrs = buffers
+        .get::<Int32Array>(QUICKSTART_ATTRIBUTE_NAME)
+        .unwrap();
+
+    for (row, col, attr) in izip!(rows.values(), cols.values(), attrs.values())
+    {
+        println!("{} {} {}", row, col, attr);
+    }
+
+    Ok(())
+}
+
+fn main() {
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        let _ = std::env::set_current_dir(
+            PathBuf::from(manifest_dir).join("examples").join("output"),
+        );
+    }
+
+    if !array_exists() {
+        create_array().expect("Failed to create array");
+    }
+    write_array().expect("Failed to write array");
+    read_array().expect("Failed to read array");
+}

--- a/tiledb/api/examples/quickstart_sparse_string_arrow.rs
+++ b/tiledb/api/examples/quickstart_sparse_string_arrow.rs
@@ -1,0 +1,139 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use arrow::array as aa;
+use itertools::izip;
+
+use tiledb::array::dimension::DimensionConstraints;
+use tiledb::array::{
+    Array, ArrayType, AttributeData, CellOrder, DimensionData, DomainData,
+    SchemaData, TileOrder,
+};
+use tiledb::context::Context;
+use tiledb::error::Error as TileDBError;
+use tiledb::query_arrow::{QueryBuilder, QueryLayout, QueryStatus, QueryType};
+use tiledb::Result as TileDBResult;
+use tiledb::{Datatype, Factory};
+
+const ARRAY_URI: &str = "quickstart_sparse_string";
+
+fn main() -> TileDBResult<()> {
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        let _ = std::env::set_current_dir(
+            PathBuf::from(manifest_dir).join("examples").join("output"),
+        );
+    }
+
+    let ctx = Context::new()?;
+    if Array::exists(&ctx, ARRAY_URI)? {
+        Array::delete(&ctx, ARRAY_URI)?;
+    }
+
+    create_array(&ctx)?;
+    write_array(&ctx)?;
+
+    let array = Array::open(&ctx, ARRAY_URI, tiledb::array::Mode::Read)?;
+    let mut query = QueryBuilder::new(array, QueryType::Read)
+        .with_layout(QueryLayout::RowMajor)
+        .start_fields()
+        .field("rows")
+        .field("cols")
+        .field("a")
+        .end_fields()
+        .start_subarray()
+        .add_range("rows", &["a", "c"])
+        .add_range("cols", &[2, 4])
+        .end_subarray()
+        .build()
+        .map_err(|e| TileDBError::Other(format!("{}", e)))?;
+
+    let status = query
+        .submit()
+        .map_err(|e| TileDBError::Other(format!("{}", e)))?;
+
+    if !matches!(status, QueryStatus::Completed) {
+        return Err(TileDBError::Other("Make this better.".to_string()));
+    }
+
+    let buffers = query
+        .buffers()
+        .map_err(|e| TileDBError::Other(format!("{}", e)))?;
+
+    let rows = buffers.get::<aa::LargeStringArray>("rows").unwrap();
+    let cols = buffers.get::<aa::Int32Array>("cols").unwrap();
+    let attr = buffers.get::<aa::Int32Array>("a").unwrap();
+
+    for (row, col, attr) in izip!(rows, cols.values(), attr.values()) {
+        println!("{} {} {}", row.unwrap(), col, attr);
+    }
+
+    Ok(())
+}
+
+fn create_array(ctx: &Context) -> TileDBResult<()> {
+    let schema = SchemaData {
+        array_type: ArrayType::Sparse,
+        domain: DomainData {
+            dimension: vec![
+                DimensionData {
+                    name: "rows".to_owned(),
+                    datatype: Datatype::StringAscii,
+                    constraints: DimensionConstraints::StringAscii,
+                    filters: None,
+                },
+                DimensionData {
+                    name: "cols".to_owned(),
+                    datatype: Datatype::Int32,
+                    constraints: ([1i32, 4], 4i32).into(),
+                    filters: None,
+                },
+            ],
+        },
+        attributes: vec![AttributeData {
+            name: "a".to_owned(),
+            datatype: Datatype::Int32,
+            ..Default::default()
+        }],
+        tile_order: Some(TileOrder::RowMajor),
+        cell_order: Some(CellOrder::RowMajor),
+
+        ..Default::default()
+    };
+
+    let schema = schema.create(ctx)?;
+    Array::create(ctx, ARRAY_URI, schema)?;
+    Ok(())
+}
+
+fn write_array(ctx: &Context) -> TileDBResult<()> {
+    let row_data = Arc::new(aa::LargeStringArray::from(vec!["a", "bb", "c"]));
+    let col_data = Arc::new(aa::Int32Array::from(vec![1, 4, 3]));
+    let a_data = Arc::new(aa::Int32Array::from(vec![1, 2, 3]));
+
+    let array =
+        tiledb::Array::open(ctx, ARRAY_URI, tiledb::array::Mode::Write)?;
+
+    let mut query = QueryBuilder::new(array, QueryType::Write)
+        .with_layout(CellOrder::Unordered)
+        .start_fields()
+        .field_with_buffer("rows", row_data)
+        .field_with_buffer("cols", col_data)
+        .field_with_buffer("a", a_data)
+        .end_fields()
+        .build()
+        .map_err(|e| TileDBError::Other(format!("{}", e)))?;
+
+    let status = query
+        .submit()
+        .map_err(|e| TileDBError::Other(format!("{}", e)))?;
+
+    if !matches!(status, QueryStatus::Completed) {
+        return Err(TileDBError::Other("Make this better.".to_string()));
+    }
+
+    let (_, _) = query
+        .finalize()
+        .map_err(|e| TileDBError::Other(format!("{e}")))?;
+
+    Ok(())
+}

--- a/tiledb/api/examples/reading_incomplete_arrow.rs
+++ b/tiledb/api/examples/reading_incomplete_arrow.rs
@@ -1,0 +1,179 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use arrow::array as aa;
+use itertools::izip;
+
+use tiledb::array::{
+    Array, ArrayType, AttributeData, CellOrder, CellValNum, DimensionData,
+    DomainData, SchemaData, TileOrder,
+};
+use tiledb::context::Context;
+use tiledb::query_arrow::fields::QueryFieldsBuilder;
+use tiledb::query_arrow::{QueryBuilder, QueryLayout, QueryType};
+use tiledb::Result as TileDBResult;
+use tiledb::{Datatype, Factory};
+
+const ARRAY_URI: &str = "reading_incomplete";
+
+fn main() -> TileDBResult<()> {
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        let _ = std::env::set_current_dir(
+            PathBuf::from(manifest_dir).join("examples").join("output"),
+        );
+    }
+
+    let ctx = Context::new()?;
+    if Array::exists(&ctx, ARRAY_URI)? {
+        Array::delete(&ctx, ARRAY_URI)?;
+    }
+
+    create_array(&ctx)?;
+    write_array(&ctx)?;
+    read_array(&ctx)?;
+    Ok(())
+}
+
+/// Creates a dense array at URI `ARRAY_NAME`.
+/// The array has two i32 dimensions ["rows", "columns"] with two
+/// attributes in each cell - (a1 INT32, a2 CHAR).
+/// Both "rows" and "columns" dimensions range from 1 to 4, and the tiles
+/// span all 4 elements on each dimension.
+/// Hence we have 16 cells of data and a single tile for the whole array.
+fn create_array(ctx: &Context) -> TileDBResult<()> {
+    let schema = SchemaData {
+        array_type: ArrayType::Sparse,
+        domain: DomainData {
+            dimension: vec![
+                DimensionData {
+                    name: "rows".to_owned(),
+                    datatype: Datatype::Int32,
+                    constraints: ([1i32, 4], 4i32).into(),
+                    filters: None,
+                },
+                DimensionData {
+                    name: "cols".to_owned(),
+                    datatype: Datatype::Int32,
+                    constraints: ([1i32, 4], 4i32).into(),
+                    filters: None,
+                },
+            ],
+        },
+        attributes: vec![
+            AttributeData {
+                name: "a1".to_string(),
+                datatype: Datatype::Int32,
+                ..Default::default()
+            },
+            AttributeData {
+                name: "a2".to_string(),
+                datatype: Datatype::StringUtf8,
+                cell_val_num: Some(CellValNum::Var),
+                ..Default::default()
+            },
+        ],
+        tile_order: Some(TileOrder::RowMajor),
+        cell_order: Some(CellOrder::RowMajor),
+
+        ..Default::default()
+    };
+
+    let schema = schema.create(ctx)?;
+    Array::create(ctx, ARRAY_URI, schema)?;
+    Ok(())
+}
+
+/// Writes data into the array.
+/// After the write, the contents of the array will be:
+/// [[ (1, "a"), (2, "bb"),  _, _],
+///  [ _,        (3, "ccc"), _, _],
+///  [ _,        _,          _, _],
+///  [ _,        _,          _, _]]
+fn write_array(ctx: &Context) -> TileDBResult<()> {
+    let rows_data = Arc::new(aa::Int32Array::from(vec![1, 2, 2, 2]));
+    let cols_data = Arc::new(aa::Int32Array::from(vec![1, 1, 2, 3]));
+    let a1_data = Arc::new(aa::Int32Array::from(vec![1, 2, 3, 3]));
+    let a2_data =
+        Arc::new(aa::LargeStringArray::from(vec!["a", "bb", "ccc", "dddd"]));
+
+    let array =
+        tiledb::Array::open(&ctx, ARRAY_URI, tiledb::array::Mode::Write)?;
+
+    let mut query = QueryBuilder::new(array, QueryType::Write)
+        .with_layout(QueryLayout::Global)
+        .start_fields()
+        .field_with_buffer("rows", rows_data)
+        .field_with_buffer("cols", cols_data)
+        .field_with_buffer("a1", a1_data)
+        .field_with_buffer("a2", a2_data)
+        .end_fields()
+        .build()?;
+
+    query.submit().and_then(|_| query.finalize())?;
+    Ok(())
+}
+
+fn read_array(ctx: &Context) -> TileDBResult<()> {
+    let mut curr_capacity = 1;
+
+    let array = tiledb::Array::open(ctx, ARRAY_URI, tiledb::array::Mode::Read)?;
+
+    let make_fields = |capacity| {
+        QueryFieldsBuilder::new()
+            .field_with_capacity("rows", capacity)
+            .field_with_capacity("cols", capacity)
+            .field_with_capacity("a1", capacity)
+            .field_with_capacity("a2", capacity)
+            .build()
+    };
+
+    let mut query = QueryBuilder::new(array, QueryType::Read)
+        .with_layout(QueryLayout::RowMajor)
+        .with_fields(make_fields(curr_capacity))
+        .start_subarray()
+        .add_range("rows", &[1i32, 4])
+        .add_range("cols", &[1i32, 4])
+        .end_subarray()
+        .build()?;
+
+    loop {
+        let status = query.submit()?;
+
+        // Double our buffer sizes if we didn't manage to get any data out
+        // of the query.
+        if !status.has_data() {
+            println!(
+                "Doubling buffer capacity: {} to {}",
+                curr_capacity,
+                curr_capacity * 2
+            );
+            curr_capacity = curr_capacity * 2;
+            query.replace_buffers(make_fields(curr_capacity))?;
+            continue;
+        }
+
+        // Print any results we did get.
+        let buffers = query.buffers()?;
+        let rows = buffers.get::<aa::Int32Array>("rows").unwrap();
+        let cols = buffers.get::<aa::Int32Array>("cols").unwrap();
+        let a1 = buffers.get::<aa::Int32Array>("a1").unwrap();
+        let a2 = buffers.get::<aa::LargeStringArray>("a2").unwrap();
+
+        for (r, c, a1, a2) in izip!(rows, cols, a1, a2) {
+            println!(
+                "\tCell ({}, {}) a1: {}, a2: {}",
+                r.unwrap(),
+                c.unwrap(),
+                a1.unwrap(),
+                a2.unwrap()
+            );
+        }
+
+        // Break from the loop when completed.
+        if status.is_complete() {
+            break;
+        }
+    }
+
+    Ok(())
+}

--- a/tiledb/api/src/array/attribute/mod.rs
+++ b/tiledb/api/src/array/attribute/mod.rs
@@ -751,7 +751,6 @@ impl Factory for AttributeData {
     }
 }
 
-#[cfg(feature = "arrow")]
 pub mod arrow;
 
 #[cfg(any(test, feature = "proptest-strategies"))]

--- a/tiledb/api/src/array/dimension/mod.rs
+++ b/tiledb/api/src/array/dimension/mod.rs
@@ -720,7 +720,6 @@ impl Factory for DimensionData {
     }
 }
 
-#[cfg(feature = "arrow")]
 pub mod arrow;
 
 #[cfg(any(test, feature = "proptest-strategies"))]

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -98,10 +98,6 @@ impl Display for Mode {
 #[derive(
     Clone, Copy, Debug, Deserialize, Eq, OptionSubset, PartialEq, Serialize,
 )]
-#[cfg_attr(
-    any(test, feature = "proptest-strategies"),
-    derive(proptest_derive::Arbitrary)
-)]
 pub enum TileOrder {
     RowMajor,
     ColumnMajor,

--- a/tiledb/api/src/array/schema/mod.rs
+++ b/tiledb/api/src/array/schema/mod.rs
@@ -32,10 +32,6 @@ use crate::{Factory, Result as TileDBResult};
     PartialEq,
     Serialize,
 )]
-#[cfg_attr(
-    any(test, feature = "proptest-strategies"),
-    derive(proptest_derive::Arbitrary)
-)]
 pub enum ArrayType {
     #[default]
     Dense,
@@ -1031,7 +1027,6 @@ impl<'a> Iterator for FieldDataIter<'a> {
 
 impl std::iter::FusedIterator for FieldDataIter<'_> {}
 
-#[cfg(feature = "arrow")]
 pub mod arrow;
 
 #[cfg(any(test, feature = "proptest-strategies"))]

--- a/tiledb/api/src/array/schema/strategy.rs
+++ b/tiledb/api/src/array/schema/strategy.rs
@@ -25,6 +25,15 @@ use crate::filter::strategy::{
     StrategyContext as FilterContext,
 };
 
+impl Arbitrary for ArrayType {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<ArrayType>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        prop_oneof![Just(ArrayType::Dense), Just(ArrayType::Sparse),].boxed()
+    }
+}
+
 #[derive(Clone)]
 pub struct Requirements {
     pub domain: Option<Rc<DomainRequirements>>,

--- a/tiledb/api/src/array/strategy.rs
+++ b/tiledb/api/src/array/strategy.rs
@@ -1,6 +1,19 @@
-#[cfg(test)]
+use proptest::prelude::*;
+
+use super::TileOrder;
+
+impl Arbitrary for TileOrder {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<TileOrder>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        prop_oneof![Just(TileOrder::RowMajor), Just(TileOrder::ColumnMajor),]
+            .boxed()
+    }
+}
+
 mod tests {
-    use proptest::prelude::*;
+    use super::*;
     use util::assert_option_subset;
     use util::option::OptionSubset;
 

--- a/tiledb/api/src/datatype/mod.rs
+++ b/tiledb/api/src/datatype/mod.rs
@@ -795,7 +795,6 @@ macro_rules! physical_type_go {
     }};
 }
 
-#[cfg(feature = "arrow")]
 pub mod arrow;
 
 #[cfg(any(test, feature = "proptest-strategies"))]

--- a/tiledb/api/src/filter/mod.rs
+++ b/tiledb/api/src/filter/mod.rs
@@ -631,7 +631,6 @@ impl PartialEq<Filter> for Filter {
     }
 }
 
-#[cfg(feature = "arrow")]
 pub mod arrow;
 
 #[cfg(any(test, feature = "proptest-strategies"))]

--- a/tiledb/api/src/lib.rs
+++ b/tiledb/api/src/lib.rs
@@ -51,13 +51,13 @@ pub mod group;
 pub mod key;
 pub mod metadata;
 pub mod query;
+pub mod query_arrow;
 #[macro_use]
 pub mod range;
 pub mod stats;
 pub mod string;
 pub mod vfs;
 
-#[cfg(feature = "arrow")]
 pub mod arrow;
 
 #[cfg(test)]

--- a/tiledb/api/src/query/buffer/mod.rs
+++ b/tiledb/api/src/query/buffer/mod.rs
@@ -4,7 +4,6 @@ use std::ops::{Deref, DerefMut};
 
 use crate::array::CellValNum;
 
-#[cfg(feature = "arrow")]
 pub mod arrow;
 
 #[derive(Debug)]

--- a/tiledb/api/src/query/read/output/mod.rs
+++ b/tiledb/api/src/query/read/output/mod.rs
@@ -12,7 +12,6 @@ use crate::query::buffer::*;
 use crate::Result as TileDBResult;
 use crate::{typed_query_buffers_go, Datatype};
 
-#[cfg(feature = "arrow")]
 pub mod arrow;
 #[cfg(any(test, feature = "proptest-strategies"))]
 pub mod strategy;

--- a/tiledb/api/src/query/write/input/mod.rs
+++ b/tiledb/api/src/query/write/input/mod.rs
@@ -9,7 +9,6 @@ use crate::query::buffer::{
 };
 use crate::Result as TileDBResult;
 
-#[cfg(feature = "arrow")]
 pub mod arrow;
 
 pub trait DataProvider {

--- a/tiledb/api/src/query_arrow/arrow.rs
+++ b/tiledb/api/src/query_arrow/arrow.rs
@@ -1,0 +1,520 @@
+use std::sync::Arc;
+
+use arrow::datatypes as adt;
+
+use thiserror::Error;
+
+use crate::array::schema::CellValNum;
+use crate::datatype::Datatype;
+
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum Error {
+    #[error("Cell value size '{0}' is out of range.")]
+    CellValNumOutOfRange(u32),
+
+    #[error("Internal type error: Unhandled Arrow type: {0}")]
+    InternalTypeError(adt::DataType),
+
+    #[error("Invalid fixed sized length: {0}")]
+    InvalidFixedSize(i32),
+
+    #[error("Invalid Arrow type for conversion: '{0}'")]
+    InvalidTargetType(adt::DataType),
+
+    #[error("Failed to convert Arrow list element type: {0}")]
+    ListElementTypeConversionFailed(Box<Error>),
+
+    #[error(
+        "The TileDB datatype '{0}' does not have a default Arrow DataType."
+    )]
+    NoDefaultArrowType(Datatype),
+
+    #[error("Arrow type '{0} requires the TileDB field to be single valued.")]
+    RequiresSingleValued(adt::DataType),
+
+    #[error("Arrow type {0} requires the TileDB field be var sized.")]
+    RequiresVarSized(adt::DataType),
+
+    #[error("TileDB does not support timezones on timestamps")]
+    TimeZonesNotSupported,
+
+    #[error(
+        "TileDB type '{0}' and Arrow type '{1}' have different physical sizes"
+    )]
+    PhysicalSizeMismatch(Datatype, adt::DataType),
+
+    #[error("Unsupported Arrow DataType: {0}")]
+    UnsupportedArrowDataType(adt::DataType),
+
+    #[error("TileDB does not support lists with element type: '{0}'")]
+    UnsupportedListElementType(adt::DataType),
+
+    #[error("The Arrow DataType '{0}' is not supported.")]
+    ArrowTypeNotSupported(adt::DataType),
+    #[error("DataFusion does not support multi-value cells.")]
+    InvalidMultiCellValNum,
+    #[error("The TileDB Datatype '{0}' is not supported by DataFusion")]
+    UnsupportedTileDBDatatype(Datatype),
+    #[error("Variable-length datatypes as list type elements are not supported by TileDB")]
+    UnsupportedListVariableLengthElement,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// ConversionMode dictates whether certain conversions are allowed
+pub enum ConversionMode {
+    /// Only allow conversions that are semantically equivalent
+    Strict,
+    /// Allow conversions as long as the physical type is maintained.
+    Relaxed,
+}
+
+pub struct ToArrowConverter {
+    mode: ConversionMode,
+}
+
+impl ToArrowConverter {
+    pub fn strict() -> Self {
+        Self {
+            mode: ConversionMode::Strict,
+        }
+    }
+
+    pub fn physical() -> Self {
+        Self {
+            mode: ConversionMode::Relaxed,
+        }
+    }
+
+    pub fn convert_datatype(
+        &self,
+        dtype: &Datatype,
+        cvn: &CellValNum,
+        nullable: bool,
+    ) -> Result<adt::DataType> {
+        if let Some(arrow_type) = self.default_arrow_type(dtype) {
+            self.convert_datatype_to(dtype, cvn, nullable, arrow_type)
+        } else {
+            Err(Error::NoDefaultArrowType(*dtype))
+        }
+    }
+
+    pub fn convert_datatype_to(
+        &self,
+        dtype: &Datatype,
+        cvn: &CellValNum,
+        nullable: bool,
+        arrow_type: adt::DataType,
+    ) -> Result<adt::DataType> {
+        if matches!(arrow_type, adt::DataType::Null) {
+            return Err(Error::InvalidTargetType(arrow_type));
+        }
+
+        if arrow_type.is_primitive() {
+            let width = arrow_type.primitive_width().unwrap();
+            if width != dtype.size() as usize {
+                return Err(Error::PhysicalSizeMismatch(*dtype, arrow_type));
+            }
+
+            if cvn.is_single_valued() {
+                return Ok(arrow_type);
+            } else if cvn.is_var_sized() {
+                let field =
+                    Arc::new(adt::Field::new("item", arrow_type, nullable));
+                return Ok(adt::DataType::LargeList(field));
+            } else {
+                // SAFETY: Due to the logic above we can guarantee that this
+                // is a fixed length cvn.
+                let cvn = cvn.fixed().unwrap().get();
+                if cvn > i32::MAX as u32 {
+                    return Err(Error::CellValNumOutOfRange(cvn));
+                }
+                let field =
+                    Arc::new(adt::Field::new("item", arrow_type, nullable));
+                return Ok(adt::DataType::FixedSizeList(field, cvn as i32));
+            }
+        } else if matches!(arrow_type, adt::DataType::Boolean) {
+            if !cvn.is_single_valued() {
+                return Err(Error::RequiresSingleValued(arrow_type));
+            }
+            return Ok(arrow_type);
+        } else if matches!(
+            arrow_type,
+            adt::DataType::LargeBinary | adt::DataType::LargeUtf8
+        ) {
+            if !cvn.is_var_sized() {
+                return Err(Error::RequiresVarSized(arrow_type));
+            }
+            return Ok(arrow_type);
+        } else {
+            return Err(Error::InternalTypeError(arrow_type));
+        }
+    }
+
+    fn default_arrow_type(&self, dtype: &Datatype) -> Option<adt::DataType> {
+        use crate::datatype::Datatype as tiledb;
+        use arrow::datatypes::DataType as arrow;
+        let arrow_type = match dtype {
+            // Any <-> Null, both indicate lack of a type
+            tiledb::Any => Some(arrow::Null),
+
+            // Boolean, n.b., this requires a byte array to bit array converesion
+            tiledb::Boolean => Some(arrow::Boolean),
+
+            // Char -> Int8
+            tiledb::Char => Some(arrow::Int8),
+
+            // Standard primitive types
+            tiledb::Int8 => Some(arrow::Int8),
+            tiledb::Int16 => Some(arrow::Int16),
+            tiledb::Int32 => Some(arrow::Int32),
+            tiledb::Int64 => Some(arrow::Int64),
+            tiledb::UInt8 => Some(arrow::UInt8),
+            tiledb::UInt16 => Some(arrow::UInt16),
+            tiledb::UInt32 => Some(arrow::UInt32),
+            tiledb::UInt64 => Some(arrow::UInt64),
+            tiledb::Float32 => Some(arrow::Float32),
+            tiledb::Float64 => Some(arrow::Float64),
+
+            // Supportable datetime types
+            tiledb::DateTimeSecond => {
+                Some(arrow::Timestamp(adt::TimeUnit::Second, None))
+            }
+            tiledb::DateTimeMillisecond => {
+                Some(arrow::Timestamp(adt::TimeUnit::Millisecond, None))
+            }
+            tiledb::DateTimeMicrosecond => {
+                Some(arrow::Timestamp(adt::TimeUnit::Microsecond, None))
+            }
+            tiledb::DateTimeNanosecond => {
+                Some(arrow::Timestamp(adt::TimeUnit::Nanosecond, None))
+            }
+
+            // Supportable time types
+            tiledb::TimeSecond => Some(arrow::Time64(adt::TimeUnit::Second)),
+            tiledb::TimeMillisecond => {
+                Some(arrow::Time64(adt::TimeUnit::Millisecond))
+            }
+            tiledb::TimeMicrosecond => {
+                Some(arrow::Time64(adt::TimeUnit::Microsecond))
+            }
+            tiledb::TimeNanosecond => {
+                Some(arrow::Time64(adt::TimeUnit::Nanosecond))
+            }
+
+            // Supported string types
+            tiledb::StringAscii => Some(arrow::LargeUtf8),
+            tiledb::StringUtf8 => Some(arrow::LargeUtf8),
+
+            // Blob <-> Binary
+            tiledb::Blob => Some(arrow::LargeBinary),
+
+            tiledb::StringUtf16
+            | tiledb::StringUtf32
+            | tiledb::StringUcs2
+            | tiledb::StringUcs4
+            | tiledb::DateTimeYear
+            | tiledb::DateTimeMonth
+            | tiledb::DateTimeWeek
+            | tiledb::DateTimeDay
+            | tiledb::DateTimeHour
+            | tiledb::DateTimeMinute
+            | tiledb::DateTimePicosecond
+            | tiledb::DateTimeFemtosecond
+            | tiledb::DateTimeAttosecond
+            | tiledb::TimeHour
+            | tiledb::TimeMinute
+            | tiledb::TimePicosecond
+            | tiledb::TimeFemtosecond
+            | tiledb::TimeAttosecond
+            | tiledb::GeometryWkb
+            | tiledb::GeometryWkt => None,
+        };
+
+        if arrow_type.is_some() {
+            return arrow_type;
+        }
+
+        // If we're doing a strict semantic conversion we don't attempt to find
+        // a matching physical type.
+        if matches!(self.mode, ConversionMode::Strict) {
+            return None;
+        }
+
+        // Assert in case we add more conversion modes in the future.
+        assert!(matches!(self.mode, ConversionMode::Relaxed));
+
+        // Physical conversions means we'll allow dropping the TileDB semantic
+        // information to allow for raw data access.
+        match dtype {
+            // Uncommon string types
+            tiledb::StringUtf16 => Some(arrow::UInt16),
+            tiledb::StringUtf32 => Some(arrow::UInt32),
+            tiledb::StringUcs2 => Some(arrow::UInt16),
+            tiledb::StringUcs4 => Some(arrow::UInt32),
+
+            // Time types that could lose data if converted to Arrow's
+            // time resolution.
+            tiledb::DateTimeYear => Some(arrow::Int64),
+            tiledb::DateTimeMonth => Some(arrow::Int64),
+            tiledb::DateTimeWeek => Some(arrow::Int64),
+            tiledb::DateTimeDay => Some(arrow::Int64),
+            tiledb::DateTimeHour => Some(arrow::Int64),
+            tiledb::DateTimeMinute => Some(arrow::Int64),
+            tiledb::DateTimePicosecond => Some(arrow::Int64),
+            tiledb::DateTimeFemtosecond => Some(arrow::Int64),
+            tiledb::DateTimeAttosecond => Some(arrow::Int64),
+            tiledb::TimeHour => Some(arrow::Int64),
+            tiledb::TimeMinute => Some(arrow::Int64),
+            tiledb::TimePicosecond => Some(arrow::Int64),
+            tiledb::TimeFemtosecond => Some(arrow::Int64),
+            tiledb::TimeAttosecond => Some(arrow::Int64),
+
+            // Geometry types
+            tiledb::GeometryWkb => Some(arrow::LargeBinary),
+            tiledb::GeometryWkt => Some(arrow::LargeUtf8),
+
+            // These are all of the types that have strict equivalents and
+            // should have already been handled above.
+            tiledb::Any
+            | tiledb::Boolean
+            | tiledb::Char
+            | tiledb::Int8
+            | tiledb::Int16
+            | tiledb::Int32
+            | tiledb::Int64
+            | tiledb::UInt8
+            | tiledb::UInt16
+            | tiledb::UInt32
+            | tiledb::UInt64
+            | tiledb::Float32
+            | tiledb::Float64
+            | tiledb::DateTimeSecond
+            | tiledb::DateTimeMillisecond
+            | tiledb::DateTimeMicrosecond
+            | tiledb::DateTimeNanosecond
+            | tiledb::TimeSecond
+            | tiledb::TimeMillisecond
+            | tiledb::TimeMicrosecond
+            | tiledb::TimeNanosecond
+            | tiledb::StringAscii
+            | tiledb::StringUtf8
+            | tiledb::Blob => unreachable!("Strict conversion failed"),
+        }
+    }
+}
+
+pub struct FromArrowConverter {
+    mode: ConversionMode,
+}
+
+impl FromArrowConverter {
+    pub fn strict() -> Self {
+        Self {
+            mode: ConversionMode::Strict,
+        }
+    }
+
+    pub fn relaxed() -> Self {
+        Self {
+            mode: ConversionMode::Relaxed,
+        }
+    }
+
+    pub fn convert_datatype(
+        &self,
+        arrow_type: adt::DataType,
+    ) -> Result<(Datatype, CellValNum, Option<bool>)> {
+        use adt::DataType as arrow;
+        use Datatype as tiledb;
+
+        let single = CellValNum::single();
+        let var = CellValNum::Var;
+
+        match arrow_type {
+            arrow::Null => Ok((tiledb::Any, single, None)),
+            arrow::Boolean => Ok((tiledb::Boolean, single, None)),
+
+            arrow::Int8 => Ok((tiledb::Int8, single, None)),
+            arrow::Int16 => Ok((tiledb::Int16, single, None)),
+            arrow::Int32 => Ok((tiledb::Int32, single, None)),
+            arrow::Int64 => Ok((tiledb::Int64, single, None)),
+            arrow::UInt8 => Ok((tiledb::UInt8, single, None)),
+            arrow::UInt16 => Ok((tiledb::UInt16, single, None)),
+            arrow::UInt32 => Ok((tiledb::UInt32, single, None)),
+            arrow::UInt64 => Ok((tiledb::UInt64, single, None)),
+            arrow::Float32 => Ok((tiledb::Float32, single, None)),
+            arrow::Float64 => Ok((tiledb::Float64, single, None)),
+
+            arrow::Timestamp(adt::TimeUnit::Second, None) => {
+                Ok((tiledb::DateTimeSecond, single, None))
+            }
+            arrow::Timestamp(adt::TimeUnit::Millisecond, None) => {
+                Ok((tiledb::DateTimeMillisecond, single, None))
+            }
+            arrow::Timestamp(adt::TimeUnit::Microsecond, None) => {
+                Ok((tiledb::DateTimeMicrosecond, single, None))
+            }
+            arrow::Timestamp(adt::TimeUnit::Nanosecond, None) => {
+                Ok((tiledb::DateTimeNanosecond, single, None))
+            }
+            arrow::Timestamp(_, Some(_)) => {
+                return Err(Error::TimeZonesNotSupported);
+            }
+
+            arrow::Time64(adt::TimeUnit::Second) => {
+                Ok((tiledb::TimeSecond, single, None))
+            }
+            arrow::Time64(adt::TimeUnit::Millisecond) => {
+                Ok((tiledb::TimeMillisecond, single, None))
+            }
+            arrow::Time64(adt::TimeUnit::Microsecond) => {
+                Ok((tiledb::TimeMicrosecond, single, None))
+            }
+            arrow::Time64(adt::TimeUnit::Nanosecond) => {
+                Ok((tiledb::TimeNanosecond, single, None))
+            }
+
+            arrow::Utf8 => Ok((tiledb::StringUtf8, var, None)),
+            arrow::LargeUtf8 => Ok((tiledb::StringUtf8, var, None)),
+            arrow::Binary => Ok((tiledb::Blob, var, None)),
+            arrow::FixedSizeBinary(cvn) => {
+                if cvn < 1 {
+                    return Err(Error::InvalidFixedSize(cvn));
+                }
+                let cvn = if cvn == 1 {
+                    CellValNum::single()
+                } else {
+                    CellValNum::try_from(cvn as u32).unwrap()
+                };
+                Ok((tiledb::Blob, cvn, None))
+            }
+            arrow::LargeBinary => Ok((tiledb::Blob, var, None)),
+
+            arrow::List(field) | arrow::LargeList(field) => {
+                let dtype = field.data_type();
+                if !dtype.is_primitive() {
+                    return Err(Error::UnsupportedListElementType(
+                        dtype.clone(),
+                    ));
+                }
+
+                let (tdb_type, _, _) =
+                    self.convert_datatype(dtype.clone()).map_err(|e| {
+                        Error::ListElementTypeConversionFailed(Box::new(e))
+                    })?;
+
+                Ok((tdb_type, var, Some(field.is_nullable())))
+            }
+
+            arrow::FixedSizeList(field, cvn) => {
+                let dtype = field.data_type();
+                if !dtype.is_primitive() {
+                    return Err(Error::UnsupportedListElementType(
+                        dtype.clone(),
+                    ));
+                }
+
+                let (tdb_type, _, _) =
+                    self.convert_datatype(dtype.clone()).map_err(|e| {
+                        Error::ListElementTypeConversionFailed(Box::new(e))
+                    })?;
+
+                Ok((
+                    tdb_type,
+                    CellValNum::try_from(cvn as u32).unwrap(),
+                    Some(field.is_nullable()),
+                ))
+            }
+
+            // A few relaxed conversions for accepting Arrow types that don't
+            // line up directly with TileDB.
+            arrow::Date32 if self.is_relaxed() => {
+                Ok((tiledb::Int32, single, None))
+            }
+
+            arrow::Date64 if self.is_relaxed() => {
+                Ok((tiledb::Int64, single, None))
+            }
+
+            arrow::Time32(_) if self.is_relaxed() => {
+                Ok((tiledb::Int32, single, None))
+            }
+
+            // Notes on other possible relaxed conversions:
+            //
+            // Duration and some intervals are likely supportable, but
+            // leaving them off for now as the docs aren't clear.
+            //
+            // Views are also likely supportable, but will likely require
+            // separate buffer allocations since individual values are not
+            // contiguous.
+            //
+            // Struct and Union are never supportable (given current core)
+            //
+            // Dictionary is, but they should be handled higher up the stack
+            // to ensure that things line up with enumerations.
+            //
+            // Decimal128 and Decimal256 might be supportable using Float64
+            // and 2 or 4 fixed length cell val num. Though it'd be fairly
+            // hacky.
+            //
+            // Map isn't supported in TileDB (given current core)
+            //
+            // RunEndEncoded is probably supportable, but like views will
+            // require separate buffer allocations so leaving for now.
+            arrow::Float16
+            | arrow::Date32
+            | arrow::Date64
+            | arrow::Time32(_)
+            | arrow::Duration(_)
+            | arrow::Interval(_)
+            | arrow::BinaryView
+            | arrow::Utf8View
+            | arrow::ListView(_)
+            | arrow::LargeListView(_)
+            | arrow::Struct(_)
+            | arrow::Union(_, _)
+            | arrow::Dictionary(_, _)
+            | arrow::Decimal128(_, _)
+            | arrow::Decimal256(_, _)
+            | arrow::Map(_, _)
+            | arrow::RunEndEncoded(_, _) => {
+                return Err(Error::UnsupportedArrowDataType(arrow_type));
+            }
+        }
+    }
+
+    fn is_relaxed(&self) -> bool {
+        matches!(self.mode, ConversionMode::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Datatype;
+
+    /// Test that a datatype is supported as a scalar type
+    /// if and only if it is also supported as a list element type
+    #[test]
+    fn list_unsupported_element() {
+        let conv = ToArrowConverter::strict();
+        for dt in Datatype::iter() {
+            let single_to_arrow =
+                conv.convert_datatype(&dt, &CellValNum::single(), false);
+            let var_to_arrow =
+                conv.convert_datatype(&dt, &CellValNum::Var, false);
+
+            if let Err(Error::RequiresVarSized(_)) = single_to_arrow {
+                assert!(var_to_arrow.is_ok());
+            } else if single_to_arrow.is_err() {
+                assert_eq!(single_to_arrow, var_to_arrow);
+            }
+
+            if var_to_arrow.is_err() {
+                assert_eq!(var_to_arrow, single_to_arrow);
+            }
+        }
+    }
+}

--- a/tiledb/api/src/query_arrow/buffers.rs
+++ b/tiledb/api/src/query_arrow/buffers.rs
@@ -1,0 +1,1645 @@
+use std::any::Any;
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use arrow::array as aa;
+use arrow::buffer::{
+    self as abuf, Buffer as ArrowBuffer, MutableBuffer as ArrowBufferMut,
+};
+use arrow::datatypes as adt;
+use arrow::error::ArrowError;
+use thiserror::Error;
+
+use super::arrow::ToArrowConverter;
+use super::fields::{QueryField, QueryFields};
+use crate::array::schema::{CellValNum, Field, Schema};
+use crate::error::Error as TileDBError;
+
+const AVERAGE_STRING_LENGTH: usize = 64;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Provided Arrow Array is externally referenced.")]
+    ArrayInUse,
+    #[error("Error converting to Arrow for field '{0}': {1}")]
+    ArrowConversionError(String, super::arrow::Error),
+    #[error("Failed to convert Arrow Array for field '{0}': {1}")]
+    FailedConversionFromArrow(String, Box<Error>),
+    #[error("Failed to allocate Arrow array: {0}")]
+    ArrayCreationFailed(ArrowError),
+    #[error("Capacity {0} is to small to hold {1} bytes per cell.")]
+    CapacityTooSmall(usize, usize),
+    #[error("Failed to convert owned buffers into a list array: {0}")]
+    FailedListArrayCreation(ArrowError),
+    #[error("Buffer is immutable")]
+    ImmutableBuffer,
+    #[error("Internal binary type mismatch error")]
+    InternalBinaryType,
+    #[error("Invalid buffer, no offsets present.")]
+    InvalidBufferNoOffsets,
+    #[error("Invalid buffer, no validity present.")]
+    InvalidBufferNoValidity,
+    #[error("Invalid data type for bytes array: {0}")]
+    InvalidBytesType(adt::DataType),
+    #[error("Invalid fixed sized list length {0} is less than 2")]
+    InvalidFixedSizeListLength(i32),
+    #[error("TileDB does not support nullable list elements")]
+    InvalidNullableListElements,
+    #[error("Invalid data type for primitive data: {0}")]
+    InvalidPrimitiveType(adt::DataType),
+    #[error("Internal error: Converted primitive array is not scalar")]
+    InternalListTypeMismatch,
+    #[error("Internal string type mismatch error")]
+    InternalStringType,
+    #[error("Error converting var sized buffers to arrow: {0}")]
+    InvalidVarBuffers(ArrowError),
+    #[error("Only the large variant is supported: {0}")]
+    LargeVariantOnly(adt::DataType),
+    #[error("Failed to convert internal list array: {0}")]
+    ListSubarrayConversion(Box<Error>),
+    #[error("Provided array had external references to its offsets buffer.")]
+    OffsetsInUse,
+    #[error("Internal TileDB Error: {0}")]
+    TileDB(#[from] TileDBError),
+    #[error("Unexpected var sized arrow type: {0}")]
+    UnexpectedArrowVarType(adt::DataType),
+    #[error("Mutable buffers are not shareable.")]
+    UnshareableMutableBuffer,
+    #[error("Unsupported arrow array type: {0}")]
+    UnsupportedArrowType(adt::DataType),
+    #[error(
+        "TileDB only supports fixed size lists of primtiive types, not {0}"
+    )]
+    UnsupportedFixedSizeListType(adt::DataType),
+    #[error("TileDB does not support timezones")]
+    UnsupportedTimeZones,
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+// The Arrow downcast_array function doesn't take an Arc which leaves us
+// with an outstanding reference when we attempt the Buffer::into_mutable
+// call. This function exists to consume the Arc after the cast.
+fn downcast_consume<T>(array: Arc<dyn aa::Array>) -> T
+where
+    T: From<aa::ArrayData>,
+{
+    aa::downcast_array(&array)
+}
+
+#[derive(Clone)]
+struct SizeInfo {
+    data: Pin<Box<u64>>,
+    offsets: Pin<Box<u64>>,
+    validity: Pin<Box<u64>>,
+}
+
+impl Default for SizeInfo {
+    fn default() -> Self {
+        Self {
+            data: Box::pin(0),
+            offsets: Box::pin(0),
+            validity: Box::pin(0),
+        }
+    }
+}
+
+/// The return type for the NewBufferTraitThing's into_arrow method. This
+/// allows for fallible conversion without dropping the underlying buffers.
+type IntoArrowResult = std::result::Result<
+    Arc<dyn aa::Array>,
+    (Box<dyn NewBufferTraitThing>, Error),
+>;
+
+/// The error type to use on TryFrom<Arc<dyn aa::Arrrow>> implementations
+type FromArrowError = (Arc<dyn aa::Array>, Error);
+
+/// The return type to use when implementing TryFrom<Arc<dyn aa::Array>
+type FromArrowResult<T> = std::result::Result<T, FromArrowError>;
+
+/// An interface to our mutable buffer implementations.
+trait NewBufferTraitThing {
+    /// Return this trait object as any for downcasting.
+    fn as_any(&self) -> &dyn Any;
+
+    /// The length of the buffer, in cells
+    fn len(&self) -> usize;
+
+    /// The data buffer
+    fn data(&mut self) -> &mut ArrowBufferMut;
+
+    /// The offsets buffer, for variants that have one
+    fn offsets(&mut self) -> Option<&mut ArrowBufferMut>;
+
+    /// The validity buffer, when present
+    fn validity(&mut self) -> Option<&mut ArrowBufferMut>;
+
+    /// The SizeInfo struct
+    fn sizes(&mut self) -> &mut SizeInfo;
+
+    /// Check if another buffer is compatible with this buffer
+    fn is_compatible(&self, other: &Box<dyn NewBufferTraitThing>) -> bool;
+
+    /// Consume self and return an Arc<dyn aa::Array>
+    fn into_arrow(self: Box<Self>) -> IntoArrowResult;
+
+    /// Reset all buffer lengths to match capacity.
+    ///
+    /// This should happen before a read query so that we're sure to be using
+    /// the entire available buffer rather than just whatever fit in the
+    /// previous iteration.
+    fn reset_len(&mut self) {
+        let data = self.data();
+        data.resize(data.capacity(), 0);
+        self.offsets().map(|o| {
+            // Arrow requires an extra offset that TileDB elides so we need
+            // to leave room for it later.
+            assert!(o.capacity() >= std::mem::size_of::<i64>());
+            o.resize(o.capacity() - std::mem::size_of::<i64>(), 0);
+        });
+        self.validity().map(|v| v.resize(v.capacity(), 0));
+
+        let data_size = self.data().len();
+        let offsets_size = self.offsets().map_or(0, |o| o.len());
+        let validity_size = self.validity().map_or(0, |v| v.len());
+        let sizes = self.sizes();
+        *sizes.data = data_size as u64;
+        *sizes.offsets = offsets_size as u64;
+        *sizes.validity = validity_size as u64;
+    }
+
+    /// Shrink len to data
+    ///
+    /// After a read query, this method is used to update the lenght of all
+    /// buffers to match the number of bytes written by TileDB.
+    fn shrink_len(&mut self) {
+        let sizes = self.sizes().clone();
+        assert!((*sizes.data as usize) <= self.data().capacity());
+        self.data().resize(*sizes.data as usize, 0);
+
+        self.offsets().map(|o| {
+            assert!(
+                (*sizes.offsets as usize)
+                    <= o.capacity() - std::mem::size_of::<i64>()
+            );
+            o.resize(*sizes.offsets as usize, 0);
+        });
+
+        self.validity().map(|v| {
+            assert!((*sizes.validity as usize) <= v.capacity());
+            v.resize(*sizes.validity as usize, 0);
+        });
+    }
+
+    /// Returns a mutable pointer to the data buffer
+    fn data_ptr(&mut self) -> *mut std::ffi::c_void {
+        self.data().as_mut_ptr() as *mut std::ffi::c_void
+    }
+
+    /// Returns a mutable pointer to the data size
+    fn data_size_ptr(&mut self) -> *mut u64 {
+        self.sizes().data.as_mut().get_mut()
+    }
+
+    /// Returns a mutable poiniter to the offsets buffer.
+    ///
+    /// For variants that don't have offsets, it returns a null pointer.
+    fn offsets_ptr(&mut self) -> *mut u64 {
+        let Some(offsets) = self.offsets() else {
+            return std::ptr::null_mut();
+        };
+
+        offsets.as_mut_ptr() as *mut u64
+    }
+
+    /// Returns a mutable pointer to the offsets size.
+    ///
+    /// For variants that don't have offsets, it returns a null pointer.
+    fn offsets_size_ptr(&mut self) -> *mut u64 {
+        let Some(_) = self.offsets() else {
+            return std::ptr::null_mut();
+        };
+
+        self.sizes().offsets.as_mut().get_mut()
+    }
+
+    /// Returns a mutable pointer to the validity buffer, when present
+    ///
+    /// When validity is not present, it returns a null pointer.
+    fn validity_ptr(&mut self) -> *mut u8 {
+        let Some(validity) = self.validity() else {
+            return std::ptr::null_mut();
+        };
+
+        validity.as_mut_ptr()
+    }
+
+    /// Returns a mutable pointer to the validity size, when present
+    ///
+    /// When validity is not present, it returns a null pointer.
+    fn validity_size_ptr(&mut self) -> *mut u64 {
+        let Some(_) = self.validity() else {
+            return std::ptr::null_mut();
+        };
+
+        self.sizes().validity.as_mut().get_mut()
+    }
+}
+
+struct BooleanBuffers {
+    data: ArrowBufferMut,
+    validity: Option<ArrowBufferMut>,
+    sizes: SizeInfo,
+}
+
+impl TryFrom<Arc<dyn aa::Array>> for BooleanBuffers {
+    type Error = FromArrowError;
+    fn try_from(array: Arc<dyn aa::Array>) -> FromArrowResult<Self> {
+        let array: aa::BooleanArray = downcast_consume(array);
+        let (data, validity) = array.into_parts();
+        let data = data
+            .iter()
+            .map(|v| if v { 1u8 } else { 0 })
+            .collect::<Vec<_>>();
+        let validity = to_tdb_validity(validity);
+        let mut sizes = SizeInfo::default();
+        *sizes.data = data.len() as u64;
+        *sizes.validity = validity.as_ref().map_or(0, |v| v.len()) as u64;
+        Ok(BooleanBuffers {
+            data: abuf::MutableBuffer::from(data),
+            validity: validity.map(abuf::MutableBuffer::from),
+            sizes,
+        })
+    }
+}
+
+impl NewBufferTraitThing for BooleanBuffers {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    fn data(&mut self) -> &mut ArrowBufferMut {
+        &mut self.data
+    }
+
+    fn offsets(&mut self) -> Option<&mut ArrowBufferMut> {
+        None
+    }
+
+    fn validity(&mut self) -> Option<&mut ArrowBufferMut> {
+        self.validity.as_mut()
+    }
+
+    fn sizes(&mut self) -> &mut SizeInfo {
+        &mut self.sizes
+    }
+
+    fn is_compatible(&self, other: &Box<dyn NewBufferTraitThing>) -> bool {
+        let Some(other) = other.as_any().downcast_ref::<Self>() else {
+            return false;
+        };
+
+        self.validity.is_some() == other.validity.is_some()
+    }
+
+    fn into_arrow(self: Box<Self>) -> IntoArrowResult {
+        let data =
+            abuf::BooleanBuffer::from_iter(self.data.iter().map(|b| *b != 0));
+        Ok(Arc::new(aa::BooleanArray::new(
+            data,
+            from_tdb_validity(self.validity),
+        )))
+    }
+}
+
+struct ByteBuffers {
+    dtype: adt::DataType,
+    data: ArrowBufferMut,
+    offsets: ArrowBufferMut,
+    validity: Option<ArrowBufferMut>,
+    sizes: SizeInfo,
+}
+
+macro_rules! to_byte_buffers {
+    ($ARRAY:expr, $ARROW_TYPE:expr, $ARROW_DT:ty) => {{
+        let array: $ARROW_DT = downcast_consume($ARRAY);
+        let (offsets, data, nulls) = array.into_parts();
+
+        let data = data.into_mutable();
+        let offsets = offsets.into_inner().into_inner().into_mutable();
+
+        if data.is_ok() && offsets.is_ok() {
+            let data = data.ok().unwrap();
+            let offsets = offsets.ok().unwrap();
+            let validity = to_tdb_validity(nulls);
+            let mut sizes = SizeInfo::default();
+            *sizes.data = data.len() as u64;
+            *sizes.offsets =
+                (offsets.len() - std::mem::size_of::<i64>()) as u64;
+            *sizes.validity = validity.as_ref().map_or(0, |v| v.len()) as u64;
+            return Ok(ByteBuffers {
+                dtype: $ARROW_TYPE,
+                data,
+                offsets,
+                validity,
+                sizes,
+            });
+        }
+
+        let data = if data.is_ok() {
+            ArrowBuffer::from(data.ok().unwrap())
+        } else {
+            data.err().unwrap()
+        };
+
+        let offsets = if offsets.is_ok() {
+            offsets
+                .map(abuf::ScalarBuffer::<i64>::from)
+                .map(abuf::OffsetBuffer::new)
+                .ok()
+                .unwrap()
+        } else {
+            offsets
+                .map_err(abuf::ScalarBuffer::<i64>::from)
+                .map_err(abuf::OffsetBuffer::new)
+                .err()
+                .unwrap()
+        };
+
+        let array: Arc<dyn aa::Array> = Arc::new(
+            aa::LargeBinaryArray::try_new(offsets, data.into(), nulls).unwrap(),
+        );
+        Err((array, Error::OffsetsInUse))
+    }};
+}
+
+impl TryFrom<Arc<dyn aa::Array>> for ByteBuffers {
+    type Error = FromArrowError;
+
+    fn try_from(array: Arc<dyn aa::Array>) -> FromArrowResult<Self> {
+        let dtype = array.data_type().clone();
+        match dtype {
+            adt::DataType::LargeBinary => {
+                to_byte_buffers!(array, dtype.clone(), aa::LargeBinaryArray)
+            }
+            adt::DataType::LargeUtf8 => {
+                to_byte_buffers!(array, dtype.clone(), aa::LargeStringArray)
+            }
+            t => Err((array, Error::InvalidBytesType(t))),
+        }
+    }
+}
+
+impl NewBufferTraitThing for ByteBuffers {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn len(&self) -> usize {
+        self.offsets.len() / std::mem::size_of::<i64>()
+    }
+
+    fn data(&mut self) -> &mut ArrowBufferMut {
+        &mut self.data
+    }
+
+    fn offsets(&mut self) -> Option<&mut ArrowBufferMut> {
+        Some(&mut self.offsets)
+    }
+
+    fn validity(&mut self) -> Option<&mut ArrowBufferMut> {
+        self.validity.as_mut()
+    }
+
+    fn sizes(&mut self) -> &mut SizeInfo {
+        &mut self.sizes
+    }
+
+    fn is_compatible(&self, other: &Box<dyn NewBufferTraitThing>) -> bool {
+        let Some(other) = other.as_any().downcast_ref::<Self>() else {
+            return false;
+        };
+
+        if self.dtype != other.dtype {
+            return false;
+        }
+
+        self.validity.is_some() == other.validity.is_some()
+    }
+
+    fn into_arrow(self: Box<Self>) -> IntoArrowResult {
+        // Make sure we add back the extra offsets element that arrow expects
+        // which TileDB doesn't use.
+        assert!(
+            self.offsets.len()
+                <= self.offsets.capacity() - std::mem::size_of::<i64>()
+        );
+
+        let mut offsets = self.offsets;
+        offsets.extend_from_slice(&[self.data.len() as i64]);
+
+        let dtype = self.dtype;
+        let data = ArrowBuffer::from(self.data);
+        let offsets = ArrowBuffer::from(offsets);
+        let validity = from_tdb_validity(self.validity);
+        let sizes = self.sizes;
+        // N.B., the calls to cloning the data/offsets/validity are as cheap
+        // as an Arc::clone plus pointer and usize copy. They are *not* cloning
+        // the underlying allocated data.
+        aa::ArrayData::try_new(
+            dtype.clone(),
+            *sizes.offsets as usize / std::mem::size_of::<i64>(),
+            validity.clone().map(|v| v.into_inner().into_inner()),
+            0,
+            vec![offsets.clone(), data.clone()],
+            vec![],
+        )
+        .map(|data| aa::make_array(data))
+        .map_err(|e| {
+            // SAFETY: These unwraps are fine because the only other reference
+            // was consumed in the failed try_new call. Unless of course
+            // the ArrowError `e` ever ends up carrying a reference.
+            let boxed: Box<dyn NewBufferTraitThing> = Box::new(ByteBuffers {
+                dtype,
+                data: data.into_mutable().unwrap(),
+                offsets: offsets.into_mutable().unwrap(),
+                validity: to_tdb_validity(validity),
+                sizes,
+            });
+
+            (boxed, Error::ArrayCreationFailed(e))
+        })
+    }
+}
+
+struct FixedListBuffers {
+    field: Arc<adt::Field>,
+    cell_val_num: CellValNum,
+    data: ArrowBufferMut,
+    validity: Option<ArrowBufferMut>,
+    sizes: SizeInfo,
+}
+
+impl TryFrom<Arc<dyn aa::Array>> for FixedListBuffers {
+    type Error = FromArrowError;
+
+    fn try_from(array: Arc<dyn aa::Array>) -> FromArrowResult<Self> {
+        assert!(matches!(
+            array.data_type(),
+            adt::DataType::FixedSizeList(_, _)
+        ));
+
+        let array: aa::FixedSizeListArray = downcast_consume(array);
+        let (field, cvn, array, nulls) = array.into_parts();
+
+        if field.is_nullable() {
+            return Err((array, Error::InvalidNullableListElements));
+        }
+
+        if cvn < 2 {
+            return Err((array, Error::InvalidFixedSizeListLength(cvn)));
+        }
+
+        // SAFETY: We just showed cvn >= 2 && cvn is i32 whicih means
+        // it can't be u32::MAX
+        let cvn = CellValNum::try_from(cvn as u32)
+            .expect("Internal cell val num error");
+
+        let dtype = field.data_type().clone();
+        if !dtype.is_primitive() {
+            return Err((array, Error::UnsupportedFixedSizeListType(dtype)));
+        }
+
+        PrimitiveBuffers::try_from(array)
+            .map(|mut buffers| {
+                assert_eq!(buffers.dtype, dtype);
+                let validity = to_tdb_validity(nulls.clone());
+                *buffers.sizes.validity =
+                    validity.as_ref().map_or(0, |v| v.len()) as u64;
+                FixedListBuffers {
+                    field: Arc::clone(&field),
+                    cell_val_num: cvn,
+                    data: buffers.data,
+                    validity,
+                    sizes: buffers.sizes,
+                }
+            })
+            .map_err(|(array, e)| {
+                let array: Arc<dyn aa::Array> = Arc::new(
+                    aa::FixedSizeListArray::try_new(
+                        field,
+                        u32::from(cvn) as i32,
+                        array,
+                        nulls,
+                    )
+                    .unwrap(),
+                );
+                (array, e)
+            })
+    }
+}
+
+impl NewBufferTraitThing for FixedListBuffers {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn len(&self) -> usize {
+        self.data.len() / u32::from(self.cell_val_num) as usize
+    }
+
+    fn data(&mut self) -> &mut ArrowBufferMut {
+        &mut self.data
+    }
+
+    fn offsets(&mut self) -> Option<&mut ArrowBufferMut> {
+        None
+    }
+
+    fn validity(&mut self) -> Option<&mut ArrowBufferMut> {
+        self.validity.as_mut()
+    }
+
+    fn sizes(&mut self) -> &mut SizeInfo {
+        &mut self.sizes
+    }
+
+    fn is_compatible(&self, other: &Box<dyn NewBufferTraitThing>) -> bool {
+        let Some(other) = other.as_any().downcast_ref::<Self>() else {
+            return false;
+        };
+
+        if self.field != other.field {
+            return false;
+        }
+
+        if self.cell_val_num != other.cell_val_num {
+            return false;
+        }
+
+        self.validity.is_some() == other.validity.is_some()
+    }
+
+    fn into_arrow(self: Box<Self>) -> IntoArrowResult {
+        let field = self.field;
+        let cell_val_num = self.cell_val_num;
+        let data = ArrowBuffer::from(self.data);
+        let validity = from_tdb_validity(self.validity);
+        let sizes = self.sizes;
+
+        assert!(field.data_type().is_primitive());
+        let num_values =
+            *sizes.data as usize / field.data_type().primitive_width().unwrap();
+        let cvn = u32::from(cell_val_num) as i32;
+        let len = num_values / cvn as usize;
+
+        // N.B., data/validity clones are cheap. They are not cloning the
+        // underlying data buffers. We have to clone so that we can put ourself
+        // back together if the array conversion failes.
+        aa::ArrayData::try_new(
+            field.data_type().clone(),
+            len,
+            validity.clone().map(|v| v.into_inner().into_inner()),
+            0,
+            vec![data.clone().into()],
+            vec![],
+        )
+        .map(|data| {
+            let array: Arc<dyn aa::Array> =
+                Arc::new(aa::FixedSizeListArray::new(
+                    Arc::clone(&field),
+                    u32::from(cell_val_num) as i32,
+                    aa::make_array(data),
+                    validity.clone(),
+                ));
+            array
+        })
+        .map_err(|e| {
+            let boxed: Box<dyn NewBufferTraitThing> =
+                Box::new(FixedListBuffers {
+                    field,
+                    cell_val_num,
+                    data: data.into_mutable().unwrap(),
+                    validity: to_tdb_validity(validity),
+                    sizes,
+                });
+
+            (boxed, Error::ArrayCreationFailed(e))
+        })
+    }
+}
+
+struct ListBuffers {
+    field: Arc<adt::Field>,
+    data: ArrowBufferMut,
+    offsets: ArrowBufferMut,
+    validity: Option<ArrowBufferMut>,
+    sizes: SizeInfo,
+}
+
+impl TryFrom<Arc<dyn aa::Array>> for ListBuffers {
+    type Error = FromArrowError;
+
+    fn try_from(array: Arc<dyn aa::Array>) -> FromArrowResult<Self> {
+        assert!(matches!(array.data_type(), adt::DataType::LargeList(_)));
+
+        let array: aa::LargeListArray = downcast_consume(array);
+        let (field, offsets, array, nulls) = array.into_parts();
+
+        if field.is_nullable() {
+            return Err((array, Error::InvalidNullableListElements));
+        }
+
+        let dtype = field.data_type().clone();
+        if !dtype.is_primitive() {
+            return Err((array, Error::UnsupportedFixedSizeListType(dtype)));
+        }
+
+        // N.B., I really, really tried to make this a fancy map/map_err
+        // cascade like all of the others. But it turns out that keeping the
+        // proper refcounts on either array or offsets turns into a bit of
+        // an issue when passing things through multiple closures.
+        let result = PrimitiveBuffers::try_from(array);
+        if result.is_err() {
+            let (array, err) = result.err().unwrap();
+            let array: Arc<dyn aa::Array> = Arc::new(
+                aa::LargeListArray::try_new(
+                    Arc::clone(&field),
+                    offsets,
+                    array,
+                    nulls.clone(),
+                )
+                .unwrap(),
+            );
+            return Err((array, err));
+        }
+
+        let mut data = result.ok().unwrap();
+
+        let result = offsets.into_inner().into_inner().into_mutable();
+        if result.is_err() {
+            let offsets_buffer = result.err().unwrap();
+            let offsets = abuf::OffsetBuffer::new(
+                abuf::ScalarBuffer::<i64>::from(offsets_buffer),
+            );
+            let array: Arc<dyn aa::Array> = Arc::new(
+                aa::LargeListArray::try_new(
+                    Arc::clone(&field),
+                    offsets,
+                    // Safety: We just turned this into a mutable buffer, so
+                    // the inversion should never fail.
+                    Box::new(data).into_arrow().ok().unwrap(),
+                    nulls.clone(),
+                )
+                .unwrap(),
+            );
+            return Err((array, Error::ArrayInUse));
+        }
+
+        // Safety: We already yeeted an error on non-primitive types.
+        let width = dtype.primitive_width().unwrap() as i64;
+        let mut offsets = result.ok().unwrap();
+
+        // TileDB works in offsets of bytes, so we re-map all of our arrow
+        // offsets here.
+        for elem in offsets.typed_data_mut::<i64>() {
+            *elem = *elem * width;
+        }
+
+        let validity = to_tdb_validity(nulls);
+        *data.sizes.offsets =
+            (offsets.len() - std::mem::size_of::<i64>()) as u64;
+        *data.sizes.validity = validity.as_ref().map_or(0, |v| v.len()) as u64;
+
+        Ok(ListBuffers {
+            field,
+            data: data.data,
+            offsets,
+            validity,
+            sizes: data.sizes,
+        })
+    }
+}
+
+impl NewBufferTraitThing for ListBuffers {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn len(&self) -> usize {
+        self.offsets.len() / std::mem::size_of::<i64>()
+    }
+
+    fn data(&mut self) -> &mut ArrowBufferMut {
+        &mut self.data
+    }
+
+    fn offsets(&mut self) -> Option<&mut ArrowBufferMut> {
+        Some(&mut self.offsets)
+    }
+
+    fn validity(&mut self) -> Option<&mut ArrowBufferMut> {
+        self.validity.as_mut()
+    }
+
+    fn sizes(&mut self) -> &mut SizeInfo {
+        &mut self.sizes
+    }
+
+    fn is_compatible(&self, other: &Box<dyn NewBufferTraitThing>) -> bool {
+        let Some(other) = other.as_any().downcast_ref::<Self>() else {
+            return false;
+        };
+
+        if self.field != other.field {
+            return false;
+        }
+
+        self.validity.is_some() == other.validity.is_some()
+    }
+
+    fn into_arrow(self: Box<Self>) -> IntoArrowResult {
+        let field = self.field;
+
+        assert!(field.data_type().is_primitive());
+        let width = field.data_type().primitive_width().unwrap() as i64;
+
+        // Update the last offset to be the total number of bytes written
+        let mut offsets = self.offsets;
+        assert!(
+            offsets.len() <= offsets.capacity() - std::mem::size_of::<i64>()
+        );
+        offsets.extend_from_slice(&[self.data.len() as i64]);
+
+        // Arrow does offsets in terms of elements, not bytes. Here we rewrite
+        // that by dividing all offsets by the width of the primitive type in
+        // the data buffer.
+        let offset_slice = offsets.typed_data_mut::<i64>();
+        for elem in offset_slice {
+            assert!(*elem % width == 0);
+            *elem = *elem / width;
+        }
+
+        let data = ArrowBuffer::from(self.data);
+        let offsets = from_tdb_offsets(offsets);
+        let validity = from_tdb_validity(self.validity);
+        let sizes = self.sizes;
+
+        // N.B., the calls to cloning the data/offsets/validity are as cheap
+        // as an Arc::clone plus pointer and usize copy. They are *not* cloning
+        // the underlying allocated data.
+        aa::ArrayData::try_new(
+            field.data_type().clone(),
+            *sizes.offsets as usize / std::mem::size_of::<i64>(),
+            None,
+            0,
+            vec![data.clone().into()],
+            vec![],
+        )
+        .and_then(|data| {
+            aa::LargeListArray::try_new(
+                field.clone(),
+                offsets.clone(),
+                aa::make_array(data),
+                validity.clone(),
+            )
+        })
+        .map(|array| {
+            let array: Arc<dyn aa::Array> = Arc::new(array);
+            array
+        })
+        .map_err(|e| {
+            let boxed: Box<dyn NewBufferTraitThing> = Box::new(ListBuffers {
+                field,
+                data: data.into_mutable().unwrap(),
+                offsets: to_tdb_offsets(offsets).unwrap(),
+                validity: to_tdb_validity(validity),
+                sizes,
+            });
+
+            (boxed, Error::ArrayCreationFailed(e))
+        })
+    }
+}
+
+struct PrimitiveBuffers {
+    dtype: adt::DataType,
+    data: ArrowBufferMut,
+    validity: Option<ArrowBufferMut>,
+    sizes: SizeInfo,
+}
+
+macro_rules! to_primitive {
+    ($ARRAY:expr, $ARROW_DT:ty) => {{
+        let array: $ARROW_DT = downcast_consume($ARRAY);
+        let len = array.len();
+        let (dtype, buffer, nulls) = array.into_parts();
+
+        buffer
+            .into_inner()
+            .into_mutable()
+            .map(|data| {
+                let validity = to_tdb_validity(nulls.clone());
+                let mut sizes = SizeInfo::default();
+                *sizes.data = data.len() as u64;
+                *sizes.validity =
+                    validity.as_ref().map_or(0, |v| v.len()) as u64;
+                PrimitiveBuffers {
+                    dtype: dtype.clone(),
+                    data,
+                    validity,
+                    sizes,
+                }
+            })
+            .map_err(|buffer| {
+                // Safety: We just broke an array open to get these so
+                // unless someone did something unsafe they should go
+                // right back together again. Sorry, Humpty.
+                let data = aa::ArrayData::try_new(
+                    dtype,
+                    len,
+                    nulls.map(|n| n.into_inner().into_inner()),
+                    0,
+                    vec![buffer],
+                    vec![],
+                )
+                .unwrap();
+                (aa::make_array(data), Error::ArrayInUse)
+            })
+    }};
+}
+
+impl TryFrom<Arc<dyn aa::Array>> for PrimitiveBuffers {
+    type Error = FromArrowError;
+    fn try_from(array: Arc<dyn aa::Array>) -> FromArrowResult<Self> {
+        assert!(array.data_type().is_primitive());
+
+        match array.data_type().clone() {
+            adt::DataType::Int8 => to_primitive!(array, aa::Int8Array),
+            adt::DataType::Int16 => to_primitive!(array, aa::Int16Array),
+            adt::DataType::Int32 => to_primitive!(array, aa::Int32Array),
+            adt::DataType::Int64 => to_primitive!(array, aa::Int64Array),
+            adt::DataType::UInt8 => to_primitive!(array, aa::UInt8Array),
+            adt::DataType::UInt16 => to_primitive!(array, aa::UInt16Array),
+            adt::DataType::UInt32 => to_primitive!(array, aa::UInt32Array),
+            adt::DataType::UInt64 => to_primitive!(array, aa::UInt64Array),
+            adt::DataType::Float32 => to_primitive!(array, aa::Float32Array),
+            adt::DataType::Float64 => to_primitive!(array, aa::Float64Array),
+            t => Err((array, Error::InvalidPrimitiveType(t))),
+        }
+    }
+}
+
+impl NewBufferTraitThing for PrimitiveBuffers {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn len(&self) -> usize {
+        assert!(self.dtype.is_primitive());
+        self.data.len() / self.dtype.primitive_width().unwrap()
+    }
+
+    fn data(&mut self) -> &mut ArrowBufferMut {
+        &mut self.data
+    }
+
+    fn offsets(&mut self) -> Option<&mut ArrowBufferMut> {
+        None
+    }
+
+    fn validity(&mut self) -> Option<&mut ArrowBufferMut> {
+        self.validity.as_mut()
+    }
+
+    fn sizes(&mut self) -> &mut SizeInfo {
+        &mut self.sizes
+    }
+
+    fn is_compatible(&self, other: &Box<dyn NewBufferTraitThing>) -> bool {
+        let Some(other) = other.as_any().downcast_ref::<Self>() else {
+            return false;
+        };
+
+        if self.dtype != other.dtype {
+            return false;
+        }
+
+        self.validity.is_some() == other.validity.is_some()
+    }
+
+    fn into_arrow(self: Box<Self>) -> IntoArrowResult {
+        let dtype = self.dtype;
+        let data = ArrowBuffer::from(self.data);
+        let validity = from_tdb_validity(self.validity);
+        let sizes = self.sizes;
+
+        assert!(dtype.is_primitive());
+
+        // N.B., data/validity clones are cheap. They are not cloning the
+        // underlying data buffers. We have to clone so that we can put ourself
+        // back together if the array conversion failes.
+        aa::ArrayData::try_new(
+            dtype.clone(),
+            *sizes.data as usize / dtype.primitive_width().unwrap(),
+            validity.clone().map(|v| v.into_inner().into_inner()),
+            0,
+            vec![data.clone()],
+            vec![],
+        )
+        .map(aa::make_array)
+        .map_err(|e| {
+            let boxed: Box<dyn NewBufferTraitThing> =
+                Box::new(PrimitiveBuffers {
+                    dtype,
+                    data: data.into_mutable().unwrap(),
+                    validity: to_tdb_validity(validity),
+                    sizes,
+                });
+
+            (boxed, Error::ArrayCreationFailed(e))
+        })
+    }
+}
+
+impl TryFrom<Arc<dyn aa::Array>> for Box<dyn NewBufferTraitThing> {
+    type Error = FromArrowError;
+
+    fn try_from(array: Arc<dyn aa::Array>) -> FromArrowResult<Self> {
+        let dtype = array.data_type().clone();
+        match dtype {
+            adt::DataType::Boolean => {
+                BooleanBuffers::try_from(array).map(|buffers| {
+                    let boxed: Box<dyn NewBufferTraitThing> = Box::new(buffers);
+                    boxed
+                })
+            }
+            adt::DataType::LargeBinary | adt::DataType::LargeUtf8 => {
+                ByteBuffers::try_from(array).map(|buffers| {
+                    let boxed: Box<dyn NewBufferTraitThing> = Box::new(buffers);
+                    boxed
+                })
+            }
+            adt::DataType::FixedSizeList(_, _) => {
+                FixedListBuffers::try_from(array).map(|buffers| {
+                    let boxed: Box<dyn NewBufferTraitThing> = Box::new(buffers);
+                    boxed
+                })
+            }
+            adt::DataType::LargeList(_) => {
+                ListBuffers::try_from(array).map(|buffers| {
+                    let boxed: Box<dyn NewBufferTraitThing> = Box::new(buffers);
+                    boxed
+                })
+            }
+            adt::DataType::Int8
+            | adt::DataType::Int16
+            | adt::DataType::Int32
+            | adt::DataType::Int64
+            | adt::DataType::UInt8
+            | adt::DataType::UInt16
+            | adt::DataType::UInt32
+            | adt::DataType::UInt64
+            | adt::DataType::Float32
+            | adt::DataType::Float64
+            | adt::DataType::Timestamp(_, None)
+            | adt::DataType::Time64(_) => PrimitiveBuffers::try_from(array)
+                .map(|buffers| {
+                    let boxed: Box<dyn NewBufferTraitThing> = Box::new(buffers);
+                    boxed
+                }),
+
+            adt::DataType::Timestamp(_, Some(_)) => {
+                Err((array, Error::UnsupportedTimeZones))
+            }
+
+            adt::DataType::Binary
+            | adt::DataType::List(_)
+            | adt::DataType::Utf8 => {
+                Err((array, Error::LargeVariantOnly(dtype)))
+            }
+
+            adt::DataType::FixedSizeBinary(_) => {
+                todo!("This can probably be supported.")
+            }
+
+            adt::DataType::Null
+            | adt::DataType::Float16
+            | adt::DataType::Date32
+            | adt::DataType::Date64
+            | adt::DataType::Time32(_)
+            | adt::DataType::Duration(_)
+            | adt::DataType::Interval(_)
+            | adt::DataType::BinaryView
+            | adt::DataType::Utf8View
+            | adt::DataType::ListView(_)
+            | adt::DataType::LargeListView(_)
+            | adt::DataType::Struct(_)
+            | adt::DataType::Union(_, _)
+            | adt::DataType::Dictionary(_, _)
+            | adt::DataType::Decimal128(_, _)
+            | adt::DataType::Decimal256(_, _)
+            | adt::DataType::Map(_, _)
+            | adt::DataType::RunEndEncoded(_, _) => {
+                return Err((array, Error::UnsupportedArrowType(dtype)));
+            }
+        }
+    }
+}
+
+/// A utility that requires it contains exactly one of two variants
+///
+/// Unfortuantely, mutating enum variants through a mutable reference isn't
+/// a thing that can be done safely, so we have a specialized utility struct
+/// that does the same idea, at the cost of an extra None in the struct.
+struct MutableOrShared {
+    mutable: Option<Box<dyn NewBufferTraitThing>>,
+    shared: Option<Arc<dyn aa::Array>>,
+}
+
+impl MutableOrShared {
+    pub fn new(value: Arc<dyn aa::Array>) -> Self {
+        Self {
+            mutable: None,
+            shared: Some(value),
+        }
+    }
+
+    pub fn mutable(&mut self) -> Option<&mut Box<dyn NewBufferTraitThing>> {
+        self.mutable.as_mut()
+    }
+
+    pub fn shared(&self) -> Option<Arc<dyn aa::Array>> {
+        self.shared.as_ref().map(Arc::clone)
+    }
+
+    pub fn to_mutable(&mut self) -> Result<()> {
+        self.validate();
+
+        if self.mutable.is_some() {
+            return Ok(());
+        }
+
+        let shared = self.shared.take().unwrap();
+        let mutable: FromArrowResult<Box<dyn NewBufferTraitThing>> =
+            shared.try_into();
+
+        let ret = if mutable.is_ok() {
+            self.mutable = mutable.ok();
+            Ok(())
+        } else {
+            let (array, err) = mutable.err().unwrap();
+            self.shared = Some(array);
+            Err(err)
+        };
+
+        self.validate();
+        ret
+    }
+
+    pub fn to_shared(&mut self) -> Result<()> {
+        self.validate();
+
+        if self.shared.is_some() {
+            return Ok(());
+        }
+
+        let mutable = self.mutable.take().unwrap();
+        let shared = mutable.into_arrow();
+
+        let ret = if shared.is_ok() {
+            self.shared = shared.ok();
+            Ok(())
+        } else {
+            let (mutable, err) = shared.err().unwrap();
+            self.mutable = Some(mutable);
+            Err(err)
+        };
+
+        self.validate();
+        ret
+    }
+
+    fn validate(&self) {
+        assert!(
+            (self.shared.is_some() && self.mutable.is_none())
+                || (self.shared.is_none() && self.mutable.is_some())
+        )
+    }
+}
+
+pub struct BufferEntry {
+    entry: MutableOrShared,
+}
+
+impl BufferEntry {
+    pub fn as_shared(&self) -> Result<Arc<dyn aa::Array>> {
+        let Some(ref array) = self.entry.shared() else {
+            return Err(Error::UnshareableMutableBuffer);
+        };
+
+        return Ok(Arc::clone(array));
+    }
+
+    pub fn len(&self) -> usize {
+        if self.entry.shared.is_some() {
+            return self.entry.shared.as_ref().unwrap().len();
+        } else {
+            self.entry.mutable.as_ref().unwrap().len()
+        }
+    }
+
+    pub fn is_compatible(&self, other: &BufferEntry) -> bool {
+        if self.entry.mutable.is_some() && other.entry.mutable.is_some() {
+            return self
+                .entry
+                .mutable
+                .as_ref()
+                .unwrap()
+                .is_compatible(other.entry.mutable.as_ref().unwrap());
+        }
+
+        false
+    }
+
+    pub fn reset_len(&mut self) -> Result<()> {
+        let Some(mutable) = self.entry.mutable() else {
+            return Err(Error::ImmutableBuffer);
+        };
+
+        mutable.reset_len();
+        Ok(())
+    }
+
+    pub fn shrink_len(&mut self) -> Result<()> {
+        let Some(mutable) = self.entry.mutable() else {
+            return Err(Error::ImmutableBuffer);
+        };
+
+        mutable.shrink_len();
+        Ok(())
+    }
+
+    pub fn data_ptr(&mut self) -> Result<*mut std::ffi::c_void> {
+        let Some(mutable) = self.entry.mutable() else {
+            return Err(Error::ImmutableBuffer);
+        };
+
+        Ok(mutable.data_ptr())
+    }
+
+    pub fn data_size_ptr(&mut self) -> Result<*mut u64> {
+        let Some(mutable) = self.entry.mutable() else {
+            return Err(Error::ImmutableBuffer);
+        };
+
+        Ok(mutable.data_size_ptr())
+    }
+
+    pub fn has_offsets(&mut self) -> Result<bool> {
+        let Some(mutable) = self.entry.mutable() else {
+            return Err(Error::ImmutableBuffer);
+        };
+
+        Ok(mutable.offsets_ptr() != std::ptr::null_mut())
+    }
+
+    pub fn offsets_ptr(&mut self) -> Result<*mut u64> {
+        let Some(mutable) = self.entry.mutable() else {
+            return Err(Error::ImmutableBuffer);
+        };
+
+        Ok(mutable.offsets_ptr())
+    }
+
+    pub fn offsets_size_ptr(&mut self) -> Result<*mut u64> {
+        let Some(mutable) = self.entry.mutable() else {
+            return Err(Error::ImmutableBuffer);
+        };
+
+        Ok(mutable.offsets_size_ptr())
+    }
+
+    pub fn has_validity(&mut self) -> Result<bool> {
+        let Some(mutable) = self.entry.mutable() else {
+            return Err(Error::ImmutableBuffer);
+        };
+
+        Ok(mutable.validity_ptr() != std::ptr::null_mut())
+    }
+
+    pub fn validity_ptr(&mut self) -> Result<*mut u8> {
+        let Some(mutable) = self.entry.mutable() else {
+            return Err(Error::ImmutableBuffer);
+        };
+
+        Ok(mutable.validity_ptr())
+    }
+
+    pub fn validity_size_ptr(&mut self) -> Result<*mut u64> {
+        let Some(mutable) = self.entry.mutable() else {
+            return Err(Error::ImmutableBuffer);
+        };
+
+        Ok(mutable.validity_size_ptr())
+    }
+
+    fn to_mutable(&mut self) -> Result<()> {
+        self.entry.to_mutable()
+    }
+
+    fn to_shared(&mut self) -> Result<()> {
+        self.entry.to_shared()
+    }
+}
+
+impl From<Arc<dyn aa::Array>> for BufferEntry {
+    fn from(array: Arc<dyn aa::Array>) -> Self {
+        Self {
+            entry: MutableOrShared::new(array),
+        }
+    }
+}
+
+pub struct QueryBuffers {
+    buffers: HashMap<String, BufferEntry>,
+}
+
+impl QueryBuffers {
+    pub fn new(buffers: HashMap<String, Arc<dyn aa::Array>>) -> Self {
+        let mut new_buffers = HashMap::with_capacity(buffers.len());
+        for (field, array) in buffers.into_iter() {
+            new_buffers.insert(field, BufferEntry::from(array));
+        }
+        Self {
+            buffers: new_buffers,
+        }
+    }
+
+    /// Reset all mutable buffers' len to match its total capacity.
+    pub fn reset_lengths(&mut self) -> Result<()> {
+        for array in self.buffers.values_mut() {
+            array.reset_len()?;
+        }
+        Ok(())
+    }
+
+    /// Shrink all mutable buffers' len to match what the TileDB size read.
+    pub fn shrink_lengths(&mut self) -> Result<()> {
+        for array in self.buffers.values_mut() {
+            array.shrink_len()?;
+        }
+        Ok(())
+    }
+
+    pub fn len(&self) -> usize {
+        self.buffers.len()
+    }
+
+    pub fn fields(&self) -> Vec<String> {
+        self.buffers.keys().cloned().collect::<Vec<_>>()
+    }
+
+    pub fn get(&self, key: &String) -> Option<&BufferEntry> {
+        self.buffers.get(key)
+    }
+
+    pub fn get_mut(&mut self, key: &String) -> Option<&mut BufferEntry> {
+        self.buffers.get_mut(key)
+    }
+
+    pub fn from_fields(schema: Schema, fields: QueryFields) -> Result<Self> {
+        let conv = ToArrowConverter::strict();
+        let mut ret = HashMap::with_capacity(fields.fields.len());
+        for (name, field) in fields.fields.into_iter() {
+            let tdb_field = schema.field(name.clone())?;
+
+            if let QueryField::Buffer(array) = field {
+                Self::validate_buffer(&tdb_field, &array)?;
+                ret.insert(name.clone(), array);
+                continue;
+            }
+
+            // ToDo: Clean these error conversions up so they clearly indicate
+            // a failed buffer creation.
+            let tdb_dtype = tdb_field.datatype()?;
+            let tdb_cvn = tdb_field.cell_val_num()?;
+            let tdb_nullable = tdb_field.nullability()?;
+            let arrow_type = if let Some(dtype) = field.target_type() {
+                conv.convert_datatype_to(
+                    &tdb_dtype,
+                    &tdb_cvn,
+                    tdb_nullable,
+                    dtype,
+                )
+            } else {
+                conv.convert_datatype(&tdb_dtype, &tdb_cvn, tdb_nullable)
+            }
+            .map_err(|e| Error::ArrowConversionError(name.clone(), e))?;
+
+            let array = alloc_array(
+                arrow_type,
+                tdb_nullable,
+                field.capacity().unwrap(),
+            )?;
+            ret.insert(name.clone(), array);
+        }
+
+        Ok(Self::new(ret))
+    }
+
+    pub fn is_compatible(&self, other: &Self) -> bool {
+        let mut my_keys = self.buffers.keys().collect::<Vec<_>>();
+        let mut their_keys = other.buffers.keys().collect::<Vec<_>>();
+
+        my_keys.sort();
+        their_keys.sort();
+        if my_keys != their_keys {
+            return false;
+        }
+
+        for key in my_keys {
+            let mine = self.buffers.get(key);
+            let theirs = other.buffers.get(key);
+
+            if mine.is_none() || theirs.is_none() {
+                return false;
+            }
+
+            if !mine.unwrap().is_compatible(theirs.unwrap()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &BufferEntry)> {
+        self.buffers.iter()
+    }
+
+    pub fn iter_mut(
+        &mut self,
+    ) -> impl Iterator<Item = (&String, &mut BufferEntry)> {
+        self.buffers.iter_mut()
+    }
+
+    pub fn to_mutable(&mut self) -> Result<()> {
+        for value in self.buffers.values_mut() {
+            value.to_mutable()?
+        }
+        Ok(())
+    }
+
+    pub fn to_shared(&mut self) -> Result<()> {
+        for value in self.buffers.values_mut() {
+            value.to_shared()?
+        }
+        Ok(())
+    }
+
+    /// When I get to it, this needs to ensure that the provided array matches
+    /// the field's TileDB datatype.
+    fn validate_buffer(
+        _field: &Field,
+        _buffer: &Arc<dyn aa::Array>,
+    ) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// A small helper for users writing code directly against the TileDB API
+///
+/// This struct is freely convertible to and from a HashMap of Arrow arrays.
+pub struct SharedBuffers {
+    buffers: HashMap<String, Arc<dyn aa::Array>>,
+}
+
+impl SharedBuffers {
+    pub fn get<T: Any>(&self, key: &str) -> Option<&T>
+    where
+        T: Any,
+    {
+        self.buffers.get(key)?.as_any().downcast_ref::<T>()
+    }
+}
+
+impl From<HashMap<String, Arc<dyn aa::Array>>> for SharedBuffers {
+    fn from(buffers: HashMap<String, Arc<dyn aa::Array>>) -> Self {
+        Self { buffers }
+    }
+}
+
+impl From<SharedBuffers> for HashMap<String, Arc<dyn aa::Array>> {
+    fn from(buffers: SharedBuffers) -> Self {
+        buffers.buffers
+    }
+}
+
+fn alloc_array(
+    dtype: adt::DataType,
+    nullable: bool,
+    capacity: usize,
+) -> Result<Arc<dyn aa::Array>> {
+    let num_cells = calculate_num_cells(dtype.clone(), nullable, capacity)?;
+
+    match dtype {
+        adt::DataType::Boolean => {
+            Ok(Arc::new(aa::BooleanArray::new_null(num_cells)))
+        }
+        adt::DataType::LargeList(field) => {
+            let offsets = abuf::OffsetBuffer::<i64>::new_zeroed(num_cells);
+            let value_capacity =
+                capacity - (num_cells * std::mem::size_of::<i64>());
+            let values =
+                alloc_array(field.data_type().clone(), false, value_capacity)?;
+            let nulls = if nullable {
+                Some(abuf::NullBuffer::new_null(num_cells))
+            } else {
+                None
+            };
+            Ok(Arc::new(
+                aa::LargeListArray::try_new(field, offsets, values, nulls)
+                    .map_err(Error::ArrayCreationFailed)?,
+            ))
+        }
+        adt::DataType::FixedSizeList(field, cvn) => {
+            let nulls = if nullable {
+                Some(abuf::NullBuffer::new_null(num_cells))
+            } else {
+                None
+            };
+            let values =
+                alloc_array(field.data_type().clone(), false, capacity)?;
+            Ok(Arc::new(
+                aa::FixedSizeListArray::try_new(field, cvn, values, nulls)
+                    .map_err(Error::ArrayCreationFailed)?,
+            ))
+        }
+        adt::DataType::LargeUtf8 => {
+            let offsets = abuf::OffsetBuffer::<i64>::new_zeroed(num_cells);
+            let values = ArrowBufferMut::from_len_zeroed(
+                capacity - (num_cells * std::mem::size_of::<i64>()),
+            );
+            let nulls = if nullable {
+                Some(abuf::NullBuffer::new_null(num_cells))
+            } else {
+                None
+            };
+            Ok(Arc::new(
+                aa::LargeStringArray::try_new(offsets, values.into(), nulls)
+                    .map_err(Error::ArrayCreationFailed)?,
+            ))
+        }
+        adt::DataType::LargeBinary => {
+            let offsets = abuf::OffsetBuffer::<i64>::new_zeroed(num_cells);
+            let values = ArrowBufferMut::from_len_zeroed(
+                capacity - (num_cells * std::mem::size_of::<i64>()),
+            );
+            let nulls = if nullable {
+                Some(abuf::NullBuffer::new_null(num_cells))
+            } else {
+                None
+            };
+            Ok(Arc::new(
+                aa::LargeBinaryArray::try_new(offsets, values.into(), nulls)
+                    .map_err(Error::ArrayCreationFailed)?,
+            ))
+        }
+        _ if dtype.is_primitive() => {
+            let data = ArrowBufferMut::from_len_zeroed(
+                num_cells * dtype.primitive_width().unwrap(),
+            );
+
+            let nulls = if nullable {
+                Some(ArrowBufferMut::from_len_zeroed(num_cells).into())
+            } else {
+                None
+            };
+
+            let data = aa::ArrayData::try_new(
+                dtype,
+                num_cells,
+                nulls,
+                0,
+                vec![data.into()],
+                vec![],
+            )
+            .map_err(|e| Error::ArrayCreationFailed(e))?;
+
+            Ok(aa::make_array(data))
+        }
+        _ => todo!(),
+    }
+}
+
+fn calculate_num_cells(
+    dtype: adt::DataType,
+    nullable: bool,
+    capacity: usize,
+) -> Result<usize> {
+    match dtype {
+        adt::DataType::Boolean => {
+            if nullable {
+                Ok(capacity * 8 / 2)
+            } else {
+                Ok(capacity * 8)
+            }
+        }
+        adt::DataType::LargeList(ref field) => {
+            if !field.data_type().is_primitive() {
+                return Err(Error::UnsupportedArrowType(dtype.clone()));
+            }
+
+            // Todo: Figure out a better way to approximate values to offsets ratios
+            // based on whatever Python does or some such.
+            //
+            // For now, I'll pull a guess at of the ether and assume on average a
+            // var sized primitive array averages two values per cell. Becuase why
+            // not?
+            let width = field.data_type().primitive_width().unwrap();
+            let bytes_per_cell = (width * 2)
+                + std::mem::size_of::<i64>()
+                + if nullable { 1 } else { 0 };
+            Ok(capacity / bytes_per_cell)
+        }
+        adt::DataType::FixedSizeList(ref field, cvn) => {
+            if !field.data_type().is_primitive() {
+                return Err(Error::UnsupportedArrowType(dtype));
+            }
+
+            if cvn < 2 {
+                return Err(Error::InvalidFixedSizeListLength(cvn));
+            }
+
+            let cvn = cvn as usize;
+            let width = field.data_type().primitive_width().unwrap();
+            let bytes_per_cell = capacity / (width * cvn);
+            let bytes_per_cell = if nullable {
+                bytes_per_cell + 1
+            } else {
+                bytes_per_cell
+            };
+            Ok(capacity / bytes_per_cell)
+        }
+        adt::DataType::LargeUtf8 | adt::DataType::LargeBinary => {
+            let bytes_per_cell =
+                AVERAGE_STRING_LENGTH + std::mem::size_of::<i64>();
+            let bytes_per_cell = if nullable {
+                bytes_per_cell + 1
+            } else {
+                bytes_per_cell
+            };
+            Ok(capacity / bytes_per_cell)
+        }
+        _ if dtype.is_primitive() => {
+            let width = dtype.primitive_width().unwrap();
+            let bytes_per_cell = width + if nullable { 1 } else { 0 };
+            Ok(capacity / bytes_per_cell)
+        }
+        _ => Err(Error::UnsupportedArrowType(dtype.clone())),
+    }
+}
+
+// Private utility functions
+
+fn to_tdb_offsets(offsets: abuf::OffsetBuffer<i64>) -> Result<ArrowBufferMut> {
+    offsets
+        .into_inner()
+        .into_inner()
+        .into_mutable()
+        .map_err(|_| Error::ArrayInUse)
+}
+
+fn to_tdb_validity(nulls: Option<abuf::NullBuffer>) -> Option<ArrowBufferMut> {
+    nulls.map(|nulls| {
+        ArrowBufferMut::from(
+            nulls
+                .iter()
+                .map(|v| if v { 1u8 } else { 0 })
+                .collect::<Vec<_>>(),
+        )
+    })
+}
+
+fn from_tdb_offsets(offsets: ArrowBufferMut) -> abuf::OffsetBuffer<i64> {
+    let buffer = abuf::ScalarBuffer::<i64>::from(offsets);
+    abuf::OffsetBuffer::new(buffer)
+}
+
+fn from_tdb_validity(
+    validity: Option<ArrowBufferMut>,
+) -> Option<abuf::NullBuffer> {
+    validity.map(|v| {
+        abuf::NullBuffer::from(
+            v.into_iter()
+                .map(|f| if *f != 0 { true } else { false })
+                .collect::<Vec<_>>(),
+        )
+    })
+}

--- a/tiledb/api/src/query_arrow/fields.rs
+++ b/tiledb/api/src/query_arrow/fields.rs
@@ -1,0 +1,171 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow::array as aa;
+use arrow::datatypes as adt;
+
+use super::QueryBuilder;
+
+/// Default field capacity is 10MiB
+const DEFAULT_CAPACITY: usize = 1024 * 1024 * 10;
+
+#[derive(Debug, Default)]
+pub enum QueryField {
+    #[default]
+    Default,
+    WithCapacity(usize),
+    WithCapacityAndType(usize, adt::DataType),
+    WithType(adt::DataType),
+    Buffer(Arc<dyn aa::Array>),
+}
+
+impl QueryField {
+    pub fn capacity(&self) -> Option<usize> {
+        match self {
+            Self::Default => Some(DEFAULT_CAPACITY),
+            Self::WithCapacity(capacity) => Some(*capacity),
+            Self::WithCapacityAndType(capacity, _) => Some(*capacity),
+            Self::WithType(_) => Some(DEFAULT_CAPACITY),
+            Self::Buffer(_) => None,
+        }
+    }
+
+    pub fn target_type(&self) -> Option<adt::DataType> {
+        match self {
+            Self::Default => None,
+            Self::WithCapacity(_) => None,
+            Self::WithCapacityAndType(_, dtype) => Some(dtype.clone()),
+            Self::WithType(dtype) => Some(dtype.clone()),
+            Self::Buffer(array) => Some(array.data_type().clone()),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct QueryFields {
+    pub fields: HashMap<String, QueryField>,
+}
+
+impl QueryFields {
+    pub fn insert<S: Into<String>>(&mut self, name: S, field: QueryField) {
+        let name: String = name.into();
+        self.fields.insert(name.clone(), field);
+    }
+}
+
+pub struct QueryFieldsBuilder {
+    fields: QueryFields,
+}
+
+impl QueryFieldsBuilder {
+    pub fn new() -> Self {
+        Self {
+            fields: Default::default(),
+        }
+    }
+
+    pub fn build(self) -> QueryFields {
+        self.fields
+    }
+
+    pub fn field(mut self, name: &str) -> Self {
+        self.fields.insert(name, Default::default());
+        self
+    }
+
+    pub fn field_with_buffer(
+        mut self,
+        name: &str,
+        buffer: Arc<dyn aa::Array>,
+    ) -> Self {
+        self.fields.insert(name, QueryField::Buffer(buffer));
+        self
+    }
+
+    pub fn field_with_capacity(mut self, name: &str, capacity: usize) -> Self {
+        self.fields.insert(name, QueryField::WithCapacity(capacity));
+        self
+    }
+
+    pub fn field_with_capacity_and_type(
+        mut self,
+        name: &str,
+        capacity: usize,
+        dtype: adt::DataType,
+    ) -> Self {
+        self.fields
+            .insert(name, QueryField::WithCapacityAndType(capacity, dtype));
+        self
+    }
+
+    pub fn field_with_type(mut self, name: &str, dtype: adt::DataType) -> Self {
+        self.fields.insert(name, QueryField::WithType(dtype));
+        self
+    }
+}
+
+pub struct QueryFieldsBuilderForQuery {
+    query_builder: QueryBuilder,
+    fields_builder: QueryFieldsBuilder,
+}
+
+impl QueryFieldsBuilderForQuery {
+    pub(crate) fn new(query_builder: QueryBuilder) -> Self {
+        Self {
+            query_builder,
+            fields_builder: QueryFieldsBuilder::new(),
+        }
+    }
+
+    pub fn end_fields(self) -> QueryBuilder {
+        self.query_builder.with_fields(self.fields_builder.build())
+    }
+
+    pub fn field(self, name: &str) -> Self {
+        Self {
+            fields_builder: self.fields_builder.field(name),
+            ..self
+        }
+    }
+
+    pub fn field_with_buffer(
+        self,
+        name: &str,
+        buffer: Arc<dyn aa::Array>,
+    ) -> Self {
+        Self {
+            fields_builder: self.fields_builder.field_with_buffer(name, buffer),
+            ..self
+        }
+    }
+
+    pub fn field_with_capacity(self, name: &str, capacity: usize) -> Self {
+        Self {
+            fields_builder: self
+                .fields_builder
+                .field_with_capacity(name, capacity),
+            ..self
+        }
+    }
+
+    pub fn field_with_capacity_and_type(
+        self,
+        name: &str,
+        capacity: usize,
+        dtype: adt::DataType,
+    ) -> Self {
+        Self {
+            fields_builder: self
+                .fields_builder
+                .field_with_capacity_and_type(name, capacity, dtype),
+            ..self
+        }
+    }
+
+    pub fn field_with_type(self, name: &str, dtype: adt::DataType) -> Self {
+        Self {
+            fields_builder: self.fields_builder.field_with_type(name, dtype),
+            ..self
+        }
+    }
+}

--- a/tiledb/api/src/query_arrow/mod.rs
+++ b/tiledb/api/src/query_arrow/mod.rs
@@ -1,0 +1,578 @@
+///! The TileDB Query interface and supporting utilities
+use std::collections::HashMap;
+use std::ops::Deref;
+
+use thiserror::Error;
+
+use crate::array::Array;
+use crate::config::Config;
+use crate::context::{CApiInterface, Context, ContextBound};
+use crate::error::Error as TileDBError;
+use crate::key::LookupKey;
+use crate::query::conditions::QueryConditionExpr;
+use crate::range::{Range, SingleValueRange, VarValueRange};
+
+use buffers::{Error as QueryBuffersError, QueryBuffers, SharedBuffers};
+use fields::{QueryFields, QueryFieldsBuilderForQuery};
+use subarray::{SubarrayBuilderForQuery, SubarrayData};
+
+pub mod arrow;
+pub mod buffers;
+pub mod fields;
+pub mod subarray;
+
+pub type QueryType = crate::array::Mode;
+pub type QueryLayout = crate::array::CellOrder;
+
+/// Errors related to query creation and execution
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Incompatible buffer specification when replacing buffers.")]
+    IncompatibleReplacementBuffers,
+    #[error("Internal TileDB Error: {0}")]
+    InternalError(String),
+    #[error("Invalid string for C API calls: {0}")]
+    NulError(#[from] std::ffi::NulError),
+    #[error("Error building query buffers: {0}")]
+    QueryBuffersError(#[from] QueryBuffersError),
+    #[error("Encountered internal libtiledb error: {0}")]
+    TileDBError(#[from] TileDBError),
+}
+
+impl From<Error> for TileDBError {
+    fn from(err: Error) -> TileDBError {
+        TileDBError::Other(format!("{err}"))
+    }
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+/// The status of a query submission
+///
+/// Note that BuffersTooSmall is a Rust invention. But given that we never
+/// attempt to translate this status object back into a capi value its fine.
+pub enum QueryStatus {
+    Uninitialized,
+    Initialized,
+    InProgress,
+    Incomplete,
+    BuffersTooSmall,
+    Completed,
+    Failed,
+}
+
+impl QueryStatus {
+    pub fn is_complete(&self) -> bool {
+        matches!(self, QueryStatus::Completed)
+    }
+
+    pub fn has_data(&self) -> bool {
+        !matches!(self, QueryStatus::BuffersTooSmall)
+    }
+}
+
+impl TryFrom<ffi::tiledb_query_status_t> for QueryStatus {
+    type Error = Error;
+    fn try_from(status: ffi::tiledb_query_status_t) -> Result<Self> {
+        match status {
+            ffi::tiledb_query_status_t_TILEDB_UNINITIALIZED => {
+                Ok(QueryStatus::Uninitialized)
+            }
+            ffi::tiledb_query_status_t_TILEDB_INITIALIZED => {
+                Ok(QueryStatus::Initialized)
+            }
+            ffi::tiledb_query_status_t_TILEDB_INPROGRESS => {
+                Ok(QueryStatus::InProgress)
+            }
+            ffi::tiledb_query_status_t_TILEDB_INCOMPLETE => {
+                Ok(QueryStatus::Incomplete)
+            }
+            ffi::tiledb_query_status_t_TILEDB_COMPLETED => {
+                Ok(QueryStatus::Completed)
+            }
+            ffi::tiledb_query_status_t_TILEDB_FAILED => Ok(QueryStatus::Failed),
+            invalid => Err(Error::InternalError(format!(
+                "Invaldi query status: {}",
+                invalid
+            ))),
+        }
+    }
+}
+
+pub(crate) enum RawQuery {
+    Owned(*mut ffi::tiledb_query_t),
+}
+
+impl Deref for RawQuery {
+    type Target = *mut ffi::tiledb_query_t;
+    fn deref(&self) -> &Self::Target {
+        let RawQuery::Owned(ref ffi) = self;
+        ffi
+    }
+}
+
+impl Drop for RawQuery {
+    fn drop(&mut self) {
+        let RawQuery::Owned(ref mut ffi) = *self;
+        unsafe { ffi::tiledb_query_free(ffi) }
+    }
+}
+
+pub(crate) enum RawSubarray {
+    Owned(*mut ffi::tiledb_subarray_t),
+}
+
+impl Deref for RawSubarray {
+    type Target = *mut ffi::tiledb_subarray_t;
+    fn deref(&self) -> &Self::Target {
+        match *self {
+            RawSubarray::Owned(ref ffi) => ffi,
+        }
+    }
+}
+
+impl Drop for RawSubarray {
+    fn drop(&mut self) {
+        let RawSubarray::Owned(ref mut ffi) = *self;
+        unsafe { ffi::tiledb_subarray_free(ffi) };
+    }
+}
+
+/// The main Query interface
+///
+/// This struct is responsible for executing queries against TileDB arrays.
+pub struct Query {
+    context: Context,
+    raw: RawQuery,
+    query_type: QueryType,
+    array: Array,
+    buffers: QueryBuffers,
+}
+
+impl ContextBound for Query {
+    fn context(&self) -> Context {
+        self.array.context()
+    }
+}
+
+impl Query {
+    pub(crate) fn capi(&mut self) -> *mut ffi::tiledb_query_t {
+        *self.raw
+    }
+
+    pub fn submit(&mut self) -> Result<QueryStatus> {
+        self.buffers.to_mutable()?;
+        if matches!(self.query_type, QueryType::Read) {
+            self.buffers.reset_lengths()?;
+        }
+        self.set_buffers()?;
+
+        let c_query = self.capi();
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_query_submit(ctx, c_query)
+        })?;
+
+        if matches!(self.query_type, QueryType::Read) {
+            self.buffers.shrink_lengths()?;
+        }
+
+        match self.curr_status()? {
+            QueryStatus::Uninitialized
+            | QueryStatus::Initialized
+            | QueryStatus::InProgress => {
+                return Err(Error::InternalError(
+                    "Invalid query status after submit".to_string(),
+                ))
+            }
+            QueryStatus::Failed => {
+                return Err(self.context.expect_last_error().into());
+            }
+            QueryStatus::Incomplete => {
+                if self.buffers.iter().any(|(_, b)| b.len() > 0) {
+                    Ok(QueryStatus::Incomplete)
+                } else {
+                    Ok(QueryStatus::BuffersTooSmall)
+                }
+            }
+            QueryStatus::BuffersTooSmall => {
+                panic!("TileDB does not generate this variant.")
+            }
+            QueryStatus::Completed => Ok(QueryStatus::Completed),
+        }
+    }
+
+    pub fn finalize(mut self) -> Result<(Array, SharedBuffers)> {
+        let c_query = self.capi();
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_query_finalize(ctx, c_query)
+        })?;
+
+        self.buffers.to_shared()?;
+        let mut ret = HashMap::with_capacity(self.buffers.len());
+        for (field, buffer) in self.buffers.iter() {
+            ret.insert(field.clone(), buffer.as_shared()?);
+        }
+
+        Ok((self.array, ret.into()))
+    }
+
+    pub fn buffers(&mut self) -> Result<SharedBuffers> {
+        self.buffers.to_shared()?;
+        let mut ret = HashMap::with_capacity(self.buffers.len());
+        for (field, buffer) in self.buffers.iter() {
+            ret.insert(field.clone(), buffer.as_shared()?);
+        }
+
+        Ok(ret.into())
+    }
+
+    /// Replace this queries buffers with a new set specified by fields
+    ///
+    /// This can be used to reallocate buffers with a larger capacity.
+    pub fn replace_buffers(
+        &mut self,
+        fields: QueryFields,
+    ) -> Result<QueryBuffers> {
+        let mut tmp_buffers =
+            QueryBuffers::from_fields(self.array.schema()?, fields)?;
+        tmp_buffers.to_mutable()?;
+        if self.buffers.is_compatible(&tmp_buffers) {
+            std::mem::swap(&mut self.buffers, &mut tmp_buffers);
+            Ok(tmp_buffers)
+        } else {
+            Err(Error::IncompatibleReplacementBuffers)
+        }
+    }
+
+    fn set_buffers(&mut self) -> Result<()> {
+        let c_query = self.capi();
+        for (field, buffer) in self.buffers.iter_mut() {
+            let c_name = std::ffi::CString::new(field.as_bytes())?;
+
+            let c_data_ptr = buffer.data_ptr()?;
+            let c_data_size_ptr = buffer.data_size_ptr()?;
+
+            self.context.capi_call(|ctx| unsafe {
+                ffi::tiledb_query_set_data_buffer(
+                    ctx,
+                    c_query,
+                    c_name.as_ptr(),
+                    c_data_ptr,
+                    c_data_size_ptr,
+                )
+            })?;
+
+            if buffer.has_offsets()? {
+                let c_offsets_ptr = buffer.offsets_ptr()?;
+                let c_offsets_size_ptr = buffer.offsets_size_ptr()?;
+                self.context.capi_call(|ctx| unsafe {
+                    ffi::tiledb_query_set_offsets_buffer(
+                        ctx,
+                        c_query,
+                        c_name.as_ptr(),
+                        c_offsets_ptr,
+                        c_offsets_size_ptr,
+                    )
+                })?;
+            }
+
+            if buffer.has_validity()? {
+                let c_validity_ptr = buffer.validity_ptr()?;
+                let c_validity_size_ptr = buffer.validity_size_ptr()?;
+                self.context.capi_call(|ctx| unsafe {
+                    ffi::tiledb_query_set_validity_buffer(
+                        ctx,
+                        c_query,
+                        c_name.as_ptr(),
+                        c_validity_ptr,
+                        c_validity_size_ptr,
+                    )
+                })?;
+            }
+        }
+        Ok(())
+    }
+
+    fn curr_status(&mut self) -> Result<QueryStatus> {
+        let c_query = self.capi();
+        let mut c_status: ffi::tiledb_query_status_t = out_ptr!();
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_query_get_status(ctx, c_query, &mut c_status)
+        })?;
+
+        QueryStatus::try_from(c_status)
+    }
+}
+
+/// The main interface to creating Query instances
+pub struct QueryBuilder {
+    context: Context,
+    array: Array,
+    query_type: QueryType,
+    config: Option<Config>,
+    layout: Option<QueryLayout>,
+    subarray: Option<SubarrayData>,
+    query_condition: Option<QueryConditionExpr>,
+    fields: QueryFields,
+}
+
+impl ContextBound for QueryBuilder {
+    fn context(&self) -> Context {
+        self.context.clone()
+    }
+}
+
+impl QueryBuilder {
+    pub fn new(array: Array, query_type: QueryType) -> Self {
+        Self {
+            context: array.context(),
+            array,
+            query_type,
+            config: None,
+            layout: None,
+            subarray: None,
+            query_condition: None,
+            fields: Default::default(),
+        }
+    }
+
+    pub fn read(array: Array) -> Self {
+        Self::new(array, QueryType::Read)
+    }
+
+    pub fn write(array: Array) -> Self {
+        Self::new(array, QueryType::Write)
+    }
+
+    pub fn build(mut self) -> Result<Query> {
+        let raw = self.alloc_query()?;
+
+        let schema = self.array.schema()?;
+        self.set_config(&raw)?;
+        self.set_layout(&raw)?;
+        self.set_subarray(&raw)?;
+        self.set_query_condition(&raw)?;
+
+        Ok(Query {
+            context: self.array.context(),
+            raw,
+            query_type: self.query_type,
+            array: self.array,
+            buffers: QueryBuffers::from_fields(schema, self.fields)?,
+        })
+    }
+
+    pub fn with_config(mut self, config: Config) -> Self {
+        self.config = Some(config);
+        self
+    }
+
+    pub fn with_layout(mut self, layout: QueryLayout) -> Self {
+        self.layout = Some(layout);
+        self
+    }
+
+    pub fn with_query_condition(
+        mut self,
+        query_condition: QueryConditionExpr,
+    ) -> Self {
+        self.query_condition = Some(query_condition);
+        self
+    }
+
+    pub fn with_subarray_data(mut self, subarray: SubarrayData) -> Self {
+        self.subarray = Some(subarray);
+        self
+    }
+
+    pub fn start_subarray(self) -> SubarrayBuilderForQuery {
+        SubarrayBuilderForQuery::new(self)
+    }
+
+    pub fn with_fields(mut self, fields: QueryFields) -> Self {
+        self.fields = fields;
+        self
+    }
+
+    pub fn start_fields(self) -> QueryFieldsBuilderForQuery {
+        QueryFieldsBuilderForQuery::new(self)
+    }
+
+    // Internal builder methods below
+
+    fn alloc_query(&self) -> Result<RawQuery> {
+        let c_array = **self.array.capi();
+        let c_query_type = self.query_type.capi_enum();
+        let mut c_query: *mut ffi::tiledb_query_t = out_ptr!();
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_query_alloc(ctx, c_array, c_query_type, &mut c_query)
+        })?;
+
+        Ok(RawQuery::Owned(c_query))
+    }
+
+    fn alloc_subarray(&self) -> Result<RawSubarray> {
+        let c_array = **self.array.capi();
+        let mut c_subarray: *mut ffi::tiledb_subarray_t = out_ptr!();
+
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_subarray_alloc(ctx, c_array, &mut c_subarray)
+        })?;
+
+        Ok(RawSubarray::Owned(c_subarray))
+    }
+
+    fn set_config(&mut self, raw: &RawQuery) -> Result<()> {
+        if self.config.is_none() {
+            return Ok(());
+        }
+
+        // TODO: Reject configurations that will break out buffer management
+        // logic. Specifically, the various sm.var_offsets.* keys.
+        let c_query = **raw;
+        let c_cfg = self.config.as_mut().unwrap().capi();
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_query_set_config(ctx, c_query, c_cfg)
+        })?;
+
+        Ok(())
+    }
+
+    fn set_layout(&mut self, raw: &RawQuery) -> Result<()> {
+        let Some(layout) = self.layout.as_ref() else {
+            return Ok(());
+        };
+
+        let c_query = **raw;
+        let c_layout = layout.capi_enum();
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_query_set_layout(ctx, c_query, c_layout)
+        })?;
+
+        Ok(())
+    }
+
+    fn set_subarray(&self, raw: &RawQuery) -> Result<()> {
+        let Some(subarray_data) = self.subarray.as_ref() else {
+            return Ok(());
+        };
+
+        let raw_subarray = self.alloc_subarray()?;
+        for (key, ranges) in subarray_data.iter() {
+            for range in ranges {
+                self.set_subarray_range(*raw_subarray, &key.into(), range)?;
+            }
+        }
+
+        let c_query = **raw;
+        let c_subarray = *raw_subarray;
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_query_set_subarray_t(ctx, c_query, c_subarray)
+        })?;
+
+        Ok(())
+    }
+
+    fn set_subarray_range(
+        &self,
+        c_subarray: *mut ffi::tiledb_subarray_t,
+        key: &LookupKey,
+        range: &Range,
+    ) -> Result<()> {
+        let schema = self.array.schema()?;
+        let dim = schema.domain()?.dimension(key.clone())?;
+
+        range
+            .check_dimension_compatibility(dim.datatype()?, dim.cell_val_num()?)
+            .map_err(Error::from)?;
+
+        match range {
+            Range::Single(range) => {
+                crate::single_value_range_go!(range, _DT, start, end, {
+                    let start = start.to_le_bytes();
+                    let end = end.to_le_bytes();
+                    match key {
+                        LookupKey::Index(idx) => {
+                            self.capi_call(|ctx| unsafe {
+                                ffi::tiledb_subarray_add_range(
+                                    ctx,
+                                    c_subarray,
+                                    *idx as u32,
+                                    start.as_ptr() as *const std::ffi::c_void,
+                                    end.as_ptr() as *const std::ffi::c_void,
+                                    std::ptr::null(),
+                                )
+                            })?;
+                        }
+                        LookupKey::Name(name) => {
+                            let c_name = std::ffi::CString::new(name.clone())?;
+                            self.capi_call(|ctx| unsafe {
+                                ffi::tiledb_subarray_add_range_by_name(
+                                    ctx,
+                                    c_subarray,
+                                    c_name.as_ptr(),
+                                    start.as_ptr() as *const std::ffi::c_void,
+                                    end.as_ptr() as *const std::ffi::c_void,
+                                    std::ptr::null(),
+                                )
+                            })?;
+                        }
+                    }
+                })
+            }
+            Range::Multi(_) => unreachable!(
+                "This is rejected by range.check_dimension_compatibility"
+            ),
+            Range::Var(range) => {
+                crate::var_value_range_go!(range, _DT, start, end, {
+                    match key {
+                        LookupKey::Index(idx) => {
+                            self.capi_call(|ctx| unsafe {
+                                ffi::tiledb_subarray_add_range_var(
+                                    ctx,
+                                    c_subarray,
+                                    *idx as u32,
+                                    start.as_ptr() as *const std::ffi::c_void,
+                                    start.len() as u64,
+                                    end.as_ptr() as *const std::ffi::c_void,
+                                    end.len() as u64,
+                                )
+                            })?;
+                        }
+                        LookupKey::Name(name) => {
+                            let c_name = std::ffi::CString::new(name.clone())?;
+                            self.capi_call(|ctx| unsafe {
+                                ffi::tiledb_subarray_add_range_var_by_name(
+                                    ctx,
+                                    c_subarray,
+                                    c_name.as_ptr(),
+                                    start.as_ptr() as *const std::ffi::c_void,
+                                    start.len() as u64,
+                                    end.as_ptr() as *const std::ffi::c_void,
+                                    end.len() as u64,
+                                )
+                            })?;
+                        }
+                    }
+                })
+            }
+        }
+
+        Ok(())
+    }
+
+    fn set_query_condition(&self, raw: &RawQuery) -> Result<()> {
+        let Some(query_condition) = self.query_condition.as_ref() else {
+            return Ok(());
+        };
+
+        let cq_raw = query_condition.build(&self.context)?;
+        let c_query = **raw;
+        let c_cond = *cq_raw;
+        self.capi_call(|ctx| unsafe {
+            ffi::tiledb_query_set_condition(ctx, c_query, c_cond)
+        })?;
+
+        Ok(())
+    }
+}

--- a/tiledb/api/src/query_arrow/subarray.rs
+++ b/tiledb/api/src/query_arrow/subarray.rs
@@ -1,0 +1,64 @@
+use std::collections::HashMap;
+
+use crate::range::Range;
+
+use super::QueryBuilder;
+
+pub type SubarrayData = HashMap<String, Vec<Range>>;
+
+pub struct SubarrayBuilder {
+    subarray: SubarrayData,
+}
+
+impl SubarrayBuilder {
+    pub fn new() -> Self {
+        Self {
+            subarray: Default::default(),
+        }
+    }
+
+    pub fn add_range<IntoRange: Into<Range>>(
+        mut self,
+        dimension: &str,
+        range: IntoRange,
+    ) -> Self {
+        self.subarray
+            .entry(dimension.to_string())
+            .or_default()
+            .push(range.into());
+        self
+    }
+
+    pub fn build(self) -> SubarrayData {
+        self.subarray
+    }
+}
+
+pub struct SubarrayBuilderForQuery {
+    query_builder: QueryBuilder,
+    subarray_builder: SubarrayBuilder,
+}
+
+impl SubarrayBuilderForQuery {
+    pub(crate) fn new(query_builder: QueryBuilder) -> Self {
+        Self {
+            query_builder,
+            subarray_builder: SubarrayBuilder::new(),
+        }
+    }
+
+    pub fn end_subarray(self) -> QueryBuilder {
+        self.query_builder
+            .with_subarray_data(self.subarray_builder.build())
+    }
+
+    pub fn add_range<IntoRange: Into<Range>>(
+        mut self,
+        dimension: &str,
+        range: IntoRange,
+    ) -> Self {
+        self.subarray_builder =
+            self.subarray_builder.add_range(dimension, range);
+        self
+    }
+}

--- a/tiledb/api/src/range.rs
+++ b/tiledb/api/src/range.rs
@@ -224,6 +224,12 @@ impl Hash for SingleValueRange {
 macro_rules! single_value_range_from {
     ($($V:ident : $U:ty),+) => {
         $(
+            impl From<[$U; 2]> for SingleValueRange {
+                fn from(value: [$U; 2]) -> SingleValueRange {
+                    SingleValueRange::$V(value[0], value[1])
+                }
+            }
+
             impl From<&[$U; 2]> for SingleValueRange {
                 fn from(value: &[$U; 2]) -> SingleValueRange {
                     SingleValueRange::$V(value[0], value[1])


### PR DESCRIPTION
This implements a second version of the Query interface using Arrow Arrays. The core idea here is that we can share Arrow arrays freely and then convert them to mutable buffers as long as there are no external references to them. This is all done safely and returns an error if any buffer is externally referenced.