### PR TITLE
fix: Allow Field set ops to accept SetMembers

### DIFF
--- a/test-utils/cells/src/lib.rs
+++ b/test-utils/cells/src/lib.rs
@@ -1320,41 +1320,41 @@ mod tests {
         let qc = {
             let f = QueryConditionExpr::field(field);
             match fdata {
-                FieldData::UInt8(cells) => f.is_in(
-                    member_idx.iter().map(|i| cells[*i]).collect::<Vec<_>>(),
-                ),
-                FieldData::UInt16(cells) => f.is_in(
-                    member_idx.iter().map(|i| cells[*i]).collect::<Vec<_>>(),
-                ),
-                FieldData::UInt32(cells) => f.is_in(
-                    member_idx.iter().map(|i| cells[*i]).collect::<Vec<_>>(),
-                ),
-                FieldData::UInt64(cells) => f.is_in(
-                    member_idx.iter().map(|i| cells[*i]).collect::<Vec<_>>(),
-                ),
-                FieldData::Int8(cells) => f.is_in(
-                    member_idx.iter().map(|i| cells[*i]).collect::<Vec<_>>(),
-                ),
-                FieldData::Int16(cells) => f.is_in(
-                    member_idx.iter().map(|i| cells[*i]).collect::<Vec<_>>(),
-                ),
-                FieldData::Int32(cells) => f.is_in(
-                    member_idx.iter().map(|i| cells[*i]).collect::<Vec<_>>(),
-                ),
-                FieldData::Int64(cells) => f.is_in(
-                    member_idx.iter().map(|i| cells[*i]).collect::<Vec<_>>(),
-                ),
-                FieldData::Float32(cells) => f.is_in(
-                    member_idx.iter().map(|i| cells[*i]).collect::<Vec<_>>(),
-                ),
-                FieldData::Float64(cells) => f.is_in(
-                    member_idx.iter().map(|i| cells[*i]).collect::<Vec<_>>(),
-                ),
+                FieldData::UInt8(cells) => {
+                    f.is_in(member_idx.iter().map(|i| cells[*i]).collect())
+                }
+                FieldData::UInt16(cells) => {
+                    f.is_in(member_idx.iter().map(|i| cells[*i]).collect())
+                }
+                FieldData::UInt32(cells) => {
+                    f.is_in(member_idx.iter().map(|i| cells[*i]).collect())
+                }
+                FieldData::UInt64(cells) => {
+                    f.is_in(member_idx.iter().map(|i| cells[*i]).collect())
+                }
+                FieldData::Int8(cells) => {
+                    f.is_in(member_idx.iter().map(|i| cells[*i]).collect())
+                }
+                FieldData::Int16(cells) => {
+                    f.is_in(member_idx.iter().map(|i| cells[*i]).collect())
+                }
+                FieldData::Int32(cells) => {
+                    f.is_in(member_idx.iter().map(|i| cells[*i]).collect())
+                }
+                FieldData::Int64(cells) => {
+                    f.is_in(member_idx.iter().map(|i| cells[*i]).collect())
+                }
+                FieldData::Float32(cells) => {
+                    f.is_in(member_idx.iter().map(|i| cells[*i]).collect())
+                }
+                FieldData::Float64(cells) => {
+                    f.is_in(member_idx.iter().map(|i| cells[*i]).collect())
+                }
                 FieldData::VecUInt8(cells) => f.is_in(
                     member_idx
                         .iter()
                         .map(|i| String::from_utf8(cells[*i].to_vec()).unwrap())
-                        .collect::<Vec<_>>(),
+                        .collect(),
                 ),
                 _ => {
                     unreachable!("Invalid field for query condition: {fdata:?}",)
@@ -1385,41 +1385,41 @@ mod tests {
         let qc = {
             let f = QueryConditionExpr::field(field);
             match fdata {
-                FieldData::UInt8(cells) => f.not_in(
-                    member_idx.iter().map(|i| cells[*i]).collect::<Vec<_>>(),
-                ),
-                FieldData::UInt16(cells) => f.not_in(
-                    member_idx.iter().map(|i| cells[*i]).collect::<Vec<_>>(),
-                ),
-                FieldData::UInt32(cells) => f.not_in(
-                    member_idx.iter().map(|i| cells[*i]).collect::<Vec<_>>(),
-                ),
-                FieldData::UInt64(cells) => f.not_in(
-                    member_idx.iter().map(|i| cells[*i]).collect::<Vec<_>>(),
-                ),
-                FieldData::Int8(cells) => f.not_in(
-                    member_idx.iter().map(|i| cells[*i]).collect::<Vec<_>>(),
-                ),
-                FieldData::Int16(cells) => f.not_in(
-                    member_idx.iter().map(|i| cells[*i]).collect::<Vec<_>>(),
-                ),
-                FieldData::Int32(cells) => f.not_in(
-                    member_idx.iter().map(|i| cells[*i]).collect::<Vec<_>>(),
-                ),
-                FieldData::Int64(cells) => f.not_in(
-                    member_idx.iter().map(|i| cells[*i]).collect::<Vec<_>>(),
-                ),
-                FieldData::Float32(cells) => f.not_in(
-                    member_idx.iter().map(|i| cells[*i]).collect::<Vec<_>>(),
-                ),
-                FieldData::Float64(cells) => f.not_in(
-                    member_idx.iter().map(|i| cells[*i]).collect::<Vec<_>>(),
-                ),
+                FieldData::UInt8(cells) => {
+                    f.not_in(member_idx.iter().map(|i| cells[*i]).collect())
+                }
+                FieldData::UInt16(cells) => {
+                    f.not_in(member_idx.iter().map(|i| cells[*i]).collect())
+                }
+                FieldData::UInt32(cells) => {
+                    f.not_in(member_idx.iter().map(|i| cells[*i]).collect())
+                }
+                FieldData::UInt64(cells) => {
+                    f.not_in(member_idx.iter().map(|i| cells[*i]).collect())
+                }
+                FieldData::Int8(cells) => {
+                    f.not_in(member_idx.iter().map(|i| cells[*i]).collect())
+                }
+                FieldData::Int16(cells) => {
+                    f.not_in(member_idx.iter().map(|i| cells[*i]).collect())
+                }
+                FieldData::Int32(cells) => {
+                    f.not_in(member_idx.iter().map(|i| cells[*i]).collect())
+                }
+                FieldData::Int64(cells) => {
+                    f.not_in(member_idx.iter().map(|i| cells[*i]).collect())
+                }
+                FieldData::Float32(cells) => {
+                    f.not_in(member_idx.iter().map(|i| cells[*i]).collect())
+                }
+                FieldData::Float64(cells) => {
+                    f.not_in(member_idx.iter().map(|i| cells[*i]).collect())
+                }
                 FieldData::VecUInt8(cells) => f.not_in(
                     member_idx
                         .iter()
                         .map(|i| String::from_utf8(cells[*i].to_vec()).unwrap())
-                        .collect::<Vec<_>>(),
+                        .collect(),
                 ),
                 _ => {
                     unreachable!("Invalid field for query condition: {fdata:?}",)

--- a/tiledb/api/src/query/condition/mod.rs
+++ b/tiledb/api/src/query/condition/mod.rs
@@ -329,7 +329,8 @@ mod tests {
 
     #[test]
     fn basic_set_test() -> TileDBResult<()> {
-        let qc = QC::field("foo").is_in([1u32, 2, 3, 4, 5]);
+        let qc =
+            QC::field("foo").is_in([1u32, 2, 3, 4, 5].into_iter().collect());
         let ctx = Context::new()?;
         assert!(qc.build(&ctx).is_ok());
 
@@ -338,7 +339,8 @@ mod tests {
 
     #[test]
     fn basic_string_set_test() -> TileDBResult<()> {
-        let qc = QC::field("foo").is_in(["foo", "bar", "baz"]);
+        let qc =
+            QC::field("foo").is_in(["foo", "bar", "baz"].into_iter().collect());
         let ctx = Context::new()?;
         assert!(qc.build(&ctx).is_ok());
 

--- a/tiledb/common/src/query/condition/mod.rs
+++ b/tiledb/common/src/query/condition/mod.rs
@@ -762,30 +762,22 @@ impl Field {
         }))
     }
 
-    pub fn is_in<V>(self, value: V) -> QueryConditionExpr
-    where
-        V: IntoIterator,
-        SetMembers: FromIterator<<V as IntoIterator>::Item>,
-    {
+    pub fn is_in(self, members: SetMembers) -> QueryConditionExpr {
         QueryConditionExpr::Cond(Predicate::SetMembership(
             SetMembershipPredicate {
                 field: self.field,
                 op: SetMembershipOp::In,
-                members: value.into_iter().collect(),
+                members,
             },
         ))
     }
 
-    pub fn not_in<V>(self, value: V) -> QueryConditionExpr
-    where
-        V: IntoIterator,
-        SetMembers: FromIterator<<V as IntoIterator>::Item>,
-    {
+    pub fn not_in(self, members: SetMembers) -> QueryConditionExpr {
         QueryConditionExpr::Cond(Predicate::SetMembership(
             SetMembershipPredicate {
                 field: self.field,
                 op: SetMembershipOp::NotIn,
-                members: value.into_iter().collect(),
+                members,
             },
         ))
     }
@@ -895,14 +887,24 @@ mod tests {
         let qc_cmp = QC::field("field").lt(5);
         assert_eq!("field < 5", qc_cmp.to_string());
 
-        let qc_setmemb = QC::field("field").is_in(["one", "two", "three"]);
+        let qc_setmemb = QC::field("field")
+            .is_in(["one", "two", "three"].into_iter().collect());
         assert_eq!("field IN ('one', 'two', 'three')", qc_setmemb.to_string());
 
-        let qc_setmemb = QC::field("field").not_in(["one", "two", "three"]);
+        let qc_setmemb = QC::field("field")
+            .not_in(["one", "two", "three"].into_iter().collect());
         assert_eq!(
             "field NOT IN ('one', 'two', 'three')",
             qc_setmemb.to_string()
         );
+
+        let qc_setmemb =
+            QC::field("field").is_in(SetMembers::from_iter([1u32, 2, 3]));
+        assert_eq!("field IN (1, 2, 3)", qc_setmemb.to_string());
+
+        let qc_setmemb =
+            QC::field("field").not_in(SetMembers::from_iter([1u32, 2, 3]));
+        assert_eq!("field NOT IN (1, 2, 3)", qc_setmemb.to_string());
 
         let qc_nullness = QC::field("field").not_null();
         assert_eq!("field IS NOT NULL", qc_nullness.to_string());


### PR DESCRIPTION
The recent change to SetMembers to use `FromIterator` traits instead of `From<Vec<_>>` implementations ended up breaking use cases of the Field set operations to accept instances of SetMembers.

This updates the APIs to just accept instances of SetMembers and now requires callers passing an iterator to create a SetMembers instance at the call site. This can be easily accomplished by just ending any iterator chain with `.collect()` without a type specified. As a happy accident, this actually ends up being slightly more efficient as it avoids the creation of a temporary `Vec<_>` in a number of places.