### PR TITLE
chore(ci): Fix package builds

### DIFF
--- a/.github/scripts/generate-package-matrix.py
+++ b/.github/scripts/generate-package-matrix.py
@@ -23,7 +23,7 @@ BASE_MATRIX = [
     {
         "platform": "linux-x86_64",
         "os": "ubuntu-20.04",
-        "manylinux": "quay.io/pypa/manylinux_2_28_x86_64",
+        "manylinux": "quay.io/pypa/manylinux_2_28_x86_64:2025.03.15-1",
         "triplet": "x64-linux-release"
     },
     {
@@ -31,13 +31,13 @@ BASE_MATRIX = [
         "os": "ubuntu-20.04",
         "cmake_args": "-DCOMPILER_SUPPORTS_AVX2=OFF",
         "triplet": "x64-linux-release",
-        "manylinux": "quay.io/pypa/manylinux_2_28_x86_64"
+        "manylinux": "quay.io/pypa/manylinux_2_28_x86_64:2025.03.15-1"
     },
     {
         "platform": "linux-aarch64",
         "os": "linux-arm64-ubuntu24",
         "triplet": "arm64-linux-release",
-        "manylinux": "quay.io/pypa/manylinux_2_28_aarch64"
+        "manylinux": "quay.io/pypa/manylinux_2_28_aarch64:2025.03.15-1"
     },
     {
         "platform": "macos-x86_64",

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -137,6 +137,18 @@ jobs:
           path: |
             ~/repos/tiledb/build/tiledb-*.tar.gz
             ~/repos/tiledb/build/tiledb-*.zip
+      - name: "Show Logs on Failure"
+        if: ${{ failure() }}
+        shell: bash
+        run: |
+          set -e pipefail
+          for f in $(find ~/repos/tiledb/build -name *.log | sort);
+            do
+              echo "$f"
+              echo "==================================================="
+              cat $f
+              echo "\n\n"
+            done;
 
   publish:
     needs:


### PR DESCRIPTION
The packaging builds managed to get themselves into a weird state which also causes nightlies to fail. This fixes the package builds by pinning the manylinux container to a version that has CMake<4.0 which should unblock nightlies as well.