### PR TITLE
feat: expose core group-exists API

### DIFF
--- a/tiledb/api/src/group/mod.rs
+++ b/tiledb/api/src/group/mod.rs
@@ -4,7 +4,7 @@ use crate::Datatype;
 use crate::Result as TileDBResult;
 use crate::config::{Config, RawConfig};
 use crate::context::{CApiError, Context};
-use crate::context::{CApiInterface, ContextBound, ObjectType};
+use crate::context::{CApiInterface, CApiResult, ContextBound, ObjectType};
 use crate::error::Error;
 use crate::key::LookupKey;
 use crate::metadata;
@@ -75,6 +75,15 @@ impl Group {
             ffi::tiledb_group_create(ctx, c_name.as_ptr())
         })?;
         Ok(())
+    }
+
+    pub fn exists<S>(context: &Context, uri: S) -> CApiResult<bool>
+    where
+        S: AsRef<str>,
+    {
+        context
+            .object_type(uri)
+            .map(|object_type| matches!(object_type, Some(ObjectType::Group)))
     }
 
     pub fn open<S>(


### PR DESCRIPTION
In the context of https://linear.app/tiledb/issue/TAB-57/misleading-error-on-read-of-tiledb-uris-in-tiledb-tables