### PR TITLE
Add public accessors to query condition data

### DIFF
--- a/tiledb/api/src/array/enumeration/mod.rs
+++ b/tiledb/api/src/array/enumeration/mod.rs
@@ -234,7 +234,7 @@ impl Debug for Enumeration {
 
 /// Wraps an [Enumeration] which has been created by [Enumeration::extend].
 /// This can be added to a [SchemaEvolution].
-#[derive(Debug)]
+#[cfg_attr(any(test, feature = "pod"), derive(Debug))]
 pub struct ExtendedEnumeration(Enumeration);
 
 impl ExtendedEnumeration {

--- a/tiledb/api/src/query/condition/mod.rs
+++ b/tiledb/api/src/query/condition/mod.rs
@@ -474,6 +474,18 @@ pub struct EqualityPredicate {
 }
 
 impl EqualityPredicate {
+    pub fn field(&self) -> &str {
+        &self.field
+    }
+
+    pub fn operation(&self) -> EqualityOp {
+        self.op
+    }
+
+    pub fn value(&self) -> &Literal {
+        &self.value
+    }
+
     fn build(&self, ctx: &Context) -> TileDBResult<RawQueryCondition> {
         let mut c_cond: *mut ffi::tiledb_query_condition_t = out_ptr!();
         ctx.capi_call(|ctx| unsafe {
@@ -518,6 +530,18 @@ pub struct SetMembershipPredicate {
 }
 
 impl SetMembershipPredicate {
+    pub fn field(&self) -> &str {
+        &self.field
+    }
+
+    pub fn operation(&self) -> SetMembershipOp {
+        self.op
+    }
+
+    pub fn members(&self) -> &SetMembers {
+        &self.members
+    }
+
     fn build(&self, ctx: &Context) -> TileDBResult<RawQueryCondition> {
         // First things first, sets require a non-zero length vector. I would
         // prefer if we couldn't even create SetMemberValues with zero length
@@ -629,6 +653,14 @@ pub struct NullnessPredicate {
 }
 
 impl NullnessPredicate {
+    pub fn field(&self) -> &str {
+        &self.field
+    }
+
+    pub fn operation(&self) -> NullnessOp {
+        self.op
+    }
+
     fn build(&self, ctx: &Context) -> TileDBResult<RawQueryCondition> {
         let mut c_cond: *mut ffi::tiledb_query_condition_t = out_ptr!();
         ctx.capi_call(|ctx| unsafe {


### PR DESCRIPTION
While writing tests for [SC-51070](https://app.shortcut.com/tiledb-inc/story/51070/tables-turn-datafusion-in-list-predicate-into-setmembership-query-condition) I stumbled into the in-capability of checking what the values inside a query condition expression actually are using a pub API.

This pull request changes the in-capability to a capability.