### PR TITLE
fix: pod::array::schema::strategy::Requirements::max_sparse_tile_capacity_default was using config min, not max

### DIFF
--- a/tiledb/pod/src/array/schema/strategy.rs
+++ b/tiledb/pod/src/array/schema/strategy.rs
@@ -54,7 +54,7 @@ impl Requirements {
     }
 
     pub fn max_sparse_tile_capacity_default() -> u64 {
-        **tiledb_proptest_config::TILEDB_STRATEGY_SCHEMA_PARAMETERS_SPARSE_TILE_CAPACITY_MIN
+        **tiledb_proptest_config::TILEDB_STRATEGY_SCHEMA_PARAMETERS_SPARSE_TILE_CAPACITY_MAX
     }
 
     pub fn attribute_enumeration_likelihood_default() -> f64 {


### PR DESCRIPTION
This is a pretty serious error as it has been causing most (probably all) of our downstream property tests to use a schema sparse tile capacity of 1 for all test cases.