### PR TITLE
Switch to 2.28.0 for packages

### DIFF
--- a/.github/scripts/generate-package-matrix.py
+++ b/.github/scripts/generate-package-matrix.py
@@ -10,7 +10,7 @@ TILEDB_REF_URL = API + "repos/TileDB-Inc/TileDB/git/ref/{ref}"
 NIGHTLY_RELEASE_URL = API + "repos/TileDB-Inc/tiledb-rs/releases/tags/nightlies"
 
 BUILD_SHARED_LIBS = ["ON", "OFF"]
-VERSIONS = ["main", "2.27.0"]
+VERSIONS = ["main", "2.28.0"]
 
 # This is taken from the TileDB Release workflow found here:
 #


### PR DESCRIPTION
Packages built successfully on a manual run here:

https://github.com/TileDB-Inc/tiledb-rs/actions/runs/15216914839