### PR TITLE
Add more `CommonOption`s

### DIFF
--- a/tiledb/api/src/config.rs
+++ b/tiledb/api/src/config.rs
@@ -343,7 +343,7 @@ impl CommonOption {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{collections::HashMap, path::Path};
+    use std::path::Path;
 
     #[test]
     fn config_alloc() {

--- a/tiledb/api/src/config.rs
+++ b/tiledb/api/src/config.rs
@@ -295,7 +295,7 @@ pub enum CommonOption {
     /// Sets an AES256GCM encryption key.
     Aes256GcmEncryptionKey(Vec<u8>),
 
-    // URL for REST server to use for remote arrays.
+    /// URL for REST server to use for remote arrays.
     RestServerAddress(String),
 
     /// Username for login to REST server.
@@ -455,7 +455,6 @@ mod tests {
         for (key, val) in key_to_val {
             let result: Option<String> =
                 cfg.get(key).expect("Error getting config key.");
-            println!("result: {:?}", result);
             assert_eq!(result.unwrap(), val);
 
             cfg.set(key, "new").expect("Error setting config key.");


### PR DESCRIPTION
### What
Add more `CommonOption`s which we use when reading from `cloud.json` in TileDB-Tables. Part of [SC-54120](https://app.shortcut.com/tiledb-inc/story/54120/support-reading-cloud-config-api-tokens-from-tiledb-cloud-json).

### Testing
Adds new tests.