### PR TITLE
fix: Unbreak signal test; make CI test it

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -53,13 +53,13 @@ jobs:
         # on that approach. So I'm just disabling the particular lint globally.
         run: cargo clippy --all-targets --all-features -- --allow non_local_definitions -Dwarnings
       - name: Build
-        run: cargo build --all-targets --all-features
+        run: cargo build --workspace --all-targets --all-features
       - name: Test
         env:
           # give up shrinking after an hour
           PROPTEST_MAX_SHRINK_ITERS: 100000000
           PROPTEST_MAX_SHRINK_TIME: 3600000
-        run: cargo test --all-targets --all-features
+        run: cargo test --workspace --all-targets --all-features
       - name: Check Linkage - Linux
         if: ${{ startsWith(matrix.os, 'ubuntu-') || startsWith(matrix.os, 'linux-') }}
         run: .github/scripts/ubuntu-check-${{ matrix.linkage }}-linkage.sh

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -38,10 +38,10 @@ jobs:
       - name: Install TileDB
         uses: ./.github/actions/install-tiledb
       - name: Build
-        run: cargo build --all-targets --all-features
+        run: cargo build --workspace --all-targets --all-features
       - name: Test
         run: |
-          cargo test --all-targets --all-features
+          cargo test --workspace --all-targets --all-features
           status=$?
           echo "Process exited with status ${status}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,9 @@ jobs:
       - name: Lint
         run: cargo clippy --all-targets --all-features -- -Dwarnings
       - name: Build
-        run: cargo build --all-targets --all-features
+        run: cargo build --workspace --all-targets --all-features
       - name: Test
-        run: cargo test --all-targets --all-features
+        run: cargo test --workspace --all-targets --all-features
 
   create_issue_on_fail:
     permissions:

--- a/test-utils/signal/src/lib.rs
+++ b/test-utils/signal/src/lib.rs
@@ -107,11 +107,10 @@ impl<'a> SignalCallback<'a> {
             restore_callback: None,
             action: Box::new(handler),
         });
-        let raw_callback = RawSignalCallback::from(callback.as_mut().get_mut());
-        SIGNAL_CALLBACKS[signo as i32 as usize]
-            .lock()
-            .unwrap()
-            .replace(raw_callback);
+        callback.restore_callback = std::mem::replace(
+            &mut SIGNAL_CALLBACKS[signo as i32 as usize].lock().unwrap(),
+            Some(RawSignalCallback::from(callback.as_mut().get_mut())),
+        );
 
         callback
     }


### PR DESCRIPTION
#216 broke a signal test which fails for me (on bisect) with

```
cargo build --workspace --all-targets --all-features
cargo test --workspace --all-targets --all-features
```

This PR reverts that, and adds the `--workspace` flag to our CI YAML files. (Without that, only `default-members` in `Cargo.toml` are tested.)