### PR TITLE
feat!: impl FromIterator for SetMembers

### DIFF
--- a/test-utils/cells/src/strategy.rs
+++ b/test-utils/cells/src/strategy.rs
@@ -702,7 +702,7 @@ impl QueryConditionField for CellsQueryConditionField {
                 e,
                 _DT,
                 _members,
-                Some(SetMembers::from(_members.clone())),
+                Some(_members.clone().into_iter().collect::<SetMembers>()),
                 {
                     // NB: this is Var, we could do String but it's just to test the test code
                     // so we will skip

--- a/tiledb/api/src/query/condition/mod.rs
+++ b/tiledb/api/src/query/condition/mod.rs
@@ -329,7 +329,7 @@ mod tests {
 
     #[test]
     fn basic_set_test() -> TileDBResult<()> {
-        let qc = QC::field("foo").is_in(&[1u32, 2, 3, 4, 5][..]);
+        let qc = QC::field("foo").is_in([1u32, 2, 3, 4, 5]);
         let ctx = Context::new()?;
         assert!(qc.build(&ctx).is_ok());
 
@@ -338,7 +338,7 @@ mod tests {
 
     #[test]
     fn basic_string_set_test() -> TileDBResult<()> {
-        let qc = QC::field("foo").is_in(&["foo", "bar", "baz"][..]);
+        let qc = QC::field("foo").is_in(["foo", "bar", "baz"]);
         let ctx = Context::new()?;
         assert!(qc.build(&ctx).is_ok());
 

--- a/tiledb/common/src/query/condition/strategy.rs
+++ b/tiledb/common/src/query/condition/strategy.rs
@@ -245,7 +245,7 @@ impl Arbitrary for SetMembers {
                     },
                     params.1
                 )
-                .prop_map(SetMembers::from)
+                .prop_map(SetMembers::from_iter)
                 .boxed()
             ),
             Range::Multi(_) => unimplemented!(),
@@ -256,7 +256,7 @@ impl Arbitrary for SetMembers {
                     }),
                     params.1,
                 )
-                .prop_map(SetMembers::from)
+                .prop_map(SetMembers::from_iter)
                 .boxed()
             }
             Range::Var(_) => unimplemented!(),
@@ -328,7 +328,7 @@ impl Arbitrary for SetMembershipPredicate {
                                     subseq_size_range,
                                 )
                             })
-                            .prop_map(SetMembers::from)
+                            .prop_map(SetMembers::from_iter)
                             .boxed()
                     })
                 } else if let Some(domain) = domain {

--- a/tiledb/pod/src/array/enumeration/mod.rs
+++ b/tiledb/pod/src/array/enumeration/mod.rs
@@ -77,8 +77,7 @@ impl EnumerationData {
                 records
                     .into_iter()
                     .map(|v| String::from_utf8_lossy(v.as_slice()).into_owned())
-                    .collect::<Vec<String>>()
-                    .into(),
+                    .collect(),
             )
         } else if self
             .cell_val_num
@@ -88,17 +87,12 @@ impl EnumerationData {
             physical_type_go!(self.datatype, DT, {
                 const WIDTH: usize = std::mem::size_of::<DT>();
                 type ByteArray = [u8; WIDTH];
-                Some(SetMembers::from(
-                    records
-                        .into_iter()
-                        .map(|v| {
-                            assert_eq!(WIDTH, v.len());
-                            DT::from_le_bytes(
-                                ByteArray::try_from(v.as_slice()).unwrap(),
-                            )
-                        })
-                        .collect::<Vec<_>>(),
-                ))
+                Some(SetMembers::from_iter(records.into_iter().map(|v| {
+                    assert_eq!(WIDTH, v.len());
+                    DT::from_le_bytes(
+                        ByteArray::try_from(v.as_slice()).unwrap(),
+                    )
+                })))
             })
         } else {
             None


### PR DESCRIPTION
BREAKING CHANGE: removes From<Vec> impls for SetMembers

This `impl` will be useful for constructing query conditions from a more generic iterator, such as:
```
struct VCFCell {
    chromosome: String,
    ...
}

my_vcf_cells.iter().map(|c| c.chromosome.as_str()).collect::<SetMembers>()
```

This also feels more idiomatic than the existing impls do.