### PR TITLE
fix: physical type of `Datatype::Char` is architecture-dependent

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -55,6 +55,10 @@ jobs:
       - name: Build
         run: cargo build --all-targets --all-features
       - name: Test
+        env:
+          # give up shrinking after an hour
+          PROPTEST_MAX_SHRINK_ITERS: 100000000
+          PROPTEST_MAX_SHRINK_TIME: 3600000
         run: cargo test --all-targets --all-features
       - name: Check Linkage - Linux
         if: ${{ startsWith(matrix.os, 'ubuntu-') || startsWith(matrix.os, 'linux-') }}

--- a/tiledb/api/src/query/strategy/tests.rs
+++ b/tiledb/api/src/query/strategy/tests.rs
@@ -1010,3 +1010,122 @@ fn shrinking_query_condition_2() -> anyhow::Result<()> {
         vec![!qc],
     )
 }
+
+#[test]
+fn shrinking_query_condition_3() -> anyhow::Result<()> {
+    let schema = SchemaData {
+        array_type: ArrayType::Sparse,
+        domain: DomainData {
+            dimension: vec![DimensionData {
+                name: "JFfM_lgORj5c_BuS8Zi1aJxG".to_owned(),
+                datatype: Datatype::DateTimeAttosecond,
+                constraints: DimensionConstraints::Int64(
+                    [1148942038937258225, 2764999564421787440],
+                    Some(4620),
+                ),
+                filters: None,
+            }],
+        },
+        capacity: Some(1),
+        cell_order: Some(CellOrder::Hilbert),
+        tile_order: Some(TileOrder::ColumnMajor),
+        allow_duplicates: Some(false),
+        attributes: vec![AttributeData {
+            name: "478MS__I7".to_owned(),
+            datatype: Datatype::Char,
+            nullability: Some(true),
+            cell_val_num: CellValNum::single().into(),
+            fill: None,
+            filters: vec![],
+            enumeration: None,
+        }],
+        enumerations: vec![],
+        coordinate_filters: vec![],
+        offsets_filters: vec![],
+        nullity_filters: vec![],
+    };
+    let writes =
+        WriteSequence::Sparse(cells::write::SparseWriteSequence::from(vec![
+            SparseWriteInput {
+                dimensions: vec![(
+                    "JFfM_lgORj5c_BuS8Zi1aJxG".to_owned(),
+                    CellValNum::single(),
+                )],
+                data: Cells::new(HashMap::from([
+                    (
+                        "478MS__I7".to_owned(),
+                        FieldData::Int8(vec![
+                            12, 17, -67, 3, 86, 80, 102, -78, 117, -68, -34,
+                            -92, -82, -113, 105,
+                        ]),
+                    ),
+                    (
+                        "JFfM_lgORj5c_BuS8Zi1aJxG".to_owned(),
+                        FieldData::Int64(vec![
+                            2710911327883039156,
+                            2039592453050290347,
+                            2238046718653247530,
+                            1557798329745860504,
+                            2426329515562266082,
+                            1153837227816138344,
+                            2637512935416275165,
+                            2548530218600618664,
+                            2064853275117424032,
+                            2555096863448532801,
+                            1165535206997694286,
+                            1259935974712440169,
+                            2084689463781898211,
+                            2199758939081023375,
+                            1169287904123472043,
+                        ]),
+                    ),
+                ])),
+            },
+            SparseWriteInput {
+                dimensions: vec![(
+                    "JFfM_lgORj5c_BuS8Zi1aJxG".to_owned(),
+                    CellValNum::single(),
+                )],
+                data: Cells::new(HashMap::from([
+                    (
+                        "JFfM_lgORj5c_BuS8Zi1aJxG".to_owned(),
+                        FieldData::Int64(vec![
+                            2685183641182661929,
+                            2304697773534321558,
+                        ]),
+                    ),
+                    ("478MS__I7".to_owned(), FieldData::Int8(vec![-76, 112])),
+                ])),
+            },
+            SparseWriteInput {
+                dimensions: vec![(
+                    "JFfM_lgORj5c_BuS8Zi1aJxG".to_owned(),
+                    CellValNum::single(),
+                )],
+                data: Cells::new(HashMap::from([
+                    (
+                        "JFfM_lgORj5c_BuS8Zi1aJxG".to_owned(),
+                        FieldData::Int64(vec![
+                            2240931305299990434,
+                            2278591491338750833,
+                            1264903526162880855,
+                            2247465574030382854,
+                        ]),
+                    ),
+                    (
+                        "478MS__I7".to_owned(),
+                        FieldData::Int8(vec![29, -82, -42, -17]),
+                    ),
+                ])),
+            },
+        ]));
+    let qc = !QueryConditionExpr::field("478MS__I7").lt(0i8);
+
+    let acc = CellsAccumulator::fold(&schema, &writes);
+    instance_query_condition(
+        schema.into(),
+        writes.into(),
+        acc.into(),
+        vec![!qc],
+    )
+}

--- a/tiledb/common/src/datatype/logical.rs
+++ b/tiledb/common/src/datatype/logical.rs
@@ -96,7 +96,7 @@ pub struct CharType {}
 
 impl LogicalType for CharType {
     const DATA_TYPE: Datatype = Datatype::Char;
-    type PhysicalType = i8;
+    type PhysicalType = std::ffi::c_char;
 }
 
 pub struct StringAsciiType {}

--- a/tiledb/common/src/datatype/mod.rs
+++ b/tiledb/common/src/datatype/mod.rs
@@ -273,12 +273,16 @@ impl Datatype {
         use std::any::TypeId;
 
         let tid = TypeId::of::<T>();
-        if tid == TypeId::of::<f32>() {
+        if matches!(*self, Datatype::Char) {
+            // NB: some architectures this is signed, some it is unsigned,
+            // so it needs this special case
+            tid == TypeId::of::<std::ffi::c_char>()
+        } else if tid == TypeId::of::<f32>() {
             matches!(*self, Datatype::Float32)
         } else if tid == TypeId::of::<f64>() {
             matches!(*self, Datatype::Float64)
         } else if tid == TypeId::of::<i8>() {
-            matches!(*self, Datatype::Char | Datatype::Int8)
+            matches!(*self, Datatype::Int8)
         } else if tid == TypeId::of::<u8>() {
             matches!(
                 *self,


### PR DESCRIPTION
The signed-ness of `char` is architecture-dependent.  We were previously using `i8` as the physical type.  Now that we are running query conditions this has manifested in test failures when comparing against negative values on architectures where `char` is actually unsigned.

This pull request fixes the issue by using `c_char` for the physical type of `Datatype::Char`.  `c_char` is just a [type alias](https://doc.rust-lang.org/std/ffi/type.c_char.html) for `u8` or `i8` depending on the architecture.

I also increased the shrinking bounds for nightly runs - we expect infrequent failures and when they do show up the smaller the better.  The changes here increase the number of shrinking iterations to a large number but bounds the shrink time at one hour.