### PR TITLE
fix(lint): Fix new nightly lints

### DIFF
--- a/test-utils/signal/src/lib.rs
+++ b/test-utils/signal/src/lib.rs
@@ -107,10 +107,11 @@ impl<'a> SignalCallback<'a> {
             restore_callback: None,
             action: Box::new(handler),
         });
-        callback.restore_callback = std::mem::replace(
-            &mut SIGNAL_CALLBACKS[signo as i32 as usize].lock().unwrap(),
-            Some(RawSignalCallback::from(callback.as_mut().get_mut())),
-        );
+        let raw_callback = RawSignalCallback::from(callback.as_mut().get_mut());
+        SIGNAL_CALLBACKS[signo as i32 as usize]
+            .lock()
+            .unwrap()
+            .replace(raw_callback);
 
         callback
     }

--- a/tiledb/pod/src/query/subarray.rs
+++ b/tiledb/pod/src/query/subarray.rs
@@ -300,7 +300,7 @@ mod tests {
                         continue;
                     };
 
-                    let found_output = di.iter().any(|ri| intersection == *ri);
+                    let found_output = di.contains(&intersection);
                     assert!(
                         found_output,
                         "rs1 = {:?}, rs2 = {:?}, intersection = {:?}",


### PR DESCRIPTION
This update addresses the `manual_contains` clippy lint.