### PR TITLE
chore(build): Strip quotes from tiledb prefix

### DIFF
--- a/tiledb/sys/build.rs
+++ b/tiledb/sys/build.rs
@@ -41,8 +41,13 @@ fn main() {
         .probe("tiledb")
         .expect("TileDB >= 2.27 not found.");
 
-    let libdir = pkg_config::get_variable("tiledb", "libdir")
+    let prefix = pkg_config::get_variable("tiledb", "prefix")
         .expect("Missing TileDB 'libdir' variable.");
+    let prefix = prefix.trim_matches('"');
+    let libdir = std::path::Path::new(prefix)
+        .join("lib")
+        .display()
+        .to_string();
 
     // If we find a libtiledb_static.a, link statically, otherwise assume
     // we want to link dynamically.


### PR DESCRIPTION
For some reason, the `pkg-config` that comes in the manylinux containers does not strip quotes. This avoids using the built-in variables and instead just grabs the prefix, strips quotes, and manually appends `lib` for now. Theoretically that could bite me later if something moves to `lib64` but I'll deal with that if and when it happens.