### PR TITLE
test: Update format version in array schema tests

### DIFF
--- a/tiledb/api/src/array/schema/mod.rs
+++ b/tiledb/api/src/array/schema/mod.rs
@@ -771,7 +771,7 @@ mod tests {
 
         // it's a little awkward to use a constant here but this does
         // not appear to be tied to the library version
-        assert_eq!(schema_version, 22);
+        assert_eq!(schema_version, 23);
     }
 
     #[test]


### PR DESCRIPTION
Merging https://github.com/TileDB-Inc/TileDB/pull/5646 bumped the fragment metadata format version. We just need to recapture it.