### PR TITLE
fix: BitsEq/BitsOrd/BitsHash impls for f32 and f64 to treat 0 == -0

### DIFF
--- a/tiledb/common/src/datatype/physical.rs
+++ b/tiledb/common/src/datatype/physical.rs
@@ -247,15 +247,34 @@ integral_type_impls!(i8: Datatype::Int8, i16: Datatype::Int16, i32: Datatype::In
 impl crate::private::Sealed for f32 {}
 impl crate::private::Sealed for f64 {}
 
+/// Defines an equivalence relation for `f32`.
+///
+/// The difference from the `PartialEq` implementation for `f32` is that of
+/// reflexivity. Specifically, if the bits match, then `self` and `other` are equal
+/// in this relation, whereas this is not true of floating-point equality for `NaN` values.
+///
+/// Zero and negative zero are considered equal under this relation.
 impl BitsEq for f32 {
     fn bits_eq(&self, other: &Self) -> bool {
-        self.to_bits() == other.to_bits()
+        self.to_bits() == other.to_bits() ||
+            // catch negative zero
+            (*self == 0f32 && *other == 0f32)
     }
 }
 
+/// Defines a total order for `f32`.
+///
+/// This ordering intends to be a bridge between
+/// `<f32 as PartialOrd>` (which is not a total order due to `NaN`)
+/// and `f32::total_cmp` (which does not consider 0 and -0 to be equal).
+/// Specifically, we use `f32::total_cmp` except zero and negative zero are equal.
 impl BitsOrd for f32 {
     fn bits_cmp(&self, other: &Self) -> Ordering {
-        self.total_cmp(other)
+        if *self == 0f32 && *other == 0f32 {
+            Ordering::Equal
+        } else {
+            self.total_cmp(other)
+        }
     }
 }
 
@@ -264,21 +283,44 @@ impl BitsHash for f32 {
     where
         H: Hasher,
     {
-        self.to_bits().bits_hash(state)
+        if self.to_bits() == (-0f32).to_bits() {
+            0f32.bits_hash(state)
+        } else {
+            self.to_bits().bits_hash(state)
+        }
     }
 }
 
 impl PhysicalType for f32 {}
 
+/// Defines an equivalence relation for `f64`.
+///
+/// The difference from the `PartialEq` implementation for `f32` is that of
+/// reflexivity. Specifically, if the bits match, then `self` and `other` are equal
+/// in this relation, whereas this is not true of floating-point equality for `NaN` values.
+///
+/// Zero and negative zero are considered equal under this relation.
 impl BitsEq for f64 {
     fn bits_eq(&self, other: &Self) -> bool {
-        self.to_bits() == other.to_bits()
+        self.to_bits() == other.to_bits() ||
+            // catch negative zero
+            (*self == 0f64 && *other == 0f64)
     }
 }
 
+/// Defines a total order for `f64`.
+///
+/// This ordering intends to be a bridge between
+/// `<f32 as PartialOrd>` (which is not a total order due to `NaN`)
+/// and `f32::total_cmp` (which does not consider 0 and -0 to be equal).
+/// Specifically, we use `f32::total_cmp` except zero and negative zero are equal.
 impl BitsOrd for f64 {
     fn bits_cmp(&self, other: &Self) -> Ordering {
-        self.total_cmp(other)
+        if *self == 0f64 && *other == 0f64 {
+            Ordering::Equal
+        } else {
+            self.total_cmp(other)
+        }
     }
 }
 
@@ -287,7 +329,11 @@ impl BitsHash for f64 {
     where
         H: Hasher,
     {
-        self.to_bits().bits_hash(state)
+        if self.to_bits() == (-0f64).to_bits() {
+            0f64.bits_hash(state)
+        } else {
+            self.to_bits().bits_hash(state)
+        }
     }
 }
 impl PhysicalType for f64 {}
@@ -509,29 +555,211 @@ pub mod strategy {
     }
 
     macro_rules! field_value_strategy {
-    ($($variant:ident : $T:ty),+) => {
-        $(
-            impl From<BoxedStrategy<$T>> for PhysicalValueStrategy {
-                fn from(value: BoxedStrategy<$T>) -> Self {
-                    Self::$variant(value)
-                }
-            }
-
-            impl TryFrom<PhysicalValueStrategy> for BoxedStrategy<$T> {
-                type Error = ();
-                fn try_from(value: PhysicalValueStrategy) -> Result<Self, Self::Error> {
-                    if let PhysicalValueStrategy::$variant(b) = value {
-                        Ok(b)
-                    } else {
-                        Err(())
+        ($($variant:ident : $T:ty),+) => {
+            $(
+                impl From<BoxedStrategy<$T>> for PhysicalValueStrategy {
+                    fn from(value: BoxedStrategy<$T>) -> Self {
+                        Self::$variant(value)
                     }
                 }
-            }
-        )+
+
+                impl TryFrom<PhysicalValueStrategy> for BoxedStrategy<$T> {
+                    type Error = ();
+                    fn try_from(value: PhysicalValueStrategy) -> Result<Self, Self::Error> {
+                        if let PhysicalValueStrategy::$variant(b) = value {
+                            Ok(b)
+                        } else {
+                            Err(())
+                        }
+                    }
+                }
+            )+
+        }
     }
-}
 
     field_value_strategy!(UInt8 : u8, UInt16 : u16, UInt32 : u32, UInt64 : u64);
     field_value_strategy!(Int8 : i8, Int16 : i16, Int32 : i32, Int64 : i64);
     field_value_strategy!(Float32 : f32, Float64 : f64);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::hash::DefaultHasher;
+
+    use proptest::prelude::*;
+
+    use super::*;
+
+    fn default_hash<T>(value: T) -> u64
+    where
+        T: BitsHash,
+    {
+        let mut hasher = DefaultHasher::new();
+        value.bits_hash(&mut hasher);
+        hasher.finish()
+    }
+
+    /// Returns a strategy which produces truly any possible f32 bits.
+    ///
+    /// This is in contrast with [Arbitrary] does not produce `NaN` or infinities.
+    fn any_f32() -> impl Strategy<Value = f32> {
+        any::<[u8; 4]>().prop_map(f32::from_le_bytes)
+    }
+
+    /// Returns a strategy which produces truly any possible f64 bits.
+    ///
+    /// This is in contrast with [Arbitrary] does not produce `NaN` or infinities.
+    fn any_f64() -> impl Strategy<Value = f64> {
+        any::<[u8; 8]>().prop_map(f64::from_le_bytes)
+    }
+
+    proptest! {
+        #[test]
+        fn bits_eq_f32_vs_eq(f1 in any_f32(), f2 in any_f32()) {
+            if f1 == f2 {
+                assert!(f1.bits_eq(&f2));
+                assert!(f2.bits_eq(&f1));
+            } else if f1.bits_eq(&f2) {
+                // NaN
+                assert!(f2.bits_eq(&f1));
+                assert_eq!(f1.to_bits(), f2.to_bits());
+            }
+        }
+
+        #[test]
+        fn bits_eq_f64_vs_eq(f1 in any_f64(), f2 in any_f64()) {
+            if f1 == f2 {
+                assert!(f1.bits_eq(&f2));
+                assert!(f2.bits_eq(&f1));
+            } else if f1.bits_eq(&f2) {
+                // NaN
+                assert!(f2.bits_eq(&f1));
+                assert_eq!(f1.to_bits(), f2.to_bits());
+            }
+        }
+
+        #[test]
+        fn bits_eq_f32_reflexive(f in any_f32()) {
+            assert!(f.bits_eq(&f));
+        }
+
+        #[test]
+        fn bits_eq_f64_reflexive(f in any_f64()) {
+            assert!(f.bits_eq(&f));
+        }
+
+        #[test]
+        fn bits_cmp_f32_total_order(f1 in any_f32(), f2 in any_f32()) {
+            let lt = matches!(f1.bits_cmp(&f2), Ordering::Less);
+            let eq = matches!(f1.bits_cmp(&f2), Ordering::Equal);
+            let gt = matches!(f1.bits_cmp(&f2), Ordering::Greater);
+
+            // exactly one of `<`, `==`, and `>` must be true for a total order
+            if lt {
+                assert!(!eq);
+                assert!(!gt);
+            } else if eq {
+                assert!(!gt);
+            } else {
+                assert!(gt);
+            }
+        }
+
+        #[test]
+        fn bits_cmp_f64_total_order(f1 in any_f64(), f2 in any_f64()) {
+            let lt = matches!(f1.bits_cmp(&f2), Ordering::Less);
+            let eq = matches!(f1.bits_cmp(&f2), Ordering::Equal);
+            let gt = matches!(f1.bits_cmp(&f2), Ordering::Greater);
+
+            // exactly one of `<`, `==`, and `>` must be true for a total order
+            if lt {
+                assert!(!eq);
+                assert!(!gt);
+            } else if eq {
+                assert!(!gt);
+            } else {
+                assert!(gt);
+            }
+        }
+
+        #[test]
+        fn bits_cmp_f32_reflexive(f in any_f32()) {
+            assert!(matches!(f.bits_cmp(&f), Ordering::Equal));
+        }
+
+        #[test]
+        fn bits_cmp_f64_reflexive(f in any_f64()) {
+            assert!(matches!(f.bits_cmp(&f), Ordering::Equal));
+        }
+
+        #[test]
+        fn bits_cmp_f32_transitive(f1 in any_f32(), f2 in any_f32(), f3 in any_f32()) {
+            let f1 = BitsKeyAdapter(f1);
+            let f2 = BitsKeyAdapter(f2);
+            let f3 = BitsKeyAdapter(f3);
+
+            if f1 <= f2 {
+                if f2 <= f3 {
+                    assert!(f1 <= f3);
+                }
+            } else if f1 <= f3 {
+                assert!(f2 <= f3);
+            }
+        }
+
+        #[test]
+        fn bits_cmp_f64_transitive(f1 in any_f64(), f2 in any_f64(), f3 in any_f64()) {
+            let f1 = BitsKeyAdapter(f1);
+            let f2 = BitsKeyAdapter(f2);
+            let f3 = BitsKeyAdapter(f3);
+
+            if f1 <= f2 {
+                if f2 <= f3 {
+                    assert!(f1 <= f3);
+                }
+            } else if f1 <= f3 {
+                assert!(f2 <= f3);
+            }
+        }
+
+        #[test]
+        fn bits_hash_f32(f1 in any_f32(), f2 in any_f32()) {
+            if f1.bits_eq(&f2) {
+                assert_eq!(default_hash(f1), default_hash(f2));
+            }
+        }
+
+        #[test]
+        fn bits_hash_f64(f1 in any_f64(), f2 in any_f64()) {
+            if f1.bits_eq(&f2) {
+                assert_eq!(default_hash(f1), default_hash(f2));
+            }
+        }
+    }
+
+    #[test]
+    fn bits_cmp_f32() {
+        // NB: no proptest since we would just use total_cmp and that's literally the
+        // implementation now, but here's a spot check of an edge case.
+        assert!(matches!(0f32.bits_cmp(&(-0f32)), Ordering::Equal));
+        assert!(matches!((-0f32).bits_cmp(&0f32), Ordering::Equal));
+    }
+
+    #[test]
+    fn bits_cmp_f64() {
+        // NB: no proptest since we would just use total_cmp and that's literally the
+        // implementation now, but here's a spot check of an edge case.
+        assert!(matches!(0f64.bits_cmp(&(-0f64)), Ordering::Equal));
+        assert!(matches!((-0f64).bits_cmp(&0f64), Ordering::Equal));
+    }
+
+    #[test]
+    fn bits_hash_f32_examples() {
+        assert_eq!(default_hash(0f32), default_hash(-0f32))
+    }
+
+    #[test]
+    fn bits_hash_f64_examples() {
+        assert_eq!(default_hash(0f64), default_hash(-0f64))
+    }
 }


### PR DESCRIPTION
We've recently seen the following appear in PR CI:
```
thread 'tests::query_condition_and' panicked at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/proptest-1.6.0/src/num/float_samplers.rs:462:1:
invalid range
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
but it turns out this has also failed in at least one nightly, which was reported in #231 .

The panic arises when `proptest-rs` asserts that the range it wants to sample is non-empty:
```
assert!(high - low > 0., "invalid range");
```
Breaking here with a debugger revealed that we have a range `-0..=0` which fails this assertion.

When does the `query_condition_and` test sample ranges? To construct atomic predicates for query conditions it samples the domain of its input (it does this so that the predicates are more likely to sometimes be true, e.g. `x = 12340765872934` matches `x` against random bits and is not likely to be true).  It follows that the strategy which does the sampling avoids constructing a range when the low and high bounds of the domain are equal; and something about -0 and 0 defeats that check.

Indeed that is exactly what we find in the following code:
```
                if lb.bits_eq(&ub) {
                    Just(Literal::from(lb)).boxed()
                } else {
                    (lb..=ub).prop_map(Literal::from).boxed()
                }
```
The `bits_eq` is the function of our custom trait `BitsEq`.  We use this trait (and sibling traits `BitsOrd` and `BitsHash`) rather than traditional float operations because those float operations are not reflexive (for equality) or not a total order (for comparison).  But the implementation of these misses the place where float comparison does the *opposite* thing, i.e. two distinct bit patterns comparing as the same logical value.

This pull request updates our `BitsEq`, `BitsOrd`, and `BitsHash` implementations so that the distinct bit patterns for 0 and -0 are treated equally.  We add tests for the logical properties requested of `Eq`, `Ord`, and `Hash` impls by the Rust standard library documentation.