### PR TITLE
Create nightly release packages

### DIFF
--- a/.github/scripts/generate-build-matrix.py
+++ b/.github/scripts/generate-build-matrix.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+# This is taken from the TileDB Release workflow found here:
+#
+# * https://github.com/TileDB-Inc/TileDB/blob/main/.github/workflows/release.yml
+#
+# The upstream version of this matrix does not include static builds which
+# can be useful for projects like TileDB-Tables that want to distribute
+# statically linked binaries.
+
+import copy
+import json
+
+BASE_MATRIX = [
+    {
+        "platform": "linux-x86_64",
+        "os": "ubuntu-20.04",
+        "manylinux": "quay.io/pypa/manylinux_2_28_x86_64",
+        "triplet": "x64-linux-release"
+    },
+    {
+        "platform": "linux-x86_64-noavx2",
+        "os": "ubuntu-20.04",
+        "cmake_args": "-DCOMPILER_SUPPORTS_AVX2=OFF",
+        "triplet": "x64-linux-release",
+        "manylinux": "quay.io/pypa/manylinux_2_28_x86_64"
+    },
+    {
+        "platform": "linux-aarch64",
+        "os": "linux-arm64-ubuntu24",
+        "triplet": "arm64-linux-release",
+        "manylinux": "quay.io/pypa/manylinux_2_28_aarch64"
+    },
+    {
+        "platform": "macos-x86_64",
+        "os": "macos-13",
+        "cmake_args": "-DCMAKE_OSX_ARCHITECTURES=x86_64",
+        "MACOSX_DEPLOYMENT_TARGET": "11",
+        "triplet": "x64-osx-release"
+    },
+    {
+        "platform": "macos-arm64",
+        "os": "macos-latest",
+        "cmake_args": "-DCMAKE_OSX_ARCHITECTURES=arm64",
+        "MACOSX_DEPLOYMENT_TARGET": "11",
+        "triplet": "arm64-osx-release"
+    }
+]
+
+BUILD_SHARED_LIBS = ["on", "off"]
+VERSIONS = ["main", "2.27.0"]
+
+def main():
+    matrix = []
+    for version in VERSIONS:
+        for build_shared in BUILD_SHARED_LIBS:
+            # Dynamically linked upstream releases are pulled from the
+            # TileDB-Inc/TileDB repository releases so we skip re-building
+            # them here.
+            if version != "main" and build_shared == "ON":
+                continue
+
+            if build_shared == "ON":
+                linkage = "Dynamic"
+            else:
+                linkage = "Static"
+
+            for config in BASE_MATRIX:
+                config = copy.deepcopy(config)
+                config["version"] = version
+                config["build_shared_libs"] = build_shared
+                config["linkage"] = linkage
+                matrix.append(config)
+
+    print(json.dumps({"include": matrix}))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/generate-releases-csv.py
+++ b/.github/scripts/generate-releases-csv.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+def main():
+    with open("release-data/releases.csv", "w") as handle:
+        handle.write("Lol, wut?")
+    with open("release-data/releases.csv.sha256") as handle:
+        handle.write("Secret of the Hashes!")
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,188 @@
+name: Package TileDB
+
+on:
+  schedule:
+    # runs every day at 04:17 UTC
+    - cron: "17 04 * * *"
+  workflow_dispatch:
+
+jobs:
+  generate-matrix:
+    name: Generate Build Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Generate
+        id: generate
+        run: |
+          MATRIX=$(.github/scripts/generate-build-matrix.py)
+          echo "matrix=${MATRIX}" >> $GITHUB_OUTPUT
+
+  build:
+    needs:
+      - generate-matrix
+    name: Build - ${{ matrix.platform }} - ${{ matrix.version }} - ${{ matrix.linkage }}
+    strategy:
+      fail-fast: false
+      matrix:
+        matrix: ${{ fromJson(needs.setup.outputs.mymatrix) }}
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.manylinux || '' }}
+    env:
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.MACOSX_DEPLOYMENT_TARGET }}
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+    steps:
+      - name: Checkout TileDB
+        # v4 uses node 20 which is incompatible with the libc version of the manylinux image
+        uses: actions/checkout@v3
+        with:
+          repository: "TileDB-Inc/TileDB"
+          ref: ${{ matrix.version }}
+      - name: Export GitHub Actions cache variables
+        uses: actions/github-script@v6
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - name: Setup Homebrew
+        run: brew install automake ninja
+        if: ${{ startsWith(matrix.os, 'macos-') == true }}
+      - name: Setup manylinux
+        if: ${{ startsWith(matrix.platform, 'linux') == true }}
+        run: |
+          set -e pipefail
+          yum install -y ninja-build perl-IPC-Cmd curl zip unzip tar
+          echo "VCPKG_FORCE_SYSTEM_BINARIES=YES" >> $GITHUB_ENV
+        shell: bash
+      - name: Set Version Variable
+        id: set-version
+        run: |
+          hash=$( git rev-parse --short HEAD )
+          version=${{ matrix.version }}
+          if [ "x${{ matrix.build_shared_libs }}" == "xOFF"]; then
+            suffix="-static"
+          else
+            suffix=""
+          fi
+          echo "release_version=${version}-${hash}${suffix}" >> $GITHUB_OUTPUT
+        shell: bash
+      - name: Configure TileDB
+        run: echo "Hello, World!"
+        shell: bash
+      # - name: Configure TileDB
+      #   run: |
+      #     cmake -S . -B build \
+      #       -DCMAKE_BUILD_TYPE=Release \
+      #       -DBUILD_SHARED_LIBS=ON \
+      #       -DCMAKE_INSTALL_PREFIX=./dist \
+      #       -DTILEDB_INSTALL_LIBDIR=lib \
+      #       -DTILEDB_S3=ON \
+      #       -DTILEDB_AZURE=ON \
+      #       -DTILEDB_GCS=ON \
+      #       -DTILEDB_HDFS=${{ startsWith(matrix.platform, 'windows') && 'OFF' || 'ON' }} \
+      #       -DTILEDB_SERIALIZATION=ON \
+      #       -DTILEDB_WEBP=ON \
+      #       -DTILEDB_TESTS=OFF \
+      #       -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }} \
+      #       ${{ matrix.cmake_args }}
+      #   shell: bash
+      - name: Build TileDB
+        env:
+          TILEDB_PACKAGE_VERSION: ${{ steps.set-version.outputs.release_version }}
+        run: |
+          mkdir build
+          touch build/tiledb-${{ matrix.platform }}-${{ env.TILEDB_PACKAGE_VERSION }}.tar.gz*
+        shell: bash
+        # run: cmake --build build -j4 --config Release --target package
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.platform }}
+          path: |
+            build/tiledb-*.tar.gz*
+            build/tiledb-*.zip*
+
+  publish:
+    needs:
+      - build
+    name: Publish Release Artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-*
+          merge-multiple: true
+          path: dist
+      - name: Publish Artifacts
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const repo = context.repo;
+            const release = await github.rest.repos.getReleaseByTag({
+              owner: repo.owner,
+              repo: repo.repo,
+              tag: "nightlies"
+            });
+            const globber = await glob.create('dist/*');
+            for await (const file of globber.globGenerator()) {
+              await github.rest.repos.uploadReleaseAsset({
+                owner: repo.owner,
+                repo: repo.repo,
+                release_id: release.data.id,
+                headers: {
+                  'content-type': 'application/octet-stream',
+                  'content-length': fs.statSync(file).size
+                },
+                name: path.basename(file),
+                data: fs.readFileSync(file)
+              });
+            }
+
+  generate-releases-csv:
+    needs:
+      - publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Create Release Directory
+        run: mkdir release-data
+        shell: bash
+      - name: Github release data
+        uses: KevinRohn/github-full-release-data@v2.0.4
+        with:
+          version: "nightlies"
+          asset-file: "*.zip,*.tar.gz"
+          asset-output: "./release-data/"
+      - name: Generate releases.csv
+        run: |
+          .github/scripts/generate-releases-csv.py
+      - name: Upload releases.*
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: release-data/releases.*
+          tag: nightlies
+          overwrite: true
+          file_glob: true
+
+  create-issue-on-fail:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    needs: generate-releases-csv
+    if: failure()
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Create Issue on Failure
+        uses: TileDB-Inc/github-actions/open-issue@main
+        with:
+          name: Nightly Build Failure
+          label: nightly-failure
+          assignee: davisp,rroelke


### PR DESCRIPTION
Initial work on adding nightly releases to be consumed downstream.

The current plan is to switch over our existing CI pipelines to using pre-built packages of tiledb similar to how we're already handling this with the nightly-libtiledb releases. However, these will provide both nightly packages as well as static builds of upstream tags.

Doing it this way means that when I get to adding the tagged release pipeline the logic will all match other than extra bits about uploading the results to the version tag.