### PR TITLE
impl conversions between RangeInclusive and SingleValueRange

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,6 +1827,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arrow-schema",
+ "num-traits",
  "paste",
  "proptest",
  "serde",

--- a/tiledb/common/Cargo.toml
+++ b/tiledb/common/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 arrow-schema = { workspace = true, optional = true }
+num-traits = { workspace = true }
 paste = { workspace = true }
 proptest = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }


### PR DESCRIPTION
`SingleValueRange` is essentially a dynamically-typed `std::ops::Range`.  This pull request implements conversions between the two.

I had this hanging around in a `git stash` and figured I'd clear it out.  I'm not sure what my original intent was but this seems potentially useful... or at least not harmful.