### PR TITLE
chore: Change 'nullity' to 'validity' in field names

### DIFF
--- a/tiledb/api/src/array/schema/arrow.rs
+++ b/tiledb/api/src/array/schema/arrow.rs
@@ -54,7 +54,7 @@ pub struct SchemaMetadata {
     enumerations: Vec<EnumerationData>,
     coordinate_filters: FilterMetadata,
     offsets_filters: FilterMetadata,
-    nullity_filters: FilterMetadata,
+    validity_filters: FilterMetadata,
 
     /// Number of dimensions in this schema. The first `ndim` Fields are
     /// Dimensions, not Attributes
@@ -77,7 +77,7 @@ impl SchemaMetadata {
                 &schema.coordinate_filters()?,
             )?,
             offsets_filters: FilterMetadata::new(&schema.offsets_filters()?)?,
-            nullity_filters: FilterMetadata::new(&schema.nullity_filters()?)?,
+            validity_filters: FilterMetadata::new(&schema.validity_filters()?)?,
             ndim: schema.domain()?.num_dimensions()?,
         })
     }
@@ -218,7 +218,7 @@ pub fn from_arrow(
         .tile_order(metadata.tile_order)?
         .coordinate_filters(&metadata.coordinate_filters.create(context)?)?
         .offsets_filters(&metadata.offsets_filters.create(context)?)?
-        .nullity_filters(&metadata.nullity_filters.create(context)?)?;
+        .validity_filters(&metadata.validity_filters.create(context)?)?;
 
     b = metadata
         .enumerations

--- a/tiledb/api/src/array/schema/mod.rs
+++ b/tiledb/api/src/array/schema/mod.rs
@@ -442,7 +442,7 @@ impl Schema {
         self.filter_list(ffi::tiledb_array_schema_get_offsets_filter_list)
     }
 
-    pub fn nullity_filters(&self) -> TileDBResult<FilterList> {
+    pub fn validity_filters(&self) -> TileDBResult<FilterList> {
         self.filter_list(ffi::tiledb_array_schema_get_validity_filter_list)
     }
 }
@@ -458,7 +458,7 @@ impl PartialEq<Schema> for Schema {
         eq_helper!(self.allows_duplicates(), other.allows_duplicates());
         eq_helper!(self.coordinate_filters(), other.coordinate_filters());
         eq_helper!(self.offsets_filters(), other.offsets_filters());
-        eq_helper!(self.nullity_filters(), other.nullity_filters());
+        eq_helper!(self.validity_filters(), other.validity_filters());
 
         for a in 0..self.num_attributes().unwrap() {
             eq_helper!(self.attribute(a), other.attribute(a));
@@ -671,7 +671,7 @@ impl Builder {
         )
     }
 
-    pub fn nullity_filters<FL>(self, filters: FL) -> TileDBResult<Self>
+    pub fn validity_filters<FL>(self, filters: FL) -> TileDBResult<Self>
     where
         FL: Borrow<FilterList>,
     {
@@ -1097,7 +1097,7 @@ mod tests {
                 CompressionType::Zstd,
             )))?
             .build();
-        let nullity_default = FilterListBuilder::new(&c)?
+        let validity_default = FilterListBuilder::new(&c)?
             .add_filter_data(FilterData::Compression(CompressionData::new(
                 CompressionType::Rle,
             )))?
@@ -1122,7 +1122,7 @@ mod tests {
 
             assert_eq!(coordinates_default, s.coordinate_filters()?);
             assert_eq!(offsets_default, s.offsets_filters()?);
-            assert_eq!(nullity_default, s.nullity_filters()?);
+            assert_eq!(validity_default, s.validity_filters()?);
         }
 
         // set coordinates filter
@@ -1138,7 +1138,7 @@ mod tests {
             };
 
             assert_eq!(offsets_default, s.offsets_filters()?);
-            assert_eq!(nullity_default, s.nullity_filters()?);
+            assert_eq!(validity_default, s.validity_filters()?);
 
             let coordinates = s.coordinate_filters()?;
             assert_eq!(target, coordinates);
@@ -1157,20 +1157,20 @@ mod tests {
             };
 
             assert_eq!(coordinates_default, s.coordinate_filters()?);
-            assert_eq!(nullity_default, s.nullity_filters()?);
+            assert_eq!(validity_default, s.validity_filters()?);
 
             let offsets = s.offsets_filters()?;
             assert_eq!(target, offsets);
         }
 
-        // set nullity filter
+        // set validity filter
         {
             let s: Schema = {
                 let a1 =
                     AttributeBuilder::new(&c, "a1", Datatype::Int32)?.build();
                 Builder::new(&c, ArrayType::Dense, sample_domain(&c))?
                     .add_attribute(a1)?
-                    .nullity_filters(&target)?
+                    .validity_filters(&target)?
                     .build()
                     .unwrap()
             };
@@ -1178,8 +1178,8 @@ mod tests {
             assert_eq!(coordinates_default, s.coordinate_filters()?);
             assert_eq!(offsets_default, s.offsets_filters()?);
 
-            let nullity = s.nullity_filters()?;
-            assert_eq!(target, nullity);
+            let validity = s.validity_filters()?;
+            assert_eq!(target, validity);
         }
 
         Ok(())
@@ -1285,10 +1285,10 @@ mod tests {
             assert_ne!(base, cmp);
         }
 
-        // nullity filters
+        // validity filters
         {
             let cmp = start_schema(base.array_type().unwrap())
-                .nullity_filters(FilterListBuilder::new(&c).unwrap().build())
+                .validity_filters(FilterListBuilder::new(&c).unwrap().build())
                 .unwrap()
                 .build()
                 .unwrap();

--- a/tiledb/api/src/array/schema/pod.rs
+++ b/tiledb/api/src/array/schema/pod.rs
@@ -43,8 +43,8 @@ impl TryFrom<&Schema> for SchemaData {
             offsets_filters: Vec::<FilterData>::try_from(
                 &schema.offsets_filters()?,
             )?,
-            nullity_filters: Vec::<FilterData>::try_from(
-                &schema.nullity_filters()?,
+            validity_filters: Vec::<FilterData>::try_from(
+                &schema.validity_filters()?,
             )?,
         })
     }
@@ -69,7 +69,7 @@ impl Factory for SchemaData {
         )?
         .coordinate_filters(self.coordinate_filters.create(context)?)?
         .offsets_filters(self.offsets_filters.create(context)?)?
-        .nullity_filters(self.nullity_filters.create(context)?)?;
+        .validity_filters(self.validity_filters.create(context)?)?;
 
         b = self
             .enumerations

--- a/tiledb/api/src/query/strategy/tests.rs
+++ b/tiledb/api/src/query/strategy/tests.rs
@@ -798,7 +798,7 @@ fn shrinking_query_condition_1() -> anyhow::Result<()> {
         }],
         coordinate_filters: Default::default(),
         offsets_filters: Default::default(),
-        nullity_filters: Default::default(),
+        validity_filters: Default::default(),
     };
     let writes =
         WriteSequence::Sparse(cells::write::SparseWriteSequence::from(vec![
@@ -956,7 +956,7 @@ fn shrinking_query_condition_2() -> anyhow::Result<()> {
         }],
         coordinate_filters: Default::default(),
         offsets_filters: Default::default(),
-        nullity_filters: Default::default(),
+        validity_filters: Default::default(),
     };
 
     let writes =

--- a/tiledb/api/src/tests/examples/sparse_all.rs
+++ b/tiledb/api/src/tests/examples/sparse_all.rs
@@ -151,6 +151,6 @@ pub fn schema(params: Parameters) -> SchemaData {
         enumerations: Default::default(),
         coordinate_filters: Default::default(),
         offsets_filters: Default::default(),
-        nullity_filters: Default::default(),
+        validity_filters: Default::default(),
     }
 }

--- a/tiledb/pod/src/array/schema/mod.rs
+++ b/tiledb/pod/src/array/schema/mod.rs
@@ -32,7 +32,7 @@ pub struct SchemaData {
     pub enumerations: Vec<EnumerationData>,
     pub coordinate_filters: Vec<FilterData>,
     pub offsets_filters: Vec<FilterData>,
-    pub nullity_filters: Vec<FilterData>,
+    pub validity_filters: Vec<FilterData>,
 }
 
 impl SchemaData {

--- a/tiledb/pod/src/array/schema/strategy.rs
+++ b/tiledb/pod/src/array/schema/strategy.rs
@@ -214,7 +214,7 @@ fn prop_schema_for_domain(
                 (attributes, enumerations),
                 coordinate_filters,
                 offsets_filters,
-                nullity_filters,
+                validity_filters,
             )| {
                 /*
                  * Update the set of dimension/attribute names to be unique.
@@ -265,7 +265,7 @@ fn prop_schema_for_domain(
                     enumerations,
                     coordinate_filters,
                     offsets_filters,
-                    nullity_filters,
+                    validity_filters,
                 }
             },
         )
@@ -365,7 +365,7 @@ pub struct SchemaValueTree {
     selected_attributes: RecordsValueTree<Vec<usize>>,
     coordinate_filters: FilterPipelineValueTree,
     offsets_filters: FilterPipelineValueTree,
-    nullity_filters: FilterPipelineValueTree,
+    validity_filters: FilterPipelineValueTree,
 }
 
 impl SchemaValueTree {
@@ -404,8 +404,8 @@ impl SchemaValueTree {
             offsets_filters: FilterPipelineValueTree::new(
                 schema.offsets_filters,
             ),
-            nullity_filters: FilterPipelineValueTree::new(
-                schema.nullity_filters,
+            validity_filters: FilterPipelineValueTree::new(
+                schema.validity_filters,
             ),
         }
     }
@@ -440,7 +440,7 @@ impl ValueTree for SchemaValueTree {
             enumerations,
             coordinate_filters: self.coordinate_filters.current(),
             offsets_filters: self.offsets_filters.current(),
-            nullity_filters: self.nullity_filters.current(),
+            validity_filters: self.validity_filters.current(),
         }
     }
 
@@ -457,7 +457,7 @@ impl ValueTree for SchemaValueTree {
             || self.tile_order.simplify()
             || self.coordinate_filters.simplify()
             || self.offsets_filters.simplify()
-            || self.nullity_filters.simplify()
+            || self.validity_filters.simplify()
     }
 
     fn complicate(&mut self) -> bool {
@@ -473,7 +473,7 @@ impl ValueTree for SchemaValueTree {
             || self.tile_order.complicate()
             || self.coordinate_filters.complicate()
             || self.offsets_filters.complicate()
-            || self.nullity_filters.complicate()
+            || self.validity_filters.complicate()
     }
 }
 


### PR DESCRIPTION
The standard nomenclature is "validity".  This pull request changes the `tiledb-rs` functions and fields to use that instead of "nullity".  This is a breaking change since it affects some public fields and functions.