### PR TITLE
chore: fix clippy::uninlined_format_args

### DIFF
--- a/test-utils/cells/src/lib.rs
+++ b/test-utils/cells/src/lib.rs
@@ -222,8 +222,7 @@ impl Cells {
         for k in keys.iter() {
             if !self.fields.contains_key(k) {
                 panic!(
-                    "Cannot construct view: key '{}' not found (fields are {:?})",
-                    k,
+                    "Cannot construct view: key '{k}' not found (fields are {:?})",
                     self.fields.keys()
                 )
             }
@@ -717,7 +716,7 @@ pub struct StructuredCells {
 impl StructuredCells {
     pub fn new(dimensions: Vec<usize>, cells: Cells) -> Self {
         let expected_cells: usize = dimensions.iter().cloned().product();
-        assert_eq!(expected_cells, cells.len(), "Dimensions: {:?}", dimensions);
+        assert_eq!(expected_cells, cells.len(), "Dimensions: {dimensions:?}",);
 
         StructuredCells { dimensions, cells }
     }
@@ -1354,8 +1353,7 @@ mod tests {
                             .$op(String::from_utf8(cells[pivot].to_vec())
                                 .unwrap()),
                         _ => unreachable!(
-                            "Invalid field for query condition: {:?}",
-                            fdata
+                            "Invalid field for query condition: {fdata:?}",
                         ),
                     }
                 };
@@ -1427,10 +1425,9 @@ mod tests {
                         .map(|i| String::from_utf8(cells[*i].to_vec()).unwrap())
                         .collect::<Vec<_>>(),
                 ),
-                _ => unreachable!(
-                    "Invalid field for query condition: {:?}",
-                    fdata
-                ),
+                _ => {
+                    unreachable!("Invalid field for query condition: {fdata:?}",)
+                }
             }
         };
 
@@ -1493,10 +1490,9 @@ mod tests {
                         .map(|i| String::from_utf8(cells[*i].to_vec()).unwrap())
                         .collect::<Vec<_>>(),
                 ),
-                _ => unreachable!(
-                    "Invalid field for query condition: {:?}",
-                    fdata
-                ),
+                _ => {
+                    unreachable!("Invalid field for query condition: {fdata:?}",)
+                }
             }
         };
 

--- a/test-utils/cells/src/write/strategy.rs
+++ b/test-utils/cells/src/write/strategy.rs
@@ -114,15 +114,11 @@ impl DenseWriteValueTree {
 
                 assert!(
                     complete.start() <= current.start(),
-                    "complete = {:?}, current = {:?}",
-                    complete,
-                    current
+                    "complete = {complete:?}, current = {current:?}",
                 );
                 assert!(
                     current.end() <= complete.end(),
-                    "complete = {:?}, current = {:?}",
-                    complete,
-                    current
+                    "complete = {complete:?}, current = {current:?}",
                 );
 
                 let start = current.start() - complete.start();
@@ -271,7 +267,7 @@ impl Strategy for DenseWriteStrategy {
                 d.subarray_strategy(Some(cell_limit)).expect("Dense dimension subarray not found")
                     .prop_map(|r| {
                         let Range::Single(s) = r else {
-                            unreachable!("Dense dimension subarray is not `Range::Single`: {:?}", r)
+                            unreachable!("Dense dimension subarray is not `Range::Single`: {r:?}")
                         };
                         s
                     }).boxed()

--- a/test-utils/proptest-config/src/lib.rs
+++ b/test-utils/proptest-config/src/lib.rs
@@ -9,7 +9,7 @@ where
     match std::env::var(env) {
         Ok(value) => Some(
             T::from_str(&value)
-                .unwrap_or_else(|_| panic!("Invalid value for {}", env)),
+                .unwrap_or_else(|_| panic!("Invalid value for {env}")),
         ),
         Err(_) => None,
     }

--- a/test-utils/strategy-ext/src/records.rs
+++ b/test-utils/strategy-ext/src/records.rs
@@ -439,8 +439,7 @@ mod tests {
             let convergence = tree.current();
             assert!(
                 convergence.is_empty(),
-                "Value tree converged to: {:?}",
-                convergence
+                "Value tree converged to: {convergence:?}"
             );
         }
     }
@@ -465,8 +464,7 @@ mod tests {
             let convergence = tree.current();
             assert!(
                 convergence.is_empty(),
-                "Value tree converged to: {:?}",
-                convergence
+                "Value tree converged to: {convergence:?}"
             );
         }
     }

--- a/tiledb/api/examples/aggregates.rs
+++ b/tiledb/api/examples/aggregates.rs
@@ -154,7 +154,7 @@ fn example_count() -> TileDBResult<()> {
     let Some(count) = count else {
         unreachable!("Count result is never `None`");
     };
-    println!("Count is {}", count);
+    println!("Count is {count}");
 
     Ok(())
 }
@@ -190,7 +190,7 @@ fn example_sum() -> TileDBResult<()> {
     let Some(sum) = results else {
         unreachable!("Sum is `None` which cannot occur on example input");
     };
-    println!("Sum is {}", sum);
+    println!("Sum is {sum}");
 
     Ok(())
 }
@@ -229,8 +229,8 @@ fn example_min_max() -> TileDBResult<()> {
     let (Some(min_res), Some(max_res)) = (min_res, max_res) else {
         unreachable!("Min or max is `None` which cannot occur on example input")
     };
-    println!("Min is {}", min_res);
-    println!("Max is {}", max_res);
+    println!("Min is {min_res}");
+    println!("Max is {max_res}");
 
     Ok(())
 }
@@ -266,7 +266,7 @@ fn example_mean() -> TileDBResult<()> {
     let Some(mean) = mean else {
         unreachable!("Mean is `None` which cannot occur on example input")
     };
-    println!("Mean is {}", mean);
+    println!("Mean is {mean}");
 
     Ok(())
 }

--- a/tiledb/api/examples/fragment_info.rs
+++ b/tiledb/api/examples/fragment_info.rs
@@ -36,7 +36,7 @@ fn read_fragment_info() -> TileDBResult<()> {
             .build()?;
     let num_frags = frag_infos.num_fragments()?;
 
-    println!("Number of fragments: {}", num_frags);
+    println!("Number of fragments: {num_frags}");
     println!("To Vacuum Num: {}", frag_infos.num_to_vacuum()?);
     println!("Total Cell Count: {}", frag_infos.total_cell_count()?);
     println!(
@@ -44,32 +44,27 @@ fn read_fragment_info() -> TileDBResult<()> {
         frag_infos.unconsolidated_metadata_num()?
     );
     for (i, frag_info) in frag_infos.iter()?.enumerate() {
-        println!("Name {}: {}", i, frag_info.name()?);
-        println!("URI  {}: {}", i, frag_info.uri()?);
-        println!("Size {}: {}", i, frag_info.size()?);
-        println!("Type {}: {:?}", i, frag_info.fragment_type()?);
-        println!("Timestamp Range {}: {:?}", i, frag_info.timestamp_range()?);
-        println!("Cell Num {}: {}", i, frag_info.num_cells()?);
-        println!("Version {}: {}", i, frag_info.version()?);
+        println!("Name {i}: {}", frag_info.name()?);
+        println!("URI  {i}: {}", frag_info.uri()?);
+        println!("Size {i}: {}", frag_info.size()?);
+        println!("Type {i}: {:?}", frag_info.fragment_type()?);
+        println!("Timestamp Range {i}: {:?}", frag_info.timestamp_range()?);
+        println!("Cell Num {i}: {}", frag_info.num_cells()?);
+        println!("Version {i}: {}", frag_info.version()?);
         println!(
-            "Has Consolidated Metadata {}: {}",
-            i,
+            "Has Consolidated Metadata {i}: {}",
             frag_info.has_consolidated_metadata()?
         );
 
         frag_info.to_vacuum_uri().expect_err("No vacuums to vacuum");
 
-        println!("Schema {}: {:?}", i, frag_info.schema()?);
-        println!("Schema Name {}: {}", i, frag_info.schema_name()?);
-        println!(
-            "Non-empty domain: {}: {:?}",
-            i,
-            frag_info.non_empty_domain()?
-        );
+        println!("Schema {i}: {:?}", frag_info.schema()?);
+        println!("Schema Name {i}: {}", frag_info.schema_name()?);
+        println!("Non-empty domain: {i}: {:?}", frag_info.non_empty_domain()?);
 
         // Dense arrays don't have MBRs, but the num_mbrs method is hard
         // coded to return 0 in libtiledb.
-        println!("Num MBRs {}: {}", i, frag_info.num_mbrs()?);
+        println!("Num MBRs {i}: {}", frag_info.num_mbrs()?);
         frag_info.mbr(0).expect_err("Dense arrays don't have MBRs");
     }
 

--- a/tiledb/api/examples/groups.rs
+++ b/tiledb/api/examples/groups.rs
@@ -131,7 +131,7 @@ fn print_group() -> TileDBResult<()> {
     let group =
         Group::open(&tdb, "my_group", tiledb::query::QueryType::Read, None)?;
     let dump_str = group.dump(true)?;
-    println!("{}", dump_str);
+    println!("{dump_str}");
     Ok(())
 }
 

--- a/tiledb/api/examples/multi_range_subarray.rs
+++ b/tiledb/api/examples/multi_range_subarray.rs
@@ -70,7 +70,7 @@ fn main() -> TileDBResult<()> {
     let (a, (cols, (rows, ()))) = query.execute()?;
 
     for (row, col, a) in izip!(rows, cols, a) {
-        println!("{} {} {}", row, col, a);
+        println!("{row} {col} {a}");
     }
     println!();
 

--- a/tiledb/api/examples/query_condition_dense.rs
+++ b/tiledb/api/examples/query_condition_dense.rs
@@ -94,9 +94,9 @@ fn read_array(ctx: &Context, qc: Option<QC>) -> TileDBResult<()> {
 
     for (index, a, a_valid, b, c, d) in izip!(index, a, a_validity, b, c, d) {
         if a_valid == 1 {
-            println!("{}: '{}' '{}' '{}', '{}'", index, a, b, c, d)
+            println!("{index}: '{a}' '{b}' '{c}', '{d}'")
         } else {
-            println!("{}: null '{}', '{}', '{}'", index, b, c, d)
+            println!("{index}: null '{b}', '{c}', '{d}'")
         }
     }
     println!();

--- a/tiledb/api/examples/query_condition_sparse.rs
+++ b/tiledb/api/examples/query_condition_sparse.rs
@@ -94,9 +94,9 @@ fn read_array(ctx: &Context, qc: Option<QC>) -> TileDBResult<()> {
 
     for (index, a, a_valid, b, c, d) in izip!(index, a, a_validity, b, c, d) {
         if a_valid == 1 {
-            println!("{}: '{}' '{}' '{}', '{}'", index, a, b, c, d)
+            println!("{index}: '{a}' '{b}' '{c}', '{d}'")
         } else {
-            println!("{}: null '{}', '{}', '{}'", index, b, c, d)
+            println!("{index}: null '{b}', '{c}', '{d}'")
         }
     }
     println!();

--- a/tiledb/api/examples/quickstart_dense.rs
+++ b/tiledb/api/examples/quickstart_dense.rs
@@ -128,7 +128,7 @@ fn read_array() -> TileDBResult<()> {
     let (results, _) = query.execute()?;
 
     for value in results {
-        print!("{} ", value)
+        print!("{value} ")
     }
     println!();
     Ok(())

--- a/tiledb/api/examples/quickstart_sparse_string.rs
+++ b/tiledb/api/examples/quickstart_sparse_string.rs
@@ -46,7 +46,7 @@ fn main() -> TileDBResult<()> {
     let (a, (cols, (rows, ()))) = query.execute()?;
 
     for (row, col, a) in izip!(rows, cols, a) {
-        println!("Cell ({} {}) has data {}", row, col, a);
+        println!("Cell ({row} {col}) has data {a}");
     }
     println!();
 

--- a/tiledb/api/examples/reading_incomplete.rs
+++ b/tiledb/api/examples/reading_incomplete.rs
@@ -212,7 +212,7 @@ fn read_array_step() -> TileDBResult<()> {
             for (row, column, a1, a2) in
                 izip!(rows.iter(), cols.iter(), a1.iter(), a2)
             {
-                println!("\tCell ({}, {}) a1: {}, a2: {}", row, column, a1, a2)
+                println!("\tCell ({row}, {column}) a1: {a1}, a2: {a2}")
             }
         } else {
             println!("\t\tNot enough space, growing buffers...");
@@ -280,7 +280,7 @@ fn read_array_collect() -> TileDBResult<()> {
     let (a2, (a1, (column, (row, _)))) = qq.execute()?;
 
     for (row, column, a1, a2) in izip!(row, column, a1, a2) {
-        println!("\tCell ({}, {}) a1: {}, a2: {}", row, column, a1, a2)
+        println!("\tCell ({row}, {column}) a1: {a1}, a2: {a2}")
     }
 
     Ok(())
@@ -292,7 +292,7 @@ fn read_array_collect() -> TileDBResult<()> {
 /// which is handled manually by swapping the buffer inside of the RefCell.
 fn read_array_callback() -> TileDBResult<()> {
     fn callback(row: i32, column: i32, a1: i32, a2: String) {
-        println!("\tCell ({}, {}) a1: {}, a2: {}", row, column, a1, a2)
+        println!("\tCell ({row}, {column}) a1: {a1}, a2: {a2}")
     }
 
     println!("read_array_callback");

--- a/tiledb/api/examples/using_tiledb_stats.rs
+++ b/tiledb/api/examples/using_tiledb_stats.rs
@@ -158,7 +158,7 @@ pub fn read_array(json: bool) -> TileDBResult<()> {
     } else {
         let stats = tiledb::stats::dump()?;
         match stats {
-            Some(stats_str) => println!("{}", &stats_str),
+            Some(stats_str) => println!("{stats_str}"),
             None => println!("No stats associated with this query."),
         }
     }

--- a/tiledb/api/src/array/attribute/arrow.rs
+++ b/tiledb/api/src/array/attribute/arrow.rs
@@ -105,7 +105,7 @@ pub fn to_arrow(attr: &Attribute) -> TileDBResult<FieldToArrowResult> {
             serde_json::ser::to_string(&AttributeMetadata::new(attr)?)
                 .map_err(|e| {
                     Error::Serialization(
-                        format!("attribute {} metadata", name),
+                        format!("attribute {name} metadata"),
                         anyhow!(e),
                     )
                 })?;
@@ -230,7 +230,7 @@ pub mod tests {
         let tdb_out = tdb_out.ok().unwrap().build();
 
         if is_to_arrow_exact {
-            assert!(is_from_arrow_exact, "{:?}", tdb_out);
+            assert!(is_from_arrow_exact, "{tdb_out:?}");
             assert_eq!(tdb_in, tdb_out);
         } else {
             /*
@@ -278,7 +278,7 @@ pub mod tests {
         };
 
         if is_from_arrow_exact {
-            assert!(is_to_arrow_exact, "{:?} => {:?}", arrow_in, arrow_out);
+            assert!(is_to_arrow_exact, "{arrow_in:?} => {arrow_out:?}");
 
             /* this should be perfectly invertible */
             assert_eq!(arrow_in, arrow_out);

--- a/tiledb/api/src/array/attribute/mod.rs
+++ b/tiledb/api/src/array/attribute/mod.rs
@@ -305,7 +305,7 @@ impl Debug for Attribute {
             Ok(a) => Debug::fmt(&a, f),
             Err(e) => {
                 let RawAttribute::Owned(ptr) = self.raw;
-                write!(f, "<Attribute @ {:?}: serialization error: {}>", ptr, e)
+                write!(f, "<Attribute @ {ptr:?}: serialization error: {e}>")
             }
         }
     }

--- a/tiledb/api/src/array/dimension/arrow.rs
+++ b/tiledb/api/src/array/dimension/arrow.rs
@@ -72,7 +72,7 @@ pub fn to_arrow(dim: &Dimension) -> TileDBResult<FieldToArrowResult> {
         )?)
         .map_err(|e| {
             TileDBError::Serialization(
-                format!("dimension {} metadata", name),
+                format!("dimension {name} metadata"),
                 anyhow!(e),
             )
         })?;
@@ -211,7 +211,7 @@ mod tests {
         let tdb_out = tdb_out.ok().unwrap().build();
 
         if is_to_arrow_exact {
-            assert!(is_from_arrow_exact, "{:?}", tdb_out);
+            assert!(is_from_arrow_exact, "{tdb_out:?}");
             assert_eq!(tdb_in, tdb_out);
         } else {
             /*

--- a/tiledb/api/src/array/dimension/mod.rs
+++ b/tiledb/api/src/array/dimension/mod.rs
@@ -165,7 +165,7 @@ impl Debug for Dimension {
             Ok(d) => Debug::fmt(&d, f),
             Err(e) => {
                 let RawDimension::Owned(ptr) = self.raw;
-                write!(f, "<Dimension @ {:?}: serialization error: {}>", ptr, e)
+                write!(f, "<Dimension @ {ptr:?}: serialization error: {e}>")
             }
         }
     }

--- a/tiledb/api/src/array/domain/mod.rs
+++ b/tiledb/api/src/array/domain/mod.rs
@@ -148,8 +148,7 @@ impl Domain {
         }
 
         Err(Error::InvalidArgument(anyhow!(
-            "Dimension '{}' does not exist in this domain.",
-            name
+            "Dimension '{name}' does not exist in this domain.",
         )))
     }
 
@@ -223,7 +222,7 @@ impl Debug for Domain {
             Ok(d) => Debug::fmt(&d, f),
             Err(e) => {
                 let RawDomain::Owned(ptr) = self.raw;
-                write!(f, "<Domain @ {:?}: serialization error: {}>", ptr, e)
+                write!(f, "<Domain @ {ptr:?}: serialization error: {e}>")
             }
         }
     }

--- a/tiledb/api/src/array/enumeration/mod.rs
+++ b/tiledb/api/src/array/enumeration/mod.rs
@@ -222,11 +222,7 @@ impl Debug for Enumeration {
             Ok(e) => Debug::fmt(&e, f),
             Err(e) => {
                 let RawEnumeration::Owned(ptr) = self.raw;
-                write!(
-                    f,
-                    "<Enumeration @ {:?}: serialization error: {}>",
-                    ptr, e
-                )
+                write!(f, "<Enumeration @ {ptr:?}: serialization error: {e}>",)
             }
         }
     }

--- a/tiledb/api/src/array/mod.rs
+++ b/tiledb/api/src/array/mod.rs
@@ -69,7 +69,7 @@ impl Display for Encryption {
         if c_ret == ffi::TILEDB_OK {
             let s =
                 unsafe { std::ffi::CStr::from_ptr(c_str) }.to_string_lossy();
-            write!(f, "{}", s)
+            write!(f, "{s}")
         } else {
             write!(f, "<Internal error>")
         }
@@ -95,8 +95,7 @@ impl FromStr for Encryption {
             Ok(encryption_type)
         } else {
             Err(Error::InvalidArgument(anyhow!(format!(
-                "Invalid encryption type: {}",
-                s
+                "Invalid encryption type: {s}",
             ))))
         }
     }
@@ -595,8 +594,7 @@ impl Array {
         // but this is written to be easy to upgrade if that ever changes
         assert_eq!(
             num_values, 1,
-            "Unexpected cell val num for dimension: {:?}",
-            cell_val_num
+            "Unexpected cell val num for dimension: {cell_val_num:?}",
         );
 
         if c_is_empty == 1 {
@@ -686,8 +684,7 @@ impl Array {
 
                 if c_is_empty == 1 {
                     unreachable!(
-                        "Non-empty domain was non-empty for size check but empty when retrieving data: dimension = {:?}, start_size = {}, end_size = {}",
-                        dimension_key, start_size, end_size
+                        "Non-empty domain was non-empty for size check but empty when retrieving data: dimension = {dimension_key:?}, start_size = {start_size}, end_size = {end_size}",
                     )
                 } else {
                     Ok(Some(VarValueRange::from((start, end))))
@@ -751,8 +748,7 @@ impl Array {
 
                 if c_is_empty == 1 {
                     unreachable!(
-                        "Non-empty domain was non-empty for size check but empty when retrieving data: dimension = {:?}, start_size = {}, end_size = {}",
-                        c_name, start_size, end_size
+                        "Non-empty domain was non-empty for size check but empty when retrieving data: dimension = {c_name:?}, start_size = {start_size}, end_size = {end_size}",
                     )
                 } else {
                     Ok(Some(VarValueRange::from((start, end))))

--- a/tiledb/api/src/array/schema/mod.rs
+++ b/tiledb/api/src/array/schema/mod.rs
@@ -477,7 +477,7 @@ impl Debug for Schema {
             Ok(s) => Debug::fmt(&s, f),
             Err(e) => {
                 let RawSchema::Owned(ptr) = self.raw;
-                write!(f, "<Schema @ {:?}: serialization error: {}>", ptr, e)
+                write!(f, "<Schema @ {ptr:?}: serialization error: {e}>")
             }
         }
     }
@@ -1542,8 +1542,7 @@ mod tests {
             assert!(
                 s.contains("not a valid Dimension Datatype")
                     || s.contains("do not support dimension datatype"),
-                "Expected dimension datatype error, received: {}",
-                s
+                "Expected dimension datatype error, received: {s}",
             );
         } else {
             assert!(
@@ -1570,8 +1569,7 @@ mod tests {
             assert!(
                 s.contains("not a valid Dimension Datatype")
                     || s.contains("do not support dimension datatype"),
-                "Expected dimension datatype error, received: {}",
-                s
+                "Expected dimension datatype error, received: {s}",
             );
         } else {
             assert!(

--- a/tiledb/api/src/context.rs
+++ b/tiledb/api/src/context.rs
@@ -148,8 +148,7 @@ impl Context {
             Err(e)
         } else {
             panic!(
-                "libtiledb context did not have error for error return value: {}",
-                c_ret
+                "libtiledb context did not have error for error return value: {c_ret}",
             )
         }
     }

--- a/tiledb/api/src/error.rs
+++ b/tiledb/api/src/error.rs
@@ -103,7 +103,7 @@ impl Serialize for Error {
     where
         S: Serializer,
     {
-        format!("<{}>", self).serialize(serializer)
+        format!("<{self}>").serialize(serializer)
     }
 }
 

--- a/tiledb/api/src/filter/list.rs
+++ b/tiledb/api/src/filter/list.rs
@@ -85,18 +85,16 @@ impl Debug for FilterList {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         let nfilters = match self.get_num_filters() {
             Ok(n) => n,
-            Err(e) => return write!(f, "<error reading filter list: {}>", e),
+            Err(e) => return write!(f, "<error reading filter list: {e}>"),
         };
         write!(f, "[")?;
         for fi in 0..nfilters {
             match self.get_filter(fi) {
                 Ok(fd) => match fd.filter_data() {
-                    Ok(fd) => write!(f, "{:?},", fd)?,
-                    Err(e) => {
-                        write!(f, "<error reading filter {}: {}>", fi, e)?
-                    }
+                    Ok(fd) => write!(f, "{fd:?},")?,
+                    Err(e) => write!(f, "<error reading filter {fi}: {e}>")?,
                 },
-                Err(e) => write!(f, "<error reading filter {}: {}>", fi, e)?,
+                Err(e) => write!(f, "<error reading filter {fi}: {e}>")?,
             };
         }
         write!(f, "]")

--- a/tiledb/api/src/filter/mod.rs
+++ b/tiledb/api/src/filter/mod.rs
@@ -345,8 +345,8 @@ impl Filter {
 impl Debug for Filter {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         match self.filter_data() {
-            Ok(data) => write!(f, "{:?}", data),
-            Err(e) => write!(f, "<error reading filter data: {}", e),
+            Ok(data) => write!(f, "{data:?}"),
+            Err(e) => write!(f, "<error reading filter data: {e}"),
         }
     }
 }
@@ -666,8 +666,8 @@ mod tests {
                     .transform_datatype(&current_dt) {
                         current_dt = next_dt
                 } else {
-                    panic!("Constructed invalid filter list for datatype {}: \
-                        {:?}, invalid at position {}", dt, fl, fi)
+                    panic!("Constructed invalid filter list for datatype {dt}: \
+                        {fl:?}, invalid at position {fi}")
                 }
             }
         });

--- a/tiledb/api/src/query/mod.rs
+++ b/tiledb/api/src/query/mod.rs
@@ -187,8 +187,7 @@ impl ReadQuery for QueryBase {
             }
             ffi::tiledb_query_status_t_TILEDB_INITIALIZED => unreachable!(),
             unrecognized => Err(Error::Internal(format!(
-                "Unrecognized query status: {}",
-                unrecognized
+                "Unrecognized query status: {unrecognized}",
             ))),
         }
     }

--- a/tiledb/api/src/query/read/aggregate/mod.rs
+++ b/tiledb/api/src/query/read/aggregate/mod.rs
@@ -50,11 +50,11 @@ impl AggregateFunction {
     pub fn aggregate_name(&self) -> String {
         match self {
             Self::Count => "Count".to_owned(),
-            Self::NullCount(s) => format!("NullCount({})", s),
-            Self::Min(s) => format!("Min({})", s),
-            Self::Max(s) => format!("Max({})", s),
-            Self::Sum(s) => format!("Sum({})", s),
-            Self::Mean(s) => format!("Mean({})", s),
+            Self::NullCount(s) => format!("NullCount({s})"),
+            Self::Min(s) => format!("Min({s})"),
+            Self::Max(s) => format!("Max({s})"),
+            Self::Sum(s) => format!("Sum({s})"),
+            Self::Mean(s) => format!("Mean({s})"),
         }
     }
 
@@ -126,10 +126,8 @@ impl AggregateFunction {
             match self.result_type_impl(Some((datatype, cell_val_num))) {
                 Some(datatype) => Ok(datatype),
                 None => Err(TileDBError::InvalidArgument(anyhow!(format!(
-                    "aggregate_type: field '{}' has invalid datatype and cell val num ({}, {})",
+                    "aggregate_type: field '{}' has invalid datatype and cell val num ({datatype}, {cell_val_num})",
                     self.argument_name().unwrap(),
-                    datatype,
-                    cell_val_num
                 )))),
             }
         } else {

--- a/tiledb/api/src/tests/examples/sparse_all.rs
+++ b/tiledb/api/src/tests/examples/sparse_all.rs
@@ -90,7 +90,7 @@ pub fn schema(params: Parameters) -> SchemaData {
                 DimensionConstraints::StringAscii
             };
             dims.push(DimensionData {
-                name: format!("d_{}", dt),
+                name: format!("d_{dt}"),
                 datatype: dt,
                 filters: None,
                 constraints,
@@ -100,7 +100,7 @@ pub fn schema(params: Parameters) -> SchemaData {
         let mut attfunc = |cell_val_num, is_nullable| {
             let tag_cvn = match cell_val_num {
                 CellValNum::Fixed(nz) if nz.get() == 1 => "single".to_owned(),
-                CellValNum::Fixed(nz) => format!("fixed@{}", nz),
+                CellValNum::Fixed(nz) => format!("fixed@{nz}"),
                 CellValNum::Var => "var".to_owned(),
             };
             let tag_nullable = if is_nullable {
@@ -110,7 +110,7 @@ pub fn schema(params: Parameters) -> SchemaData {
             };
 
             atts.push(AttributeData {
-                name: format!("a_{}_{}_{}", dt, tag_cvn, tag_nullable),
+                name: format!("a_{dt}_{tag_cvn}_{tag_nullable}"),
                 datatype: dt,
                 nullability: Some(is_nullable),
                 cell_val_num: Some(cell_val_num),

--- a/tiledb/api/src/vfs.rs
+++ b/tiledb/api/src/vfs.rs
@@ -737,7 +737,7 @@ mod tests {
     fn vfs_ls_recursive_new() -> TileDBResult<()> {
         // Recursive ls over the Posix backend doesn't exist before 2.21
         let (major, minor, patch) = crate::version();
-        println!("VERSION: {}.{}.{}", major, minor, patch);
+        println!("VERSION: {major}.{minor}.{patch}");
         if !(major >= 2 && minor >= 21) {
             return Ok(());
         }

--- a/tiledb/common/src/datatype/arrow.rs
+++ b/tiledb/common/src/datatype/arrow.rs
@@ -755,10 +755,7 @@ pub mod tests {
                 assert_eq!(
                     tdb_dt.size(),
                     arrow_size,
-                    "to_arrow({}, {:?}) = {}",
-                    tdb_dt,
-                    cell_val_num,
-                    arrow
+                    "to_arrow({tdb_dt}, {cell_val_num:?}) = {arrow}",
                 );
 
                 let tdb_out = from_arrow(&arrow);
@@ -775,10 +772,7 @@ pub mod tests {
                 assert_eq!(
                     tdb_dt.size(),
                     arrow_size,
-                    "to_arrow({}, {:?}) = {}",
-                    tdb_dt,
-                    cell_val_num,
-                    arrow
+                    "to_arrow({tdb_dt}, {cell_val_num:?}) = {arrow}",
                 );
 
                 let tdb_out = from_arrow(&arrow);
@@ -825,8 +819,7 @@ pub mod tests {
                         }
                     }
                     arrow => unreachable!(
-                        "Expected FixedSizeList for inexact match but found {}",
-                        arrow
+                        "Expected FixedSizeList for inexact match but found {arrow}",
                     ),
                 }
 
@@ -884,8 +877,7 @@ pub mod tests {
                         assert_eq!(fixed_len_in, fixed_len_out as u32);
                     }
                     adt => unreachable!(
-                        "to_arrow({}, {:?}) = {}",
-                        tdb_dt, cell_val_num, adt
+                        "to_arrow({tdb_dt}, {cell_val_num:?}) = {adt}",
                     ),
                 }
 
@@ -917,10 +909,7 @@ pub mod tests {
             DatatypeToArrowResult::Inexact(arrow) => {
                 assert!(
                     !arrow.is_primitive(),
-                    "to_arrow({}, {:?}) = {}",
-                    tdb_dt,
-                    cell_val_num,
-                    arrow
+                    "to_arrow({tdb_dt}, {cell_val_num:?}) = {arrow}",
                 );
 
                 if let ADT::LargeList(ref item) = arrow {
@@ -953,10 +942,7 @@ pub mod tests {
             DatatypeToArrowResult::Exact(arrow) => {
                 assert!(
                     !arrow.is_primitive(),
-                    "to_arrow({}, {:?}) = {}",
-                    tdb_dt,
-                    cell_val_num,
-                    arrow
+                    "to_arrow({tdb_dt}, {cell_val_num:?}) = {arrow}"
                 );
 
                 match arrow {
@@ -978,8 +964,7 @@ pub mod tests {
                                 assert_eq!(*item.data_type(), item_dt);
                             } else {
                                 unreachable!(
-                                    "Expected inexact item match but found {:?}",
-                                    item_dt
+                                    "Expected inexact item match but found {item_dt:?}"
                                 )
                             }
                         } else {
@@ -1005,8 +990,7 @@ pub mod tests {
                         assert!(matches!(tdb_dt, Datatype::Blob))
                     }
                     adt => unreachable!(
-                        "to_arrow({}, {:?}) = {}",
-                        tdb_dt, cell_val_num, adt
+                        "to_arrow({tdb_dt}, {cell_val_num:?}) = {adt}",
                     ),
                 }
 
@@ -1054,9 +1038,7 @@ pub mod tests {
                 let arrow_out = arrow_out.into_inner();
                 assert!(
                     is_physical_type_match(arrow_in, &arrow_out),
-                    "{:?} => {:?}",
-                    arrow_in,
-                    arrow_out
+                    "{arrow_in:?} => {arrow_out:?}"
                 );
             }
         }

--- a/tiledb/common/src/datatype/mod.rs
+++ b/tiledb/common/src/datatype/mod.rs
@@ -984,10 +984,7 @@ mod tests {
             if i < NUM_DATATYPES {
                 let dt = Datatype::try_from(i as u32)
                     .expect("Error converting value to Datatype");
-                assert_ne!(
-                    format!("{}", dt),
-                    "<UNKNOWN DATA TYPE>".to_string()
-                );
+                assert_ne!(format!("{dt}"), "<UNKNOWN DATA TYPE>".to_string());
                 assert!(check_valid(&dt));
             } else {
                 assert!(Datatype::try_from(i as u32).is_err());

--- a/tiledb/common/src/query/condition/mod.rs
+++ b/tiledb/common/src/query/condition/mod.rs
@@ -211,7 +211,7 @@ impl Display for Literal {
         literal_go!(
             self,
             val,
-            write!(f, "{}", val),
+            write!(f, "{val}"),
             write!(f, "'{}'", escape_string_literal(val))
         )
     }
@@ -419,8 +419,8 @@ impl SetMembers {
         T: Display,
     {
         if let Some((first, rest)) = members.split_first() {
-            write!(f, "({}", first)?;
-            rest.iter().try_for_each(|value| write!(f, ", {}", value))?;
+            write!(f, "({first}")?;
+            rest.iter().try_for_each(|value| write!(f, ", {value}"))?;
             write!(f, ")")
         } else {
             write!(f, "()")
@@ -671,9 +671,9 @@ impl Predicate {
 impl Display for Predicate {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         match self {
-            Self::Equality(e) => write!(f, "{}", e),
-            Self::SetMembership(m) => write!(f, "{}", m),
-            Self::Nullness(n) => write!(f, "{}", n),
+            Self::Equality(e) => write!(f, "{e}"),
+            Self::SetMembership(m) => write!(f, "{m}"),
+            Self::Nullness(n) => write!(f, "{n}"),
         }
     }
 }
@@ -864,11 +864,11 @@ impl Not for QueryConditionExpr {
 impl Display for QueryConditionExpr {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         match self {
-            Self::Cond(pred) => write!(f, "{}", pred),
+            Self::Cond(pred) => write!(f, "{pred}"),
             Self::Comb { lhs, rhs, op } => {
-                write!(f, "({}) {} ({})", lhs, op, rhs)
+                write!(f, "({lhs}) {op} ({rhs})")
             }
-            Self::Negate(pred) => write!(f, "NOT ({})", pred),
+            Self::Negate(pred) => write!(f, "NOT ({pred})"),
         }
     }
 }
@@ -892,12 +892,12 @@ mod tests {
 
         let qc_comb = qc_cmp.clone() & qc_setmemb.clone();
         assert_eq!(
-            format!("({}) AND ({})", qc_cmp, qc_setmemb),
+            format!("({qc_cmp}) AND ({qc_setmemb})"),
             qc_comb.to_string()
         );
 
         let qc_neg = !qc_nullness.clone();
-        assert_eq!(format!("NOT ({})", qc_nullness), qc_neg.to_string());
+        assert_eq!(format!("NOT ({qc_nullness})"), qc_neg.to_string());
 
         /* parentheses should leave no ambiguity */
         let atom = QC::field("x").lt(5);

--- a/tiledb/common/src/range.rs
+++ b/tiledb/common/src/range.rs
@@ -208,8 +208,7 @@ impl SingleValueRange {
             },
             {
                 panic!(
-                    "`SingleValueRange::union` on non-matching datatypes: `self` = {:?}, `other` = {:?}",
-                    self, other
+                    "`SingleValueRange::union` on non-matching datatypes: `self` = {self:?}, `other` = {other:?}"
                 )
             }
         )
@@ -238,8 +237,7 @@ impl SingleValueRange {
             },
             {
                 panic!(
-                    "`SingleValueRange::intersection` on non-matching datatypes: `self` = {:?}, `other` = {:?}",
-                    self, other
+                    "`SingleValueRange::intersection` on non-matching datatypes: `self` = {self:?}, `other` = {other:?}"
                 )
             }
         )
@@ -706,10 +704,7 @@ impl MultiValueRange {
                     .try_fold(0i128, |num_cells, (lower, upper)| {
                         if upper < lower && num_cells == 0 {
                             // this is the first unequal value, upper must be greater
-                            unreachable!(
-                                "Invalid `MultiValueRange`: {:?}",
-                                self
-                            )
+                            unreachable!("Invalid `MultiValueRange`: {self:?}")
                         }
 
                         let num_cells = num_cells.checked_mul(iter_factor)?;
@@ -737,9 +732,7 @@ impl MultiValueRange {
         assert_eq!(
             self.num_values(),
             other.num_values(),
-            "`MultiValueRange::union` on ranges of non-matching length: `self` = {:?}, `other` = {:?}",
-            self,
-            other
+            "`MultiValueRange::union` on ranges of non-matching length: `self` = {self:?}, `other` = {other:?}"
         );
 
         crate::multi_value_range_cmp!(
@@ -767,8 +760,7 @@ impl MultiValueRange {
                     .unwrap()
             },
             panic!(
-                "`MultiValueRange::union` on non-matching datatypes: `self` = {:?}, `other` = {:?}",
-                self, other
+                "`MultiValueRange::union` on non-matching datatypes: `self` = {self:?}, `other` = {other:?}"
             )
         )
     }
@@ -784,9 +776,7 @@ impl MultiValueRange {
         assert_eq!(
             self.num_values(),
             other.num_values(),
-            "`MultiValueRange::union` on ranges of non-matching length: `self` = {:?}, `other` = {:?}",
-            self,
-            other
+            "`MultiValueRange::union` on ranges of non-matching length: `self` = {self:?}, `other` = {other:?}"
         );
 
         crate::multi_value_range_cmp!(
@@ -811,8 +801,7 @@ impl MultiValueRange {
                 )
             },
             panic!(
-                "`MultiValueRange::union` on non-matching datatypes: `self` = {:?}, `other` = {:?}",
-                self, other
+                "`MultiValueRange::union` on non-matching datatypes: `self` = {self:?}, `other` = {other:?}"
             )
         )
     }
@@ -1157,8 +1146,7 @@ impl VarValueRange {
                 VarValueRange::from((min, max))
             },
             panic!(
-                "`VarValueRange::union` on non-matching datatypes: `self` = {:?}, `other` = {:?}",
-                self, other
+                "`VarValueRange::union` on non-matching datatypes: `self` = {self:?}, `other` = {other:?}"
             )
         )
     }
@@ -1188,8 +1176,7 @@ impl VarValueRange {
                 )))
             },
             panic!(
-                "`VarValueRange::union` on non-matching datatypes: `self` = {:?}, `other` = {:?}",
-                self, other
+                "`VarValueRange::union` on non-matching datatypes: `self` = {self:?}, `other` = {other:?}"
             )
         )
     }
@@ -1576,8 +1563,7 @@ impl Range {
             (Self::Multi(l), Self::Multi(r)) => Self::Multi(l.union(r)),
             (Self::Var(l), Self::Var(r)) => Self::Var(l.union(r)),
             _ => panic!(
-                "`Range::union` on non-matching range variants: `self` = {:?}, `other` = {:?}",
-                self, other
+                "`Range::union` on non-matching range variants: `self` = {self:?}, `other` = {other:?}"
             ),
         }
     }
@@ -1599,8 +1585,7 @@ impl Range {
             }
             (Self::Var(l), Self::Var(r)) => Some(Self::Var(l.intersection(r)?)),
             _ => panic!(
-                "`Range::intersection` on non-matching range variants: `self` = {:?}, `other` = {:?}",
-                self, other
+                "`Range::intersection` on non-matching range variants: `self` = {self:?}, `other` = {other:?}"
             ),
         }
     }
@@ -2381,7 +2366,7 @@ mod tests {
                 .is_err()
         );
 
-        let _ = format!("{:?}", range);
+        let _ = format!("{range:?}");
     }
 
     #[test]

--- a/tiledb/pod/src/query/subarray.rs
+++ b/tiledb/pod/src/query/subarray.rs
@@ -255,9 +255,7 @@ mod tests {
                     .iter()
                     .zip(ranges.iter())
                     .map(|(d, r)| format!(
-                        "({:?} && {:?} = {:?}",
-                        d,
-                        r,
+                        "({d:?} && {r:?} = {:?}",
                         d.iter()
                             .map(|dr| dr.intersection(r))
                             .collect::<Vec<Option<Range>>>()
@@ -291,7 +289,7 @@ mod tests {
                         .any(|(rs1, rs2)| {
                             Some(ri) == rs1.intersection(rs2).as_ref()
                         });
-                    assert!(found_input, "ri = {:?}", ri);
+                    assert!(found_input, "ri = {ri:?}");
                 }
 
                 // and for all pairs (rs1, rs2), there must be some ri which covers
@@ -303,8 +301,7 @@ mod tests {
                     let found_output = di.contains(&intersection);
                     assert!(
                         found_output,
-                        "rs1 = {:?}, rs2 = {:?}, intersection = {:?}",
-                        rs1, rs2, intersection
+                        "rs1 = {rs1:?}, rs2 = {rs2:?}, intersection = {intersection:?}",
                     );
                 }
             }

--- a/tiledb/proc-macro/src/option_subset.rs
+++ b/tiledb/proc-macro/src/option_subset.rs
@@ -77,12 +77,12 @@ fn option_subset_body_enum_variants(
             syn::Fields::Named(ref fields) => {
                 let fnames = fields.named.iter().map(|f| f.ident.as_ref().unwrap()).collect::<Vec<_>>();
                 let self_fnames = fnames.iter().map(|f| {
-                    let fname = format!("self_{}", f);
+                    let fname = format!("self_{f}");
                     Ident::new(&fname, Span::call_site())
                 }).collect::<Vec<_>>();
 
                 let other_fnames = fnames.iter().map(|f| {
-                    let fname = format!("other_{}", f);
+                    let fname = format!("other_{f}");
                     Ident::new(&fname, Span::call_site())
                 }).collect::<Vec<_>>();
 
@@ -95,12 +95,12 @@ fn option_subset_body_enum_variants(
             },
             syn::Fields::Unnamed(ref fields) => {
                 let self_fnames = (0.. fields.unnamed.len()).map(|idx| {
-                    let fname = format!("self_{}", idx);
+                    let fname = format!("self_{idx}");
                     Ident::new(&fname, Span::call_site())
                 }).collect::<Vec<_>>();
 
                 let other_fnames = (0.. fields.unnamed.len()).map(|idx| {
-                    let fname = format!("other_{}", idx);
+                    let fname = format!("other_{idx}");
                     Ident::new(&fname, Span::call_site())
                 }).collect::<Vec<_>>();
 

--- a/tiledb/queries/examples/aggregate-adapters.rs
+++ b/tiledb/queries/examples/aggregate-adapters.rs
@@ -147,7 +147,7 @@ fn example_count() -> TileDBResult<()> {
     let Some(count) = count else {
         unreachable!("Count result is never `None`");
     };
-    println!("Count is {}", count);
+    println!("Count is {count}");
 
     Ok(())
 }
@@ -181,7 +181,7 @@ fn example_sum() -> TileDBResult<()> {
     let Some(sum) = results else {
         unreachable!("Sum is `None` which cannot occur on example input");
     };
-    println!("Sum is {}", sum);
+    println!("Sum is {sum}");
 
     Ok(())
 }
@@ -220,8 +220,8 @@ fn example_min_max() -> TileDBResult<()> {
     let (Some(min_res), Some(max_res)) = (min_res, max_res) else {
         unreachable!("Min or max is `None` which cannot occur on example input")
     };
-    println!("Min is {}", min_res);
-    println!("Max is {}", max_res);
+    println!("Min is {min_res}");
+    println!("Max is {max_res}");
 
     Ok(())
 }
@@ -255,7 +255,7 @@ fn example_mean() -> TileDBResult<()> {
     let Some(mean) = mean else {
         unreachable!("Mean is `None` which cannot occur on example input")
     };
-    println!("Mean is {}", mean);
+    println!("Mean is {mean}");
 
     Ok(())
 }

--- a/tiledb/sys-cfg/build.rs
+++ b/tiledb/sys-cfg/build.rs
@@ -4,7 +4,7 @@ fn main() {
     if linkage == "dynamic" {
         let libdir = std::env::var("DEP_TILEDB_LIBDIR")
             .expect("Missing DEP_TILEDB_LIBDIR");
-        println!("cargo::rustc-env=TILEDB_RPATH={}", libdir);
+        println!("cargo::rustc-env=TILEDB_RPATH={libdir}");
     } else if linkage == "static" {
         println!("cargo::rustc-env=TILEDB_RPATH=");
     } else {

--- a/tiledb/sys/build.rs
+++ b/tiledb/sys/build.rs
@@ -20,7 +20,7 @@ fn configure_rustc(_libdir: String) {
 fn configure_static(libdir: String) {
     // Configure linking
     println!("cargo::metadata=LINKAGE=static");
-    println!("cargo::rustc-link-search=native={}", libdir);
+    println!("cargo::rustc-link-search=native={libdir}");
     println!("cargo::rustc-link-lib=static=tiledb_static");
 
     // Add any extra OS specific config
@@ -29,7 +29,7 @@ fn configure_static(libdir: String) {
 
 fn configure_dynamic(libdir: String) {
     println!("cargo::metadata=LINKAGE=dynamic");
-    println!("cargo::rustc-link-search=native={}", libdir);
+    println!("cargo::rustc-link-search=native={libdir}");
     println!("cargo::rustc-link-lib=tiledb");
     println!("cargo::metadata=LIBDIR={libdir}");
 }

--- a/tools/api-coverage/src/api.rs
+++ b/tools/api-coverage/src/api.rs
@@ -56,13 +56,12 @@ pub fn process(name: &String) -> Result<HashSet<String>> {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
-        .unwrap_or_else(|_| panic!("Failed to run `cargo expand {}`", name));
+        .unwrap_or_else(|_| panic!("Failed to run `cargo expand {name}`"));
 
     if !output.status.success() {
         panic!(
-            "Failed to run `cargo exapnd -p {}`\n\n\
+            "Failed to run `cargo exapnd -p {name}`\n\n\
             *NOTE* You may need to run: `cargo install cargo-expand`\n",
-            name
         );
     }
 

--- a/tools/api-coverage/src/generated.rs
+++ b/tools/api-coverage/src/generated.rs
@@ -21,7 +21,7 @@ impl<'ast> Visit<'ast> for BindgenDefs {
             return;
         }
         if self.constants.contains_key(&ident) {
-            panic!("Duplicate constant defintion: {}", ident);
+            panic!("Duplicate constant defintion: {ident}");
         }
 
         // Drop all attributes on const definitions to avoid spurious
@@ -42,7 +42,7 @@ impl<'ast> Visit<'ast> for BindgenDefs {
             return;
         }
         if self.signatures.contains_key(&ident) {
-            panic!("Duplicate signature definition: {}", ident);
+            panic!("Duplicate signature definition: {ident}");
         }
         self.signatures.insert(ident, node.clone());
         visit::visit_signature(self, node);
@@ -58,7 +58,7 @@ fn generate_bindings(generated: &String, wrapper: &String) -> Result<()> {
 
     let wrappath = Path::new(&wrapper);
     if !wrappath.is_file() {
-        return Err(anyhow!("Missing wrapper file: {}", wrapper));
+        return Err(anyhow!("Missing wrapper file: {wrapper}"));
     }
 
     let tiledb_lib = pkg_config::Config::new()
@@ -90,7 +90,7 @@ pub fn generate(generated: &String, wrapper: &String) -> Result<BindgenDefs> {
 
     let mut bindgen = BindgenDefs::default();
     let ast = util::parse_file(generated).unwrap_or_else(|e| {
-        panic!("Error parsing {} - {:?}", generated, e);
+        panic!("Error parsing {generated} - {e:?}");
     });
     bindgen.visit_file(&ast);
 
@@ -105,7 +105,7 @@ pub fn process(ignored: &String) -> Result<BindgenDefs> {
 
     let mut bindgen = BindgenDefs::default();
     let ast = util::parse_file(ignored).unwrap_or_else(|e| {
-        panic!("Error parsing {} - {:?}", ignored, e);
+        panic!("Error parsing {ignored} - {e:?}");
     });
     bindgen.visit_file(&ast);
 

--- a/tools/api-coverage/src/main.rs
+++ b/tools/api-coverage/src/main.rs
@@ -114,7 +114,7 @@ impl Processor {
         for (key, val) in self.ignored_defs.constants.iter() {
             let generated = self.generated_defs.constants.get(key);
             if generated.is_none() {
-                panic!("Ignored constant was not generated: {}", key);
+                panic!("Ignored constant was not generated: {key}");
             }
             // Ignore the TILEDB_VERESION_* constants so that we're not
             // constantly (heh) updating them.
@@ -126,7 +126,7 @@ impl Processor {
                         util::unparse_constant(generated)
                     );
                     println!("Ignored:   {}", util::unparse_constant(val));
-                    panic!("Invalid ignore for constant: {}", key);
+                    panic!("Invalid ignore for constant: {key}");
                 }
             }
             self.generated_defs
@@ -138,13 +138,13 @@ impl Processor {
         for (key, val) in self.ignored_defs.signatures.iter() {
             let generated = self.generated_defs.signatures.get(key);
             if generated.is_none() {
-                panic!("Ignored signature not generated: {}", key);
+                panic!("Ignored signature not generated: {key}");
             }
             let generated = generated.unwrap();
             if generated != val {
                 println!("Generated: {}", util::unparse_signature(generated));
                 println!("Ignored:   {}", util::unparse_signature(val));
-                panic!("Invalid ignore for signature: {}", key);
+                panic!("Invalid ignore for signature: {key}");
             }
             self.generated_defs
                 .signatures
@@ -156,16 +156,16 @@ impl Processor {
     fn remap(&mut self) {
         for (key, val) in self.remapped_defs.constants.iter() {
             if val.old.as_ref().is_none() {
-                panic!("Missing old half of remapped definition for: {}", key);
+                panic!("Missing old half of remapped definition for: {key}");
             }
 
             if val.new.as_ref().is_none() {
-                panic!("Misisng new half of remapped definition for: {}", key);
+                panic!("Misisng new half of remapped definition for: {key}");
             }
 
             let generated = self.generated_defs.constants.get(key);
             if generated.is_none() {
-                panic!("Remapped constant was not generated: {}", key);
+                panic!("Remapped constant was not generated: {key}");
             }
             let generated = generated.unwrap();
             if generated != val.old.as_ref().unwrap() {
@@ -174,7 +174,7 @@ impl Processor {
                     "Remapped:  {}",
                     util::unparse_constant(val.old.as_ref().unwrap())
                 );
-                panic!("Invalid remap for constant: {}", key);
+                panic!("Invalid remap for constant: {key}");
             }
             self.generated_defs
                 .constants
@@ -184,7 +184,7 @@ impl Processor {
         for (key, val) in self.remapped_defs.signatures.iter() {
             let generated = self.generated_defs.signatures.get(key);
             if generated.is_none() {
-                panic!("Remapped signature not generated: {}", key);
+                panic!("Remapped signature not generated: {key}");
             }
             let generated = generated.unwrap();
             if generated != val.old.as_ref().unwrap() {
@@ -193,7 +193,7 @@ impl Processor {
                     "Remapped:  {}",
                     util::unparse_signature(val.old.as_ref().unwrap())
                 );
-                panic!("Invalid remap for signature: {}", key);
+                panic!("Invalid remap for signature: {key}");
             }
             self.generated_defs
                 .signatures
@@ -210,12 +210,11 @@ impl Processor {
     {
         println!(
             "<tr>\
-            <th align=\"left\">{}</th>\
-            <td align=\"right\">{}</td>\
-            <td align=\"right\">{}</td>\
-            <td align=\"right\">{}</td>\
+            <th align=\"left\">{label}</th>\
+            <td align=\"right\">{count}</td>\
+            <td align=\"right\">{total}</td>\
+            <td align=\"right\">{perc}</td>\
             </tr>",
-            label, count, total, perc
         )
     }
 
@@ -316,7 +315,7 @@ impl Processor {
             println!("## Unwrapped Constants");
             println!();
             for name in &unwrapped_constants[..] {
-                println!(" * `{}`", name);
+                println!(" * `{name}`");
             }
             println!();
         }
@@ -324,7 +323,7 @@ impl Processor {
         if !unwrapped_apis.is_empty() {
             println!("## Unwrapped APIs:");
             for name in &unwrapped_apis[..] {
-                println!("  * `{}`", name);
+                println!("  * `{name}`");
             }
             println!();
         }
@@ -332,7 +331,7 @@ impl Processor {
         if !uncalled_apis.is_empty() {
             println!("## Uncalled APIs:");
             for name in &uncalled_apis[..] {
-                println!("  * `{}`", name);
+                println!("  * `{name}`");
             }
             println!();
         }
@@ -421,7 +420,7 @@ impl Processor {
                     println!();
                 }
                 mismatch = true;
-                println!("### {}", name);
+                println!("### {name}");
                 println!();
                 println!("<table>");
                 println!("<tr><th>Generated</th><th>Declared</th></tr>");

--- a/tools/api-coverage/src/remapped.rs
+++ b/tools/api-coverage/src/remapped.rs
@@ -49,8 +49,7 @@ impl<'ast> Visit<'ast> for RemappedDefs {
         } else {
             panic!(
                 "Mapping names must be prefixed with \
-                    `old_` or `new_`. '{}' is not valid.",
-                ident
+                    `old_` or `new_`. '{ident}' is not valid."
             );
         };
 
@@ -64,12 +63,12 @@ impl<'ast> Visit<'ast> for RemappedDefs {
 
         if is_old {
             if entry.old.is_some() {
-                panic!("Multiple definitions for old_{}", ident);
+                panic!("Multiple definitions for old_{ident}");
             }
             entry.old = Some(node.clone());
         } else {
             if entry.new.is_some() {
-                panic!("Multiple definitions for: new_{}", ident)
+                panic!("Multiple definitions for: new_{ident}")
             }
             entry.new = Some(node.clone());
         }
@@ -100,8 +99,7 @@ impl<'ast> Visit<'ast> for RemappedDefs {
         } else {
             panic!(
                 "Mapping names must be prefixed with \
-                    `old_` or `new_`. '{}' is not valid.",
-                ident
+                    `old_` or `new_`. '{ident}' is not valid.",
             );
         };
 
@@ -115,12 +113,12 @@ impl<'ast> Visit<'ast> for RemappedDefs {
 
         if is_old {
             if entry.old.is_some() {
-                panic!("Multiple definitions for old_{}", ident);
+                panic!("Multiple definitions for old_{ident}");
             }
             entry.old = Some(node.clone());
         } else {
             if entry.new.is_some() {
-                panic!("Multiple definitions for: new_{}", ident)
+                panic!("Multiple definitions for: new_{ident}")
             }
             entry.new = Some(node.clone());
         }
@@ -137,7 +135,7 @@ pub fn process(remapped: &String) -> Result<RemappedDefs> {
 
     let mut defs = RemappedDefs::default();
     let ast = util::parse_file(remapped).unwrap_or_else(|e| {
-        panic!("Error parsing {} - {:?}", remapped, e);
+        panic!("Error parsing {remapped} - {e:?}");
     });
     defs.visit_file(&ast);
 

--- a/tools/api-coverage/src/sys.rs
+++ b/tools/api-coverage/src/sys.rs
@@ -16,7 +16,7 @@ impl<'ast> syn::visit::Visit<'ast> for SysDefs {
     fn visit_item_const(&mut self, node: &'ast syn::ItemConst) {
         let ident = format!("{}", node.ident);
         if self.constants.contains_key(&ident) {
-            panic!("Error: Duplicate constant definition: {}", ident);
+            panic!("Error: Duplicate constant definition: {ident}");
         }
         self.constants.insert(ident, node.clone());
         visit::visit_item_const(self, node);
@@ -25,7 +25,7 @@ impl<'ast> syn::visit::Visit<'ast> for SysDefs {
     fn visit_signature(&mut self, node: &'ast syn::Signature) {
         let ident = format!("{}", node.ident);
         if self.signatures.contains_key(&ident) {
-            panic!("Error: Duplicate function signature: {}", ident);
+            panic!("Error: Duplicate function signature: {ident}");
         }
         self.signatures.insert(ident, node.clone());
         visit::visit_signature(self, node);
@@ -38,7 +38,7 @@ pub fn process(defs: &str, funcs: &str) -> Result<SysDefs> {
     let mut walk = |path| {
         util::walk_rust_sources(path, |src| {
             let ast = util::parse_file(&src).unwrap_or_else(|e| {
-                panic!("Error parsing {} - {:?}", src, e);
+                panic!("Error parsing {src} - {e:?}");
             });
             sys.visit_file(&ast);
         })


### PR DESCRIPTION
This lint was turned on by default in nightly.  This PR cleans out the lint.

Enabling this lint by default strikes me as a bad decision.  As we can see in this PR, it increases the length of the format strings, which `cargo fmt` does not split onto multiple lines based on the desired display width; whereas it can do so more easily with arguments.

As an alternative we could disable this lint in our projects.

Since I already did the work here I'm fine either way; I don't mind the larger format strings too much, and it is *possible* to break them up on multiple lines - it just doesn't happen automatically.