### PR TITLE
chore: Fix new nightly lint

### DIFF
--- a/test-utils/cells/src/write/mod.rs
+++ b/test-utils/cells/src/write/mod.rs
@@ -298,7 +298,7 @@ pub enum WriteSequence {
 }
 
 impl WriteSequence {
-    pub fn iter(&self) -> WriteSequenceRefIter {
+    pub fn iter(&self) -> WriteSequenceRefIter<'_> {
         self.into_iter()
     }
 }

--- a/tiledb/api/src/array/domain/mod.rs
+++ b/tiledb/api/src/array/domain/mod.rs
@@ -152,7 +152,7 @@ impl Domain {
         )))
     }
 
-    pub fn dimensions(&self) -> TileDBResult<Dimensions> {
+    pub fn dimensions(&self) -> TileDBResult<Dimensions<'_>> {
         Dimensions::new(self)
     }
 }

--- a/tiledb/api/src/array/fragment_info.rs
+++ b/tiledb/api/src/array/fragment_info.rs
@@ -617,7 +617,7 @@ impl FragmentInfoList {
         self.info.num_fragments()
     }
 
-    pub fn get_fragment(&self, index: u32) -> TileDBResult<FragmentInfo> {
+    pub fn get_fragment(&self, index: u32) -> TileDBResult<FragmentInfo<'_>> {
         if index >= self.num_fragments()? {
             return Err(Error::InvalidIndex(index as usize));
         }
@@ -628,7 +628,7 @@ impl FragmentInfoList {
         })
     }
 
-    pub fn iter(&self) -> TileDBResult<FragmentInfoListIterator> {
+    pub fn iter(&self) -> TileDBResult<FragmentInfoListIterator<'_>> {
         FragmentInfoListIterator::try_from(self)
     }
 }

--- a/tiledb/api/src/query/mod.rs
+++ b/tiledb/api/src/query/mod.rs
@@ -80,7 +80,7 @@ pub trait Query {
     ///     let _ = subarray.ranges();
     /// }
     /// ```
-    fn subarray(&self) -> TileDBResult<Subarray> {
+    fn subarray(&self) -> TileDBResult<Subarray<'_>> {
         let ctx = self.base().context();
         let c_query = *self.base().raw;
         let mut c_subarray: *mut ffi::tiledb_subarray_t = out_ptr!();
@@ -213,7 +213,7 @@ pub trait QueryBuilder: Sized {
     /// Get the in-progress subarray for this query.
     ///
     /// The returned `Subarray` is tied to the lifetime of `self`.
-    fn subarray(&self) -> TileDBResult<Subarray> {
+    fn subarray(&self) -> TileDBResult<Subarray<'_>> {
         let ctx = self.base().context();
         let c_query = *self.base().query.raw;
         let mut c_subarray: *mut ffi::tiledb_subarray_t = out_ptr!();

--- a/tiledb/api/src/query/write/input/arrow.rs
+++ b/tiledb/api/src/query/write/input/arrow.rs
@@ -26,7 +26,7 @@ use crate::query::write::input::{
 fn cell_structure_var(
     offsets: &OffsetBuffer<i64>,
     cell_val_num: CellValNum,
-) -> TileDBResult<CellStructure> {
+) -> TileDBResult<CellStructure<'_>> {
     match cell_val_num {
         CellValNum::Fixed(nz) => {
             let expect_len = nz.get() as i64;
@@ -253,7 +253,7 @@ where
         &self,
         cell_val_num: CellValNum,
         is_nullable: bool,
-    ) -> TileDBResult<QueryBuffers<Self::Unit>> {
+    ) -> TileDBResult<QueryBuffers<'_, Self::Unit>> {
         let data = Buffer::Borrowed(self.values().as_ref());
 
         match cell_val_num {
@@ -299,7 +299,7 @@ impl DataProvider for FixedSizeBinaryArray {
         &self,
         cell_val_num: CellValNum,
         is_nullable: bool,
-    ) -> TileDBResult<QueryBuffers<Self::Unit>> {
+    ) -> TileDBResult<QueryBuffers<'_, Self::Unit>> {
         let cell_structure = cell_structure_fixed(
             self.value_length(),
             self.len(),
@@ -324,7 +324,7 @@ impl DataProvider for LargeBinaryArray {
         &self,
         cell_val_num: CellValNum,
         is_nullable: bool,
-    ) -> TileDBResult<QueryBuffers<Self::Unit>> {
+    ) -> TileDBResult<QueryBuffers<'_, Self::Unit>> {
         let cell_structure = cell_structure_var(self.offsets(), cell_val_num)?;
         let data = Buffer::Borrowed(self.value_data());
         let validity = validity_buffer(self, is_nullable)?;
@@ -344,7 +344,7 @@ impl DataProvider for LargeStringArray {
         &self,
         cell_val_num: CellValNum,
         is_nullable: bool,
-    ) -> TileDBResult<QueryBuffers<Self::Unit>> {
+    ) -> TileDBResult<QueryBuffers<'_, Self::Unit>> {
         let cell_structure = cell_structure_var(self.offsets(), cell_val_num)?;
         let data = Buffer::Borrowed(self.value_data());
         let validity = validity_buffer(self, is_nullable)?;
@@ -362,7 +362,7 @@ impl TypedDataProvider for FixedSizeListArray {
         &self,
         cell_val_num: CellValNum,
         is_nullable: bool,
-    ) -> TileDBResult<TypedQueryBuffers> {
+    ) -> TileDBResult<TypedQueryBuffers<'_>> {
         let cell_structure = cell_structure_fixed(
             self.value_length(),
             self.len(),
@@ -384,7 +384,7 @@ impl TypedDataProvider for GenericListArray<i64> {
         &self,
         cell_val_num: CellValNum,
         is_nullable: bool,
-    ) -> TileDBResult<TypedQueryBuffers> {
+    ) -> TileDBResult<TypedQueryBuffers<'_>> {
         let cell_structure = cell_structure_var(self.offsets(), cell_val_num)?;
         let validity = validity_buffer(self, is_nullable)?;
 
@@ -402,7 +402,7 @@ impl TypedDataProvider for dyn ArrowArray {
         &self,
         cell_val_num: CellValNum,
         is_nullable: bool,
-    ) -> TileDBResult<TypedQueryBuffers> {
+    ) -> TileDBResult<TypedQueryBuffers<'_>> {
         let c = cell_val_num;
         let n = is_nullable;
 

--- a/tiledb/api/src/query/write/input/mod.rs
+++ b/tiledb/api/src/query/write/input/mod.rs
@@ -19,7 +19,7 @@ pub trait DataProvider {
         &self,
         cell_val_num: CellValNum,
         is_nullable: bool,
-    ) -> TileDBResult<QueryBuffers<Self::Unit>>;
+    ) -> TileDBResult<QueryBuffers<'_, Self::Unit>>;
 }
 
 pub trait TypedDataProvider {
@@ -40,7 +40,7 @@ where
         &self,
         cell_val_num: CellValNum,
         is_nullable: bool,
-    ) -> TileDBResult<TypedQueryBuffers> {
+    ) -> TileDBResult<TypedQueryBuffers<'_>> {
         let qb = <T as DataProvider>::query_buffers(
             self,
             cell_val_num,
@@ -60,7 +60,7 @@ where
         &self,
         _cell_val_num: CellValNum,
         _is_nullable: bool,
-    ) -> TileDBResult<QueryBuffers<Self::Unit>> {
+    ) -> TileDBResult<QueryBuffers<'_, Self::Unit>> {
         let ptr = self.data.as_ptr();
         let byte_len = std::mem::size_of_val(&self.data);
         let raw_slice = unsafe { std::slice::from_raw_parts(ptr, byte_len) };
@@ -84,7 +84,7 @@ where
         &self,
         _cell_val_num: CellValNum,
         _is_nullable: bool,
-    ) -> TileDBResult<QueryBuffers<Self::Unit>> {
+    ) -> TileDBResult<QueryBuffers<'_, Self::Unit>> {
         let ptr = self.data.as_ptr();
         let byte_len = std::mem::size_of_val(&self.data);
         let raw_slice = unsafe { std::slice::from_raw_parts(ptr, byte_len) };
@@ -149,7 +149,7 @@ impl AsSlice for String {
 fn cell_structure<S>(
     cell_val_num: CellValNum,
     items: &[S],
-) -> TileDBResult<CellStructure>
+) -> TileDBResult<CellStructure<'_>>
 where
     S: AsSlice,
 {
@@ -188,7 +188,7 @@ fn query_buffers_impl<S>(
     value: &[S],
     cell_val_num: CellValNum,
     is_nullable: bool,
-) -> TileDBResult<QueryBuffers<<S as AsSlice>::Item>>
+) -> TileDBResult<QueryBuffers<'_, <S as AsSlice>::Item>>
 where
     S: AsSlice,
 {
@@ -226,7 +226,7 @@ where
         &self,
         cell_val_num: CellValNum,
         is_nullable: bool,
-    ) -> TileDBResult<QueryBuffers<Self::Unit>> {
+    ) -> TileDBResult<QueryBuffers<'_, Self::Unit>> {
         self.as_slice().query_buffers(cell_val_num, is_nullable)
     }
 }
@@ -241,7 +241,7 @@ where
         &self,
         _cell_val_num: CellValNum,
         is_nullable: bool,
-    ) -> TileDBResult<QueryBuffers<Self::Unit>> {
+    ) -> TileDBResult<QueryBuffers<'_, Self::Unit>> {
         let validity = if is_nullable {
             Some(Buffer::Owned(vec![1u8; self.len()].into_boxed_slice()))
         } else {
@@ -266,7 +266,7 @@ where
         &self,
         cell_val_num: CellValNum,
         is_nullable: bool,
-    ) -> TileDBResult<QueryBuffers<Self::Unit>> {
+    ) -> TileDBResult<QueryBuffers<'_, Self::Unit>> {
         query_buffers_impl(self, cell_val_num, is_nullable)
     }
 }
@@ -278,7 +278,7 @@ impl DataProvider for Vec<&str> {
         &self,
         cell_val_num: CellValNum,
         is_nullable: bool,
-    ) -> TileDBResult<QueryBuffers<Self::Unit>> {
+    ) -> TileDBResult<QueryBuffers<'_, Self::Unit>> {
         query_buffers_impl(self, cell_val_num, is_nullable)
     }
 }
@@ -290,7 +290,7 @@ impl DataProvider for Vec<String> {
         &self,
         cell_val_num: CellValNum,
         is_nullable: bool,
-    ) -> TileDBResult<QueryBuffers<Self::Unit>> {
+    ) -> TileDBResult<QueryBuffers<'_, Self::Unit>> {
         query_buffers_impl(self, cell_val_num, is_nullable)
     }
 }

--- a/tiledb/pod/src/array/schema/mod.rs
+++ b/tiledb/pod/src/array/schema/mod.rs
@@ -101,7 +101,7 @@ impl SchemaData {
         }
     }
 
-    pub fn fields(&self) -> FieldDataIter {
+    pub fn fields(&self) -> FieldDataIter<'_> {
         FieldDataIter::new(self)
     }
 


### PR DESCRIPTION
Example:

```
error: lifetime flowing from input to output with different syntax can be confusing
   --> tiledb/pod/src/array/schema/mod.rs:104:19
    |
104 |     pub fn fields(&self) -> FieldDataIter {
    |                   ^^^^^     ------------- the lifetime gets resolved as `'_`
    |                   |
    |                   this lifetime flows to the output
    |
    = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(mismatched_lifetime_syntaxes)]`
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
104 |     pub fn fields(&self) -> FieldDataIter<'_> {
```

https://linear.app/tiledb/issue/TAB-79/address-new-nightly-lint-about-naming-lifetimes