### PR TITLE
`tiledb-rs` error styling part 1: `Context::capi_call` returns its own error type

### DIFF
--- a/tiledb/api/src/array/attribute/mod.rs
+++ b/tiledb/api/src/array/attribute/mod.rs
@@ -208,11 +208,12 @@ impl Attribute {
             return Ok(None);
         }
 
-        TDBString {
-            raw: RawTDBString::Owned(c_str),
-        }
-        .to_string()
-        .map(Some)
+        Ok(Some(
+            TDBString {
+                raw: RawTDBString::Owned(c_str),
+            }
+            .to_string()?,
+        ))
     }
 }
 

--- a/tiledb/api/src/array/enumeration/mod.rs
+++ b/tiledb/api/src/array/enumeration/mod.rs
@@ -57,10 +57,10 @@ impl Enumeration {
             ffi::tiledb_enumeration_get_name(ctx, c_enmr, &mut c_str)
         })?;
 
-        TDBString {
+        Ok(TDBString {
             raw: RawTDBString::Owned(c_str),
         }
-        .to_string()
+        .to_string()?)
     }
 
     pub fn datatype(&self) -> TileDBResult<Datatype> {

--- a/tiledb/api/src/array/fragment_info.rs
+++ b/tiledb/api/src/array/fragment_info.rs
@@ -192,7 +192,7 @@ impl FragmentInfoInternal {
         })?;
 
         let str = TDBString::from_raw(RawTDBString::Owned(c_str));
-        str.to_string()
+        Ok(str.to_string()?)
     }
 
     pub fn fragment_uri(&self, frag_idx: u32) -> TileDBResult<String> {

--- a/tiledb/api/src/array/schema/mod.rs
+++ b/tiledb/api/src/array/schema/mod.rs
@@ -701,8 +701,8 @@ impl Builder {
         let c_schema = *self.schema.raw;
         self.capi_call(|ctx| unsafe {
             ffi::tiledb_array_schema_check(ctx, c_schema)
-        })
-        .map(|_| self.schema)
+        })?;
+        Ok(self.schema)
     }
 }
 
@@ -736,6 +736,7 @@ mod tests {
     use crate::array::{
         AttributeBuilder, DimensionBuilder, DimensionConstraints, DomainBuilder,
     };
+    use crate::context::CApiError;
     use crate::filter::{
         CompressionData, CompressionType, FilterData, FilterListBuilder,
     };
@@ -1553,7 +1554,7 @@ mod tests {
             datatype,
         );
         assert_eq!(allowed, r.is_ok(), "try_construct => {:?}", r.err());
-        if let Err(Error::LibTileDB(s)) = r {
+        if let Err(Error::LibTileDB(CApiError::Error(s))) = r {
             assert!(
                 s.contains("not a valid Dimension Datatype")
                     || s.contains("do not support dimension datatype"),
@@ -1581,7 +1582,7 @@ mod tests {
             datatype,
         );
         assert_eq!(allowed, r.is_ok(), "try_construct => {:?}", r.err());
-        if let Err(Error::LibTileDB(s)) = r {
+        if let Err(Error::LibTileDB(CApiError::Error(s))) = r {
             assert!(
                 s.contains("not a valid Dimension Datatype")
                     || s.contains("do not support dimension datatype"),

--- a/tiledb/api/src/context.rs
+++ b/tiledb/api/src/context.rs
@@ -8,6 +8,7 @@ use crate::filesystem::Filesystem;
 use crate::stats::RawStatsString;
 use crate::Result as TileDBResult;
 
+/// An error which can occur when creating a new `Context`.
 #[derive(Debug, thiserror::Error)]
 pub enum CreateContextError {
     #[error("Error configuring context: {0}")]
@@ -20,6 +21,7 @@ pub enum CreateContextError {
     InternalInvalidReturnValue(i64),
 }
 
+/// An error which can occur when calling a `libtiledb` C API function.
 #[derive(Debug, thiserror::Error)]
 pub enum CApiError {
     #[error("Invalid string argument to C API: {0}")]

--- a/tiledb/api/src/lib.rs
+++ b/tiledb/api/src/lib.rs
@@ -6,16 +6,11 @@ extern crate tiledb_sys as ffi;
 extern crate tiledb_utils as utils;
 
 macro_rules! cstring {
-    ($arg:expr) => {
-        match std::ffi::CString::new($arg) {
-            Ok(c_arg) => c_arg,
-            Err(nullity) => {
-                return Err(crate::error::Error::InvalidArgument(
-                    anyhow::anyhow!(nullity),
-                ))
-            }
-        }
-    };
+    ($arg:expr) => {{
+        let arg = $arg;
+        std::ffi::CString::new(arg)
+            .map_err(|e| crate::context::CApiError::InvalidCString(e))?
+    }};
 }
 
 macro_rules! eq_helper {

--- a/tiledb/api/src/query/mod.rs
+++ b/tiledb/api/src/query/mod.rs
@@ -125,8 +125,8 @@ impl QueryBase {
         let mut c_status: ffi::tiledb_query_status_t = out_ptr!();
         self.capi_call(|ctx| unsafe {
             ffi::tiledb_query_get_status(ctx, c_query, &mut c_status)
-        })
-        .map(|_| c_status)
+        })?;
+        Ok(c_status)
     }
 
     pub fn array(&self) -> &Array {
@@ -160,7 +160,8 @@ impl ReadQuery for QueryBase {
 
         match self.capi_status()? {
             ffi::tiledb_query_status_t_TILEDB_FAILED => {
-                Err(self.context().expect_last_error())
+                Err(Error::from(self.context().get_last_error()
+                        .expect("libtiledb context did not have error for failed query status")))
             }
             ffi::tiledb_query_status_t_TILEDB_COMPLETED => {
                 Ok(ReadStepOutput::Final(()))

--- a/tiledb/api/src/stats.rs
+++ b/tiledb/api/src/stats.rs
@@ -102,22 +102,13 @@ pub fn dump() -> Result<Option<String>, Error> {
 }
 
 #[cfg(feature = "serde")]
-mod __serde {
+pub fn dump_json() -> Result<Option<Vec<Metrics>>, Error> {
     use anyhow::anyhow;
-
-    use super::*;
-
-    #[cfg(feature = "serde")]
-    pub fn dump_json() -> Result<Option<Vec<Metrics>>, Error> {
-        if let Some(dump) = dump()? {
-            Ok(serde_json::from_str::<Vec<Metrics>>(dump.as_str())
-                .map(Some)
-                .map_err(|e| Error::ToJson(anyhow!(e)))?)
-        } else {
-            Ok(None)
-        }
+    if let Some(dump) = dump()? {
+        Ok(serde_json::from_str::<Vec<Metrics>>(dump.as_str())
+            .map(Some)
+            .map_err(|e| Error::ToJson(anyhow!(e)))?)
+    } else {
+        Ok(None)
     }
 }
-
-#[cfg(feature = "serde")]
-pub use __serde::*;

--- a/tiledb/api/src/stats.rs
+++ b/tiledb/api/src/stats.rs
@@ -4,8 +4,19 @@ use std::ops::Deref;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::error::Error;
-use crate::Result as TileDBResult;
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Internal error enabling stats")]
+    Enable,
+    #[error("Internal error disabling stats")]
+    Disable,
+    #[error("Internal error resetting stats")]
+    Reset,
+    #[error("Internal error retrieving stats")]
+    ToString,
+    #[error("Error parsing stats to json: {0}")]
+    ToJson(anyhow::Error),
+}
 
 pub(crate) enum RawStatsString {
     Owned(*mut std::ffi::c_char),
@@ -38,37 +49,37 @@ pub struct Metrics {
     pub counters: HashMap<String, u64>,
 }
 
-pub fn enable() -> TileDBResult<()> {
+pub fn enable() -> Result<(), Error> {
     let c_ret = unsafe { ffi::tiledb_stats_enable() };
 
     if c_ret == ffi::TILEDB_OK {
         Ok(())
     } else {
-        Err(Error::LibTileDB(String::from("Failed to enable stats.")))
+        Err(Error::Enable)
     }
 }
 
-pub fn disable() -> TileDBResult<()> {
+pub fn disable() -> Result<(), Error> {
     let c_ret = unsafe { ffi::tiledb_stats_disable() };
 
     if c_ret == ffi::TILEDB_OK {
         Ok(())
     } else {
-        Err(Error::LibTileDB(String::from("Failed to disable stats.")))
+        Err(Error::Disable)
     }
 }
 
-pub fn reset() -> TileDBResult<()> {
+pub fn reset() -> Result<(), Error> {
     let c_ret = unsafe { ffi::tiledb_stats_reset() };
 
     if c_ret == ffi::TILEDB_OK {
         Ok(())
     } else {
-        Err(Error::LibTileDB(String::from("Failed to reset stats.")))
+        Err(Error::Reset)
     }
 }
 
-pub fn dump() -> TileDBResult<Option<String>> {
+pub fn dump() -> Result<Option<String>, Error> {
     let mut c_str = std::ptr::null_mut::<std::ffi::c_char>();
 
     let c_ret = unsafe {
@@ -76,9 +87,7 @@ pub fn dump() -> TileDBResult<Option<String>> {
     };
 
     if c_ret != ffi::TILEDB_OK {
-        return Err(Error::LibTileDB(String::from(
-            "Failed to retrieve stats.",
-        )));
+        return Err(Error::ToString);
     }
 
     assert!(!c_str.is_null());
@@ -93,20 +102,22 @@ pub fn dump() -> TileDBResult<Option<String>> {
 }
 
 #[cfg(feature = "serde")]
-pub fn dump_json() -> TileDBResult<Option<Vec<Metrics>>> {
+mod __serde {
     use anyhow::anyhow;
 
-    if let Some(dump) = dump()? {
-        let datas: Vec<Metrics> = serde_json::from_str::<Vec<Metrics>>(
-            dump.as_str(),
-        )
-        .map_err(|e| {
-            Error::Deserialization(
-                format!("Failed to deserialize stats JSON value {}", dump),
-                anyhow!(e),
-            )
-        })?;
-        return Ok(Some(datas));
+    use super::*;
+
+    #[cfg(feature = "serde")]
+    pub fn dump_json() -> Result<Option<Vec<Metrics>>, Error> {
+        if let Some(dump) = dump()? {
+            Ok(serde_json::from_str::<Vec<Metrics>>(dump.as_str())
+                .map(Some)
+                .map_err(|e| Error::ToJson(anyhow!(e)))?)
+        } else {
+            Ok(None)
+        }
     }
-    Ok(None)
 }
+
+#[cfg(feature = "serde")]
+pub use __serde::*;


### PR DESCRIPTION
In `tiledb-tables`, we've begun to declare at least one `Error` enum per module.  If a module `foo` calls a function from a module `bar`, then `foo::Error` has an enum variant approximating `Bar(bar::Error)`.  This can help build a causality chain in error output.

We have discussed bringing this error style into `tiledb-rs`, and this pull request is a foray into doing so.  We begin with the core of `tiledb-rs`, `Context::capi_call`.  This pull request adds `CApiError` which is returned by `Context::capi_call`.  The rest of the changes fell out of that in some way.

There are a few `// SAFETY` comments for new `unwrap`s.  These are added in situations where we try to convert a value returned from tiledb into one of the `tiledb-rs` enums.  The presupposition is that if libtiledb returned `TILEDB_OK` then it must have given a valid enum value.  I am personally comfortable with this assumption (I believe I am aligned with [this blog](https://blog.burntsushi.net/unwrap/#so-one-should-never-use-unwrap-or-expect) about `unwrap`) but I'm also fine changing it if requested - it would nudge the code in the direction of more `Error` variants.

