### PR TITLE
chore(ci): Fix nightly lints

### DIFF
--- a/tiledb/api/src/array/attribute/pod.rs
+++ b/tiledb/api/src/array/attribute/pod.rs
@@ -52,12 +52,15 @@ impl Factory for AttributeData {
         if let Some(n) = self.nullability {
             b = b.nullability(n)?;
         }
+
+        #[allow(clippy::collapsible_if)]
         if let Some(c) = self.cell_val_num {
             if !matches!((self.datatype, c), (Datatype::Any, CellValNum::Var)) {
                 /* SC-46696 */
                 b = b.cell_val_num(c)?;
             }
         }
+
         if let Some(ref fill) = self.fill {
             b = metadata_value_go!(fill.data, _DT, ref value, {
                 if let Some(fill_nullability) = fill.nullability {
@@ -67,6 +70,7 @@ impl Factory for AttributeData {
                 }
             })?;
         }
+
         if let Some(enumeration) = self.enumeration.as_ref() {
             b = b.enumeration_name(enumeration)?
         }

--- a/tiledb/api/src/array/enumeration/mod.rs
+++ b/tiledb/api/src/array/enumeration/mod.rs
@@ -161,11 +161,10 @@ impl Enumeration {
         // nullptr can be used to distinguish between Some and None. The stdlib
         // empty slices all appear to return 0x1 which is mentioned in the docs
         // as a valid strategy.
-        let (offsets_ptr, offsets_len) = if offsets.is_none() {
-            (std::ptr::null_mut() as *const u64, 0u64)
-        } else {
-            let offsets = offsets.unwrap();
+        let (offsets_ptr, offsets_len) = if let Some(offsets) = offsets {
             (offsets.as_ptr(), std::mem::size_of_val(offsets) as u64)
+        } else {
+            (std::ptr::null_mut() as *const u64, 0u64)
         };
 
         // An important note here is that the Enumeration allocator copies the

--- a/tiledb/api/src/filesystem.rs
+++ b/tiledb/api/src/filesystem.rs
@@ -82,8 +82,7 @@ mod tests {
     fn filesystem_roundtrips() {
         for i in 0..256 {
             let maybe_fs = Filesystem::try_from(i);
-            if maybe_fs.is_ok() {
-                let fs = maybe_fs.unwrap();
+            if let Ok(fs) = maybe_fs {
                 let fs_str = fs.to_string().expect("Error creating string.");
                 let str_fs = Filesystem::from_string(&fs_str)
                     .expect("Error round tripping filesystem string.");

--- a/tiledb/api/src/query/read/aggregate/mod.rs
+++ b/tiledb/api/src/query/read/aggregate/mod.rs
@@ -251,6 +251,7 @@ where
             )
         })?;
 
+        #[allow(clippy::collapsible_if)]
         if let Some(field_name) = self.handle.field_name.as_ref() {
             if !matches!(self.handle.function, AggregateFunction::NullCount(_))
                 && self

--- a/tiledb/api/src/query/strategy/tests.rs
+++ b/tiledb/api/src/query/strategy/tests.rs
@@ -597,6 +597,7 @@ impl QueryConditionField for FieldWithDomain {
     }
 
     fn domain(&self) -> Option<Range> {
+        #[allow(clippy::collapsible_if)]
         if let SchemaField::Attribute(ref a) = self.field {
             if let Some(edata) = self
                 .schema

--- a/tiledb/api/src/query/write/input/arrow.rs
+++ b/tiledb/api/src/query/write/input/arrow.rs
@@ -616,6 +616,7 @@ mod tests {
         let cell_val_num = rr_in.cell_structure().as_cell_val_num();
         let is_nullable = rr_in.buffers.validity().is_some();
 
+        #[allow(clippy::collapsible_if)]
         if let Some(offsets) = rr_in.cell_structure().offsets_ref() {
             if offsets.as_ref().is_empty() {
                 /*


### PR DESCRIPTION
Nightly has chainable if-let expressions which causes nightly clippy to trigger collapsible_if. Once chainable if-let is stabilized we can remove these and apply the collapse suggestion.