### PR TITLE
fix: Set the minimum fixed sized list to 2

### DIFF
--- a/tiledb/common/src/datatype/arrow.rs
+++ b/tiledb/common/src/datatype/arrow.rs
@@ -552,7 +552,7 @@ pub mod strategy {
                 max_fixed_binary_len: DEFAULT_MAX_FIXED_BINARY_LEN,
                 min_numeric_precision: 1,
                 max_numeric_precision: u8::MAX,
-                min_fixed_list_len: 0,
+                min_fixed_list_len: 2,
                 max_fixed_list_len: DEFAULT_MAX_FIXED_LIST_LEN,
                 min_struct_fields: 0,
                 max_struct_fields: 16,


### PR DESCRIPTION
We caught a proptest failure because we translate a fixed size list of length 1, to a non-list version of the contained datatype. I.e., we changed the faux data type `[u32; 1]` to `u32`.